### PR TITLE
Configurable kanban statuses: board config, ownership + routing, Blocked / Ready to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ account, no API key, no config changes — `Markdown` is the default.
    ```
    Start task 1.        → moves it to [Active], implements it
    Send task 1 to review.
-   Complete task 1.     → verified + [Completed]
+   Finalize task 1.     → verified, committed + [Ready to deploy]
    ```
 
 That's the whole loop — plan → start → review → complete — in generic vocabulary
@@ -198,6 +198,16 @@ Two files, each the "one file you edit per project" for its layer.
 
 > Set **`TEAM_MODE=true`** before running a team.
 
+### Configure your board
+
+`config/statuses.config.json` defines the kanban board: every status, its legal
+`transitions`, its `owner` (the team or single agent that works items in that status),
+and per-tracker `tool` mappings. Default board: `Planned → Active → Review → Ready to
+deploy`, with `Blocked` as the parking status for stuck work. Add, rename, or remove
+statuses by editing the JSON — then run `bin/launch-team.sh validate-board` to check it.
+Make sure your tracker has a matching state for every status (the Markdown tracker
+needs nothing).
+
 ### `config/team.config.md` — the team (only for multi-agent)
 
 | Section | Keys | Purpose |
@@ -220,7 +230,7 @@ Just talk to your agent in the generic vocabulary:
 
 - *"Plan a feature: …"* → creates a `[feature]` + `[tasks]`
 - *"Start task ENG-142"* → `[Active]`, then implements
-- *"Send it to review"* / *"Complete it"* → `[Review]` → `[Completed]`
+- *"Send it to review"* / *"Finalize it"* → `[Review]` → `[Ready to deploy]`
 - *"Switch the tracker to Linear"* → follows the adapter's setup
 
 ### A whole team
@@ -265,7 +275,7 @@ Just talk to your agent in the generic vocabulary:
 Product Manager, gates each `[task]`'s design before any code, reviews
 architecture) → specialists implement in isolated worktrees → the **Senior QA
 Engineer is the final review gate** → the integrator merges and marks
-`[Completed]` (commit and completion are one atomic step). The lead detects
+`[Ready to deploy]` (commit and the move are one atomic step). The lead detects
 stuck/conflicting/crashed agents and unblocks them — message → decide → reassign →
 relaunch — escalating to you only as a last resort.
 
@@ -298,7 +308,7 @@ adapter translates it to a concrete tracker.
    Your agents  ───▶│            THE PORT (stable)             │
    speak only this  │  vocabulary.md · lifecycle.md            │
                     │  [feature] [task] [subtask]              │
-                    │  [Planned] [Active] [Review] [Completed] │
+                    │  statuses from statuses.config.json      │
                     └───────────────────┬─────────────────────┘
                                         │  one config line selects the adapter
                       ┌─────────────────┼──────────────────┐

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,17 +48,18 @@ each generic operation through the adapter's *Operations* table:
 | Start / pick up / work on a task | 2 — Start a `[task]` |
 | Note a change from what a task said | 3 — Diverge |
 | Send a task for review | 4 — Request review |
-| Finish / close out a task | 5 — Complete a `[task]` |
+| Finish / close out a task | 5 — Finalize a `[task]` |
 | File a bug / follow-up found mid-work | 6 — File newly-discovered work |
-| (anything wrong / blocked / failed) | 7 — Andon cord: stop & report |
+| Work is stuck / blocked / cannot proceed | 7 — Block a `[task]` |
+| (anything wrong / blocked / failed) | 8 — Andon cord: stop & report |
 | Run an agent team on a feature ("launch the team") | Team: set `TEAM_MODE=true`, follow `reference/orchestration.md`; launch via `bin/launch-team.sh` |
-| Connect a new tool / switch tools | 8 — Connect / switch |
+| Connect a new tool / switch tools | 9 — Connect / switch |
 
 ## Non-negotiables (the fail-loud contract)
 
 - **Every status change is a real write** through the adapter's mechanism — then confirm
   it. Never claim a status you didn't set.
-- **If any operation fails, stop and report it** (Scenario 7). Never work around a failure
+- **If any operation fails, stop and report it** (Scenario 8). Never work around a failure
   or fabricate a result.
 - **Never skip a status transition.** Legal moves are the `transitions` graph in
   `config/statuses.config.json` (default board:

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ skill's directory):
 - `adapters/<Tool>.md` — how to perform each operation in the active tool
 
 > **Golden rule:** in everything you write — comments, commit messages, messages to the
-> user — use only the generic vocabulary — terms `[feature]`, `[task]`, `[subtask]` and statuses `[Planned]`/`[Active]`/`[Review]`/`[Completed]`. Never write "issue", "epic",
+> user — use only the generic vocabulary — terms `[feature]`, `[task]`, `[subtask]` and the statuses defined in `config/statuses.config.json` (default board: `[Planned]`/`[Active]`/`[Review]`/`[Blocked]`/`[Ready to deploy]`). Never write "issue", "epic",
 > "story", or "ticket" outside the adapter. See the banned-terms list in `vocabulary.md`.
 
 ## Mandatory Preparation (every invocation)
@@ -60,12 +60,16 @@ each generic operation through the adapter's *Operations* table:
   it. Never claim a status you didn't set.
 - **If any operation fails, stop and report it** (Scenario 7). Never work around a failure
   or fabricate a result.
-- **Never skip a status transition.** Move in order:
-  `[Planned]` → `[Active]` → `[Review]` → `[Completed]` (rework: `[Review]` → `[Active]`).
-- **When `STRICT_STATUS=true`, verify the current status before writing.** If it's not what
-  the step expects, pull the andon cord instead of forcing the change.
-- **`[Completed]` means verified-done** — reviewed, tests/build green, and (if your project
-  couples them) committed. Never mark work complete that was skipped or is failing.
+- **Never skip a status transition.** Legal moves are the `transitions` graph in
+  `config/statuses.config.json` (default board:
+  `[Planned]` → `[Active]` → `[Review]` → `[Ready to deploy]`, rework `[Review]` → `[Active]`,
+  `[Blocked]` for stuck work).
+- **When `STRICT_STATUS=true`, verify the current status before writing** and that the
+  intended move is in its `transitions` list. If not, pull the andon cord instead of
+  forcing the change.
+- **`[Ready to deploy]` means verified-done** — reviewed, tests/build green, and committed
+  (the move and the commit are one atomic step). Never mark work done that was skipped
+  or is failing.
 
 ## Reporting back
 

--- a/adapters/GitHubIssues.md
+++ b/adapters/GitHubIssues.md
@@ -5,7 +5,7 @@
 Uses native GitHub Issues, grouped by Milestone. Default access is the **`gh` CLI** (no MCP
 server required); set `GITHUB_USE_MCP=true` to use the GitHub MCP server instead. A
 `[feature]` is a Milestone, a `[task]` is an Issue, task status is carried by labels, and
-`[Completed]` closes the issue.
+`[Ready to deploy]` closes the issue.
 
 ## MCP / CLI Setup
 
@@ -17,14 +17,19 @@ gh auth status         # verify
 ```
 
 Repo comes from `GITHUB_REPO` in `../config/project-management.config.md`, or is inferred
-from the current git remote when that is `null`. Create the four status labels once:
+from the current git remote when that is `null`. Create the `status:*` labels for every
+non-terminal status in the board once:
 
 ```bash
 gh label create "status:planned" --color BFD4F2 2>/dev/null || true
 gh label create "status:active"  --color 0E8A16 2>/dev/null || true
 gh label create "status:review"  --color FBCA04 2>/dev/null || true
+gh label create "status:blocked" --color E4E669 2>/dev/null || true
 ```
-(`[Completed]` needs no label — it's the closed state.)
+(`[Ready to deploy]` needs no label — it's the closed state.)
+
+> Create `status:*` labels for every non-terminal status in `config/statuses.config.json`
+> before running the workflow — a missing label is an andon stop.
 
 **MCP (optional):** add the GitHub MCP server and set `GITHUB_USE_MCP=true`:
 
@@ -48,24 +53,28 @@ gh label create "status:review"  --color FBCA04 2>/dev/null || true
 | `[Task]` | Issue |
 | `[Subtask]` | Task-list checkbox (`- [ ] ...`) in the issue body |
 
-## Feature Status Mapping
+## Status Mapping
 
-Milestones only have open/closed, so most feature status is *derived from its tasks*.
+Statuses come from `config/statuses.config.json` — each status's `tool` map holds this
+adapter's concrete value under the `"GitHubIssues"` key. This adapter's *mechanism* for
+setting a status is: open/closed + one `status:*` label (setting a status removes the
+previous `status:*` label).
 
-| Generic status | GitHub (Milestone) |
+**Missing mapping = andon.** If a status has no `"GitHubIssues"` entry, or the repo
+lacks the required `status:*` label, stop and report — never invent a fallback status.
+
+Shipped defaults (the default board):
+
+| Status | GitHub (Issue) |
 |---|---|
-| `[Planned]` | Open, no task started |
-| `[Active]` | Open, ≥1 task in progress (derived) |
-| `[Resolved]` | Closed |
+| `[Planned]` | open + `status:planned` |
+| `[Active]` | open + `status:active` |
+| `[Review]` | open + `status:review` |
+| `[Blocked]` | open + `status:blocked` |
+| `[Ready to deploy]` | closed |
 
-## Task Status Mapping
-
-| Generic status | GitHub (Issue) |
-|---|---|
-| `[Planned]` | Open + label `status:planned` (or no status label) |
-| `[Active]` | Open + label `status:active` |
-| `[Review]` | Open + label `status:review` |
-| `[Completed]` | Closed |
+Feature statuses `[Planned]` / `[Active]` / `[Resolved]` map to milestone open (no task
+started) / milestone open (≥1 task active, derived) / milestone closed.
 
 > Setting a status label means **removing the previous** status label and adding the new
 > one — never leave two status labels on one issue.
@@ -88,7 +97,7 @@ CLI column assumes `-R <GITHUB_REPO>` is appended when `GITHUB_REPO` is set.
 | Read a `[task]` | `gh issue view <taskId> --comments` |
 | List `[tasks]` in a feature | `gh issue list --milestone "<featureId>" --state all` |
 | Set `[task]` status | `gh issue edit <taskId> --remove-label "status:planned" --add-label "status:active"` (remove the label matching the [task]'s current status — read it first; globs do not work with `--remove-label`) |
-| Set `[task]` → `[Completed]` | `gh issue close <taskId>` |
+| Set `[task]` → `[Ready to deploy]` | `gh issue close <taskId>` |
 | Reopen (rework) | `gh issue reopen <taskId> --add-label status:active` |
 | Set `[feature]` → `[Resolved]` | `gh api -X PATCH repos/:owner/:repo/milestones/<n> -f state=closed` |
 | Add a comment to a `[task]` | `gh issue comment <taskId> --body "<...>"` |
@@ -98,7 +107,7 @@ CLI column assumes `-R <GITHUB_REPO>` is appended when `GITHUB_REPO` is set.
 - Every write goes through `gh` (or the GitHub MCP tools when `GITHUB_USE_MCP=true`). On a
   non-zero exit / MCP error: **stop and report** (andon cord). Never fake success.
 - Exactly one `status:*` label at a time on an open issue.
-- `[Completed]` = closed; reopening for rework re-adds `status:active`.
+- `[Ready to deploy]` = closed; reopening for rework re-adds `status:active`.
 - `featureId` is a Milestone (title or number); `taskId` is an Issue number.
 
 ## Initialization

--- a/adapters/Jira.md
+++ b/adapters/Jira.md
@@ -54,6 +54,10 @@ adf() { jq -cn --arg t "$1" '{"type":"doc","version":1,"content":[{"type":"parag
 
 (`jq` handles JSON escaping; if `jq` is unavailable, escape the text yourself before splicing it into the body.)
 
+> Make sure every status in `config/statuses.config.json` has a matching workflow state
+> or transition in your Jira project (e.g. add a "Blocked" status) — a missing state is
+> an andon stop.
+
 ## Terminology Mapping
 
 | Generic term | Jira |
@@ -62,25 +66,32 @@ adf() { jq -cn --arg t "$1" '{"type":"doc","version":1,"content":[{"type":"parag
 | `[Task]` | Story |
 | `[Subtask]` | Bullet point in the story description |
 
-## Feature Status Mapping
+## Status Mapping
 
-| Generic status | Jira (Epic) |
-|---|---|
-| `[Planned]` | To Do |
-| `[Active]` | In Progress |
-| `[Resolved]` | Done |
+Statuses come from `config/statuses.config.json` — each status's `tool` map holds this
+adapter's concrete value under the `"Jira"` key. This adapter's *mechanism* for setting a
+status is: workflow transition on the Story/Epic.
 
-## Task Status Mapping
+**Missing mapping = andon.** If a status has no `"Jira"` entry, or the Jira project
+lacks the mapped workflow transition, stop and report — never invent a fallback status.
 
-| Generic status | Jira (Story) |
+Shipped defaults (the default board):
+
+| Status | Jira |
 |---|---|
 | `[Planned]` | To Do |
 | `[Active]` | In Progress |
 | `[Review]` | In Review |
-| `[Completed]` | Done |
+| `[Blocked]` | Blocked |
+| `[Ready to deploy]` | Done |
+
+Feature statuses `[Planned]` / `[Active]` / `[Resolved]` map to To Do / In Progress /
+Done (Epic workflow states).
 
 > Jira workflows are per-project and often customized. If your board uses different status
-> names (e.g. "Code Review", "Selected for Development"), edit these two tables only.
+> names (e.g. "Code Review", "Selected for Development"), update the `"Jira"` values in
+> `config/statuses.config.json` — the generic status names never change, only the
+> tool-side values do.
 
 ## ID Mapping
 

--- a/adapters/Linear.md
+++ b/adapters/Linear.md
@@ -40,6 +40,9 @@ lookup row). `jq -e` makes a GraphQL `errors` response a non-zero exit (andon co
 
 Relevant config: `LINEAR_DEFAULT_TEAM`, `LINEAR_DEFAULT_PROJECT`, `LINEAR_ACCESS`.
 
+> Make sure every status in `config/statuses.config.json` has a matching workflow state
+> in your Linear team (e.g. create a "Blocked" state) — a missing state is an andon stop.
+
 ## Terminology Mapping
 
 | Generic term | Linear |
@@ -48,27 +51,32 @@ Relevant config: `LINEAR_DEFAULT_TEAM`, `LINEAR_DEFAULT_PROJECT`, `LINEAR_ACCESS
 | `[Task]` | Issue |
 | `[Subtask]` | Bullet point in the issue description |
 
-## Feature Status Mapping
+## Status Mapping
 
-Linear Projects use states like Backlog / Planned / In Progress / Completed.
+Statuses come from `config/statuses.config.json` — each status's `tool` map holds this
+adapter's concrete value under the `"Linear"` key. This adapter's *mechanism* for setting
+a status is: issue workflow state (team-configurable names) for tasks; project state for
+features.
 
-| Generic status | Linear (Project state) |
-|---|---|
-| `[Planned]` | Planned |
-| `[Active]` | In Progress |
-| `[Resolved]` | Completed |
+**Missing mapping = andon.** If a status has no `"Linear"` entry, or the Linear team
+lacks the mapped workflow state, stop and report — never invent a fallback status.
 
-## Task Status Mapping
+Shipped defaults (the default board):
 
-| Generic status | Linear (Issue workflow state) |
+| Status | Linear |
 |---|---|
 | `[Planned]` | Todo |
 | `[Active]` | In Progress |
 | `[Review]` | In Review |
-| `[Completed]` | Done |
+| `[Blocked]` | Blocked |
+| `[Ready to deploy]` | Done |
+
+Feature statuses `[Planned]` / `[Active]` / `[Resolved]` map to Planned / In Progress /
+Completed (Linear project states).
 
 > Team workflow states are configurable in Linear. If a team renames "In Review", update
-> this table — the port never changes, only this mapping does.
+> the `"Linear"` values in `config/statuses.config.json` — the generic status names never
+> change, only the tool-side values do.
 
 ## ID Mapping
 

--- a/adapters/Markdown.md
+++ b/adapters/Markdown.md
@@ -26,26 +26,14 @@ The root directory comes from `MARKDOWN_ROOT` in
 | `[Task]` | A numbered `##` section within the feature file |
 | `[Subtask]` | A `-` bullet under a task section |
 
-## Feature Status Mapping
+## Status Mapping
 
-Status is literal bracket text on the feature's title line.
+Status is literal bracket text (on the feature's title line; at the end of a task's
+`##` header). This adapter writes each status's `"Markdown"` value from
+`config/statuses.config.json` verbatim — custom boards work with no setup at all.
 
-| Generic status | Markdown |
-|---|---|
-| `[Planned]` | `[Planned]` |
-| `[Active]` | `[Active]` |
-| `[Resolved]` | `[Resolved]` |
-
-## Task Status Mapping
-
-Status is literal bracket text at the end of the task's `##` header.
-
-| Generic status | Markdown |
-|---|---|
-| `[Planned]` | `[Planned]` |
-| `[Active]` | `[Active]` |
-| `[Review]` | `[Review]` |
-| `[Completed]` | `[Completed]` |
+Shipped defaults: `[Planned]`, `[Active]`, `[Review]`, `[Blocked]`,
+`[Ready to deploy]` for tasks; `[Planned]`, `[Active]`, `[Resolved]` for features.
 
 ## ID Mapping
 

--- a/adapters/_TEMPLATE.md
+++ b/adapters/_TEMPLATE.md
@@ -33,22 +33,26 @@ For a CLI tool, the install/auth commands. For a file-based tool, "none".
 | `[Task]` | <e.g. Issue / Story / Ticket> |
 | `[Subtask]` | Bullet/checklist item in the [task] description |
 
-## Feature Status Mapping
+## Status Mapping
 
-| Generic status | <ToolName> |
-|---|---|
-| `[Planned]` | <...> |
-| `[Active]` | <...> |
-| `[Resolved]` | <...> |
+Statuses come from `config/statuses.config.json` — each status's `tool` map holds this
+adapter's concrete value under the `"<ToolName>"` key. This adapter's *mechanism* for
+setting a status is: <how a status is represented and changed in this tool>.
 
-## Task Status Mapping
+**Missing mapping = andon.** If a status has no `"<ToolName>"` entry, or the tool's
+workspace lacks the mapped state, stop and report — never invent a fallback status.
 
-| Generic status | <ToolName> |
+Shipped defaults (the default board):
+
+| Status | <ToolName> |
 |---|---|
 | `[Planned]` | <...> |
 | `[Active]` | <...> |
 | `[Review]` | <...> |
-| `[Completed]` | <...> |
+| `[Blocked]` | <...> |
+| `[Ready to deploy]` | <...> |
+
+Feature statuses `[Planned]` / `[Active]` / `[Resolved]` map to <...>.
 
 ## ID Mapping
 

--- a/bin/launch-team.sh
+++ b/bin/launch-team.sh
@@ -3,12 +3,13 @@
 # LLM-agnostic: which CLI runs each role comes from config/team.config.md.
 #
 # Usage:
-#   launch-team.sh team     <preset> <team> <featureId>          # launch a preset roster (teams/<preset>.md)
-#   launch-team.sh start    <team> <featureId> <role>...
-#   launch-team.sh relaunch <team> <featureId> <role> [preset]
-#   launch-team.sh worktree <team> <role> <taskId>
-#   launch-team.sh status   <team>
-#   launch-team.sh stop     <team>
+#   launch-team.sh team          <preset> <team> <featureId>     # launch a preset roster (teams/<preset>.md)
+#   launch-team.sh start         <team> <featureId> <role>...
+#   launch-team.sh relaunch      <team> <featureId> <role> [preset]
+#   launch-team.sh worktree      <team> <role> <taskId>
+#   launch-team.sh validate-board [config-path]                  # validate board config JSON
+#   launch-team.sh status        <team>
+#   launch-team.sh stop          <team>
 set -euo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -48,6 +49,84 @@ roster_of() { # roster_of <preset> -> space-separated role names from teams/<pre
   local line; line="$(grep -m1 '^ROSTER=' "$f" || true)"
   [ -n "$line" ] || die "teams/$1.md has no ROSTER= line"
   printf '%s' "${line#ROSTER=}"
+}
+
+validate_board() { # validate_board [config-path] — structural checks on the board config
+  local cfg="${1:-$SKILL_DIR/config/statuses.config.json}"
+  [ -f "$cfg" ] || die "no board config: $cfg"
+  command -v python3 >/dev/null 2>&1 || die "validate-board requires python3"
+  python3 - "$cfg" "$SKILL_DIR" <<'PYEOF'
+import json, sys, os
+cfg_path, skill_dir = sys.argv[1], sys.argv[2]
+try:
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+except ValueError as e:
+    print("validate-board: invalid JSON: %s" % e, file=sys.stderr); sys.exit(1)
+
+ABSTRACT_ROLES = {"implementer", "reviewer", "coordinator", "finalizer"}
+errors = []
+
+def role_exists(name):
+    return (name in ABSTRACT_ROLES
+            or os.path.isfile(os.path.join(skill_dir, "roles", name + ".md"))
+            or os.path.isfile(os.path.join(skill_dir, "teams", "roles", name + ".md")))
+
+def team_exists(name):
+    return os.path.isfile(os.path.join(skill_dir, "teams", name + ".md"))
+
+for machine in ("features", "tasks"):
+    statuses = cfg.get(machine, {}).get("statuses")
+    if not isinstance(statuses, list) or not statuses:
+        errors.append("%s: missing or empty 'statuses' list" % machine); continue
+    names = [s.get("name") for s in statuses]
+    for d in sorted(set(n for n in names if names.count(n) > 1)):
+        errors.append("%s: duplicate status name '%s'" % (machine, d))
+    by_name = dict((s.get("name"), s) for s in statuses)
+    initials = [s for s in statuses if s.get("initial")]
+    if len(initials) != 1:
+        errors.append("%s: exactly one initial status required, found %d" % (machine, len(initials)))
+    if not any(s.get("terminal") for s in statuses):
+        errors.append("%s: at least one terminal status required" % machine)
+    for s in statuses:
+        name = s.get("name") or "<unnamed>"
+        trans = s.get("transitions")
+        if not isinstance(trans, list):
+            errors.append("%s/%s: 'transitions' must be a list" % (machine, name)); trans = []
+        for t in trans:
+            if t not in by_name:
+                errors.append("%s/%s: transition to undefined status '%s'" % (machine, name, t))
+        if s.get("terminal") and trans:
+            errors.append("%s/%s: terminal status must have empty transitions" % (machine, name))
+        if s.get("requiresCommit") and s.get("initial"):
+            errors.append("%s/%s: requiresCommit not allowed on the initial status" % (machine, name))
+        owner = s.get("owner")
+        if not isinstance(owner, dict) or len(owner) != 1 or list(owner)[0] not in ("role", "team"):
+            errors.append("%s/%s: owner must be exactly one of {\"role\": ...} or {\"team\": ...}" % (machine, name))
+        else:
+            kind, val = list(owner.items())[0]
+            if kind == "role" and not role_exists(val):
+                errors.append("%s/%s: unknown role '%s'" % (machine, name, val))
+            if kind == "team" and not team_exists(val):
+                errors.append("%s/%s: unknown team preset '%s'" % (machine, name, val))
+    if len(initials) == 1:
+        seen, stack = set(), [initials[0].get("name")]
+        while stack:
+            n = stack.pop()
+            if n in seen: continue
+            seen.add(n)
+            t = by_name.get(n, {}).get("transitions")
+            for nxt in (t if isinstance(t, list) else []):
+                if nxt in by_name: stack.append(nxt)
+        for n in by_name:
+            if n not in seen:
+                errors.append("%s: status '%s' unreachable from the initial status" % (machine, n))
+
+if errors:
+    for e in errors: print("validate-board: %s" % e, file=sys.stderr)
+    sys.exit(1)
+print("board config OK: %s" % cfg_path)
+PYEOF
 }
 
 teamroot() {
@@ -92,6 +171,12 @@ compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt
     echo
     echo "---"
     cat "$CONFIG"
+    if [ -f "$SKILL_DIR/config/statuses.config.json" ]; then
+      echo
+      echo "---"
+      echo "# Board config (config/statuses.config.json)"
+      cat "$SKILL_DIR/config/statuses.config.json"
+    fi
   } > "$out"
   printf '%s' "$out"
 }
@@ -134,6 +219,7 @@ case "${1:-}" in
     [ -f "$SKILL_DIR/teams/$preset.md" ] || die "unknown preset: $preset (no teams/$preset.md)"
     roster="$(roster_of "$preset")"                       # validate before the loop
     [ -n "$roster" ] || die "teams/$preset.md has an empty ROSTER"
+    validate_board >/dev/null
     for role in $roster; do
       if key_is_null "$(role_cmd_key "$role")"; then
         echo "skipping $role (disabled: $(role_cmd_key "$role")=null)"; continue
@@ -194,7 +280,11 @@ case "${1:-}" in
     done
     echo "stopped team $2"
     ;;
+  validate-board)
+    [ $# -le 2 ] || die "usage: validate-board [config-path]"
+    validate_board "${2:-}"
+    ;;
   *)
-    die "usage: launch-team.sh {team|start|relaunch|worktree|status|stop} ..."
+    die "usage: launch-team.sh {team|start|relaunch|worktree|validate-board|status|stop} ..."
     ;;
 esac

--- a/config/project-management.config.md
+++ b/config/project-management.config.md
@@ -60,6 +60,9 @@ Apply regardless of tool.
 
 ```
 TEAM_MODE=false        # true enables the status-ownership model in reference/team-roles.md
-STRICT_STATUS=true     # true = refuse an action if the item is not in the expected status
+STRICT_STATUS=true     # true = before any write, verify the current status and that the
+                       #        intended move is in that status's transitions list
                        #        (the "andon cord" — see reference/lifecycle.md)
+STATUS_CONFIG=config/statuses.config.json   # the kanban board: statuses, transitions,
+                                            # owners, per-tool mappings (skill-relative path)
 ```

--- a/config/statuses.config.json
+++ b/config/statuses.config.json
@@ -1,0 +1,42 @@
+{
+  "features": {
+    "statuses": [
+      { "name": "Planned", "initial": true,
+        "owner": { "role": "team-lead" },
+        "transitions": ["Active"],
+        "tool": { "Linear": "Planned", "Jira": "To Do", "GitHubIssues": "milestone open, no task started", "Markdown": "[Planned]" } },
+      { "name": "Active",
+        "owner": { "role": "team-lead" },
+        "transitions": ["Resolved"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "milestone open, >=1 task active (derived)", "Markdown": "[Active]" } },
+      { "name": "Resolved", "terminal": true,
+        "owner": { "role": "team-lead" },
+        "transitions": [],
+        "tool": { "Linear": "Completed", "Jira": "Done", "GitHubIssues": "milestone closed", "Markdown": "[Resolved]" } }
+    ]
+  },
+  "tasks": {
+    "statuses": [
+      { "name": "Planned", "initial": true,
+        "owner": { "role": "team-lead" },
+        "transitions": ["Active"],
+        "tool": { "Linear": "Todo", "Jira": "To Do", "GitHubIssues": "open + label status:planned", "Markdown": "[Planned]" } },
+      { "name": "Active",
+        "owner": { "role": "implementer" },
+        "transitions": ["Review", "Blocked"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "open + label status:active", "Markdown": "[Active]" } },
+      { "name": "Review",
+        "owner": { "role": "reviewer" },
+        "transitions": ["Active", "Ready to deploy", "Blocked"],
+        "tool": { "Linear": "In Review", "Jira": "In Review", "GitHubIssues": "open + label status:review", "Markdown": "[Review]" } },
+      { "name": "Blocked",
+        "owner": { "role": "team-lead" },
+        "transitions": ["Planned", "Active", "Review"],
+        "tool": { "Linear": "Blocked", "Jira": "Blocked", "GitHubIssues": "open + label status:blocked", "Markdown": "[Blocked]" } },
+      { "name": "Ready to deploy", "terminal": true, "requiresCommit": true,
+        "owner": { "role": "integrator" },
+        "transitions": [],
+        "tool": { "Linear": "Done", "Jira": "Done", "GitHubIssues": "closed", "Markdown": "[Ready to deploy]" } }
+    ]
+  }
+}

--- a/docs/superpowers/plans/2026-07-06-kanban-status-config.md
+++ b/docs/superpowers/plans/2026-07-06-kanban-status-config.md
@@ -1,0 +1,845 @@
+# Configurable Kanban Statuses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the kanban status machine configurable via `config/statuses.config.json` — adding `Blocked` and `Ready to deploy` (terminal, commit-coupled), removing `Completed`, and assigning each status an owner (team or single agent) that both gates and routes work.
+
+**Architecture:** One global JSON board config becomes the single source of truth for both state machines (features, tasks). All docs (vocabulary, lifecycle, team-roles, orchestration, role briefs, adapters) defer to it; adapters keep their current values only as shipped defaults. A `validate-board` launcher subcommand (python3-backed) enforces structural rules and runs before every team launch. Spec: `docs/superpowers/specs/2026-07-06-kanban-status-config-design.md`.
+
+**Tech Stack:** Bash 3.2-portable shell (launcher), python3 (JSON validation only), Markdown docs. No new dependencies.
+
+## Global Constraints
+
+- Terminal task status is named exactly **`Ready to deploy`** (NOT "Ready for production", NOT "Done", NOT "Completed").
+- Bracket notation everywhere: `[Planned]`, `[Active]`, `[Review]`, `[Blocked]`, `[Ready to deploy]`, `[Resolved]` — exact case.
+- Generic status `[Completed]` must not survive anywhere outside git history and `.workspace/` scratch files.
+- `bin/launch-team.sh` stays bash 3.2-portable (no associative arrays, no `${var,,}`); JSON parsing only via `python3`.
+- Owner field is exactly one of `{"role": "<name>"}` or `{"team": "<preset>"}`. Abstract role names: `implementer`, `reviewer`, `coordinator`, `finalizer`; concrete roles resolve to `roles/<name>.md` or `teams/roles/<name>.md`; teams resolve to `teams/<name>.md`.
+- Blocked vs andon stay distinct: `[Blocked]` = work can't proceed (a configured status with an owner); andon = process is broken (no status write, stop and report).
+- All work happens on branch `feature/agent-teams`. Commit after every task.
+
+---
+
+### Task 1: Default board config + config pointer
+
+**Files:**
+- Create: `config/statuses.config.json`
+- Modify: `config/project-management.config.md` (Optional Behaviour Flags block, lines 61–65)
+
+**Interfaces:**
+- Produces: `config/statuses.config.json` with top-level keys `features.statuses[]` and `tasks.statuses[]`; per-status fields `name`, `initial?`, `terminal?`, `requiresCommit?`, `owner` (`{"role":...}` or `{"team":...}`), `transitions[]`, `tool{}`. Every later task reads this file.
+
+- [ ] **Step 1: Create `config/statuses.config.json`**
+
+```json
+{
+  "features": {
+    "statuses": [
+      { "name": "Planned", "initial": true,
+        "owner": { "role": "team-lead" },
+        "transitions": ["Active"],
+        "tool": { "Linear": "Planned", "Jira": "To Do", "GitHubIssues": "milestone open, no task started", "Markdown": "[Planned]" } },
+      { "name": "Active",
+        "owner": { "role": "team-lead" },
+        "transitions": ["Resolved"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "milestone open, >=1 task active (derived)", "Markdown": "[Active]" } },
+      { "name": "Resolved", "terminal": true,
+        "owner": { "role": "team-lead" },
+        "transitions": [],
+        "tool": { "Linear": "Completed", "Jira": "Done", "GitHubIssues": "milestone closed", "Markdown": "[Resolved]" } }
+    ]
+  },
+  "tasks": {
+    "statuses": [
+      { "name": "Planned", "initial": true,
+        "owner": { "role": "team-lead" },
+        "transitions": ["Active"],
+        "tool": { "Linear": "Todo", "Jira": "To Do", "GitHubIssues": "open + label status:planned", "Markdown": "[Planned]" } },
+      { "name": "Active",
+        "owner": { "role": "implementer" },
+        "transitions": ["Review", "Blocked"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "open + label status:active", "Markdown": "[Active]" } },
+      { "name": "Review",
+        "owner": { "role": "reviewer" },
+        "transitions": ["Active", "Ready to deploy", "Blocked"],
+        "tool": { "Linear": "In Review", "Jira": "In Review", "GitHubIssues": "open + label status:review", "Markdown": "[Review]" } },
+      { "name": "Blocked",
+        "owner": { "role": "team-lead" },
+        "transitions": ["Planned", "Active", "Review"],
+        "tool": { "Linear": "Blocked", "Jira": "Blocked", "GitHubIssues": "open + label status:blocked", "Markdown": "[Blocked]" } },
+      { "name": "Ready to deploy", "terminal": true, "requiresCommit": true,
+        "owner": { "role": "integrator" },
+        "transitions": [],
+        "tool": { "Linear": "Done", "Jira": "Done", "GitHubIssues": "closed", "Markdown": "[Ready to deploy]" } }
+    ]
+  }
+}
+```
+
+Note the task-status tool values match the adapters' existing shipped defaults (Linear `Todo`, not the spec's illustrative `Backlog`).
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `python3 -c "import json; c=json.load(open('config/statuses.config.json')); print(len(c['tasks']['statuses']), 'task statuses')"`
+Expected: `5 task statuses`
+
+- [ ] **Step 3: Add the pointer to `config/project-management.config.md`**
+
+Replace the Optional Behaviour Flags code block:
+
+```
+TEAM_MODE=false        # true enables the status-ownership model in reference/team-roles.md
+STRICT_STATUS=true     # true = refuse an action if the item is not in the expected status
+                       #        (the "andon cord" — see reference/lifecycle.md)
+```
+
+with:
+
+```
+TEAM_MODE=false        # true enables the status-ownership model in reference/team-roles.md
+STRICT_STATUS=true     # true = before any write, verify the current status and that the
+                       #        intended move is in that status's transitions list
+                       #        (the "andon cord" — see reference/lifecycle.md)
+STATUS_CONFIG=config/statuses.config.json   # the kanban board: statuses, transitions,
+                                            # owners, per-tool mappings (skill-relative path)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/statuses.config.json config/project-management.config.md
+git commit -m "feat: add configurable kanban board config (statuses.config.json)"
+```
+
+---
+
+### Task 2: `validate-board` subcommand + board in composed prompts (TDD)
+
+**Files:**
+- Modify: `bin/launch-team.sh` (add `validate_board()` after `roster_of()` ~line 51; extend `compose_prompt()` ~line 95; add `validate-board` case + call it in `team` case ~line 131; extend usage comment lines 5–11 and the `*)` usage string)
+- Test: `tests/launcher-test.sh`
+
+**Interfaces:**
+- Consumes: `config/statuses.config.json` (Task 1).
+- Produces: `bin/launch-team.sh validate-board [config-path]` — exit 0 + `board config OK: <path>` on stdout, exit 1 with `validate-board: <problem>` lines on stderr otherwise. `compose_prompt` output now ends with a `# Board config` section containing the JSON. The `team` subcommand validates before launching.
+
+- [ ] **Step 1: Add failing tests to `tests/launcher-test.sh`**
+
+The fixture (line 20–21) copies `roles reference bin teams` and then creates `config/` — add the board config to the fixture. After line 21 (`mkdir -p .claude/skills/pm/config`) insert:
+
+```bash
+cp "$SKILL_DIR/config/statuses.config.json" .claude/skills/pm/config/
+```
+
+Insert this block before the `# -- status + stop` section (line 103):
+
+```bash
+# -- validate-board: shipped config passes --------------------------------------
+check "validate-board accepts shipped config" "$LAUNCH" validate-board
+
+# -- validate-board: prompt composition includes the board ----------------------
+check "prompt contains board config" grep -q '"Ready to deploy"' .teamwork/test-feature/prompts/backend.md
+
+# -- validate-board: each broken config is refused with the right message -------
+bad() { # bad <desc> <needle> <json>
+  local desc="$1" needle="$2" json="$3" out
+  printf '%s' "$json" > "$TMP/bad.json"
+  if out="$("$LAUNCH" validate-board "$TMP/bad.json" 2>&1)"; then
+    echo "FAIL: $desc (accepted)"; FAILURES=$((FAILURES+1))
+  elif printf '%s' "$out" | grep -q "$needle"; then
+    echo "ok: $desc"
+  else
+    echo "FAIL: $desc (wrong message: $out)"; FAILURES=$((FAILURES+1))
+  fi
+}
+MINF='"features":{"statuses":[{"name":"P","initial":true,"owner":{"role":"team-lead"},"transitions":["R"]},{"name":"R","terminal":true,"owner":{"role":"team-lead"},"transitions":[]}]}'
+bad "invalid JSON refused"            "invalid JSON" '{nope'
+bad "two initials refused"            "exactly one initial" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"initial\":true,\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "unknown transition refused"      "undefined status" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Nope\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "unreachable status refused"      "unreachable" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]},{\"name\":\"Island\",\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]}]}}"
+bad "terminal with outbound refused"  "terminal status must have empty transitions" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
+bad "bad owner refused"               "unknown role" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"nobody-such\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "two-key owner refused"           "exactly one of" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\",\"team\":\"full-stack\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "requiresCommit on initial refused" "not allowed on the initial" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"requiresCommit\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "no terminal refused"             "at least one terminal" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash tests/launcher-test.sh 2>&1 | tail -20`
+Expected: FAIL lines for every new check (the subcommand doesn't exist yet — usage error), ending `N FAILURE(S)`.
+
+- [ ] **Step 3: Implement `validate_board()` in `bin/launch-team.sh`**
+
+Insert after `roster_of()` (after line 51):
+
+```bash
+validate_board() { # validate_board [config-path] — structural checks on the board config
+  local cfg="${1:-$SKILL_DIR/config/statuses.config.json}"
+  [ -f "$cfg" ] || die "no board config: $cfg"
+  command -v python3 >/dev/null 2>&1 || die "validate-board requires python3"
+  python3 - "$cfg" "$SKILL_DIR" <<'PYEOF'
+import json, sys, os
+cfg_path, skill_dir = sys.argv[1], sys.argv[2]
+try:
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+except ValueError as e:
+    print("validate-board: invalid JSON: %s" % e, file=sys.stderr); sys.exit(1)
+
+ABSTRACT_ROLES = {"implementer", "reviewer", "coordinator", "finalizer"}
+errors = []
+
+def role_exists(name):
+    return (name in ABSTRACT_ROLES
+            or os.path.isfile(os.path.join(skill_dir, "roles", name + ".md"))
+            or os.path.isfile(os.path.join(skill_dir, "teams", "roles", name + ".md")))
+
+def team_exists(name):
+    return os.path.isfile(os.path.join(skill_dir, "teams", name + ".md"))
+
+for machine in ("features", "tasks"):
+    statuses = cfg.get(machine, {}).get("statuses")
+    if not isinstance(statuses, list) or not statuses:
+        errors.append("%s: missing or empty 'statuses' list" % machine); continue
+    names = [s.get("name") for s in statuses]
+    for d in sorted(set(n for n in names if names.count(n) > 1)):
+        errors.append("%s: duplicate status name '%s'" % (machine, d))
+    by_name = dict((s.get("name"), s) for s in statuses)
+    initials = [s for s in statuses if s.get("initial")]
+    if len(initials) != 1:
+        errors.append("%s: exactly one initial status required, found %d" % (machine, len(initials)))
+    if not any(s.get("terminal") for s in statuses):
+        errors.append("%s: at least one terminal status required" % machine)
+    for s in statuses:
+        name = s.get("name") or "<unnamed>"
+        trans = s.get("transitions")
+        if not isinstance(trans, list):
+            errors.append("%s/%s: 'transitions' must be a list" % (machine, name)); trans = []
+        for t in trans:
+            if t not in by_name:
+                errors.append("%s/%s: transition to undefined status '%s'" % (machine, name, t))
+        if s.get("terminal") and trans:
+            errors.append("%s/%s: terminal status must have empty transitions" % (machine, name))
+        if s.get("requiresCommit") and s.get("initial"):
+            errors.append("%s/%s: requiresCommit not allowed on the initial status" % (machine, name))
+        owner = s.get("owner")
+        if not isinstance(owner, dict) or len(owner) != 1 or list(owner)[0] not in ("role", "team"):
+            errors.append("%s/%s: owner must be exactly one of {\"role\": ...} or {\"team\": ...}" % (machine, name))
+        else:
+            kind, val = list(owner.items())[0]
+            if kind == "role" and not role_exists(val):
+                errors.append("%s/%s: unknown role '%s'" % (machine, name, val))
+            if kind == "team" and not team_exists(val):
+                errors.append("%s/%s: unknown team preset '%s'" % (machine, name, val))
+    if len(initials) == 1:
+        seen, stack = set(), [initials[0].get("name")]
+        while stack:
+            n = stack.pop()
+            if n in seen: continue
+            seen.add(n)
+            t = by_name.get(n, {}).get("transitions")
+            for nxt in (t if isinstance(t, list) else []):
+                if nxt in by_name: stack.append(nxt)
+        for n in by_name:
+            if n not in seen:
+                errors.append("%s: status '%s' unreachable from the initial status" % (machine, n))
+
+if errors:
+    for e in errors: print("validate-board: %s" % e, file=sys.stderr)
+    sys.exit(1)
+print("board config OK: %s" % cfg_path)
+PYEOF
+}
+```
+
+- [ ] **Step 4: Wire the subcommand, the `team` pre-check, and prompt composition**
+
+In the `case` statement add before `*)`:
+
+```bash
+  validate-board)
+    [ $# -le 2 ] || die "usage: validate-board [config-path]"
+    validate_board "${2:-}"
+    ;;
+```
+
+In the `team)` case, after `roster="$(roster_of "$preset")"` validation and before the `for role` loop, add:
+
+```bash
+    validate_board >/dev/null
+```
+
+In `compose_prompt()`, after `cat "$CONFIG"` (line 94) and before the closing `} > "$out"`, add:
+
+```bash
+    if [ -f "$SKILL_DIR/config/statuses.config.json" ]; then
+      echo
+      echo "---"
+      echo "# Board config (config/statuses.config.json)"
+      cat "$SKILL_DIR/config/statuses.config.json"
+    fi
+```
+
+Update the usage comment (line 5–11) and the final `die "usage: launch-team.sh {team|start|relaunch|worktree|status|stop} ..."` to include `validate-board`:
+
+```bash
+    die "usage: launch-team.sh {team|start|relaunch|worktree|validate-board|status|stop} ..."
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bash tests/launcher-test.sh 2>&1 | tail -20`
+Expected: `ALL PASS`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/launch-team.sh tests/launcher-test.sh
+git commit -m "feat: validate-board subcommand; compose board config into agent prompts"
+```
+
+---
+
+### Task 3: Rewrite `reference/vocabulary.md` status model
+
+**Files:**
+- Modify: `reference/vocabulary.md:33-66` (Status Model section), `:87` (invariant 3)
+
+**Interfaces:**
+- Consumes: `config/statuses.config.json` field names (Task 1).
+- Produces: the canonical prose rule "next status = a status in the current status's `transitions` list" that Tasks 4–9 reference.
+
+- [ ] **Step 1: Replace the entire `## Status Model` section (lines 33–66, up to but not including `## Identifiers`) with:**
+
+```markdown
+## Status Model
+
+Statuses are **configured, not fixed**. The single source of truth is
+`config/statuses.config.json`: for features and for tasks it defines the status list,
+each status's legal outbound `transitions`, its `owner` — the team or single agent that
+works items sitting in that status — and per-adapter `tool` mappings.
+
+Rules that hold for every board:
+
+- **Bracket notation.** Write any status exactly as `[Status Name]` — bracketed, exact
+  case, greppable (`[Planned]`, `[Ready to deploy]`).
+- **Exactly one `initial` status** per machine — where new items are created.
+- **At least one `terminal` status** — where work ends; it has no outbound transitions.
+- **`requiresCommit`** — entering such a status is atomically coupled to a successful
+  commit, performed by that status's owner.
+- **"Next status" means a status listed in the current status's `transitions`.** Any
+  other move is illegal — an **andon cord** condition (see `lifecycle.md`).
+
+### The default board (shipped)
+
+Features: `[Planned]` → `[Active]` → `[Resolved]`.
+
+Tasks:
+
+| Status | Owner (default) | Transitions to | Notes |
+|---|---|---|---|
+| `[Planned]` | team-lead | Active | initial |
+| `[Active]` | implementer | Review, Blocked | |
+| `[Review]` | reviewer | Active, Ready to deploy, Blocked | rework returns to Active |
+| `[Blocked]` | team-lead | Planned, Active, Review | work is stuck; owner unblocks |
+| `[Ready to deploy]` | integrator | — | terminal; `requiresCommit` |
+
+This table is an **example** — the JSON is authoritative. Projects add, rename, or
+remove statuses by editing the config; no other file changes as long as owners and
+tool mappings are set. Validate edits with `bin/launch-team.sh validate-board`.
+```
+
+- [ ] **Step 2: Update invariant 3 (line 87)**
+
+Old: `3. **Status is never skipped.** Move through the state machine in order.`
+New: `3. **Status moves follow the configured \`transitions\` graph.** Never skip, invent, or reverse a move the board does not define.`
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `grep -c 'Completed' reference/vocabulary.md`
+Expected: `0`
+
+```bash
+git add reference/vocabulary.md
+git commit -m "docs: vocabulary defers status model to statuses.config.json"
+```
+
+---
+
+### Task 4: Rewrite `reference/lifecycle.md` scenarios
+
+**Files:**
+- Modify: `reference/lifecycle.md` (Scenario 2 step 2–3, Scenario 4 tail, Scenario 5, new Blocked scenario, Scenario 7 intro, quick-reference table)
+
+**Interfaces:**
+- Consumes: vocabulary rule from Task 3; config from Task 1.
+- Produces: scenario numbering — Blocked becomes **Scenario 7**, andon shifts to **8**, connect/switch tools to **9**. Tasks 5–9 cite "Scenario 7 (Block)" and "Scenario 8 (andon)".
+
+- [ ] **Step 1: Scenario 2 — config-driven start**
+
+Replace step 2 (lines 40–41):
+
+```markdown
+2. **Verify the status is the board's initial status** (`[Planned]` on the default
+   board). If it isn't and `STRICT_STATUS=true`, pull the **andon cord** (Scenario 8).
+   Don't start work on something already `[Active]` elsewhere.
+```
+
+- [ ] **Step 2: Scenario 4 — transitions-graph wording**
+
+Replace the closing paragraph (lines 76–77):
+
+```markdown
+If review finds problems: **move the [task] back to `[Active]`**, fix, and return to
+`[Review]`. Backward moves are legal exactly where `config/statuses.config.json` lists
+them (on the default board: `Review → Active`, plus the `Blocked` returns).
+```
+
+- [ ] **Step 3: Replace Scenario 5 entirely**
+
+```markdown
+## Scenario 5 — Finalize a [task]
+
+Only after the work is reviewed **and** verified (tests/build green, change actually does
+what the [task] asked):
+
+1. Confirm the [task] is in `[Review]`. If not, andon cord.
+2. The terminal status carries `requiresCommit: true` on the default board: **commit the
+   work and move the [task] to `[Ready to deploy]` as one atomic step** — never one
+   without the other. Cite the commit hash in the completion comment.
+3. If **all** [tasks] in the [feature] have reached the terminal status, move the
+   [feature] to `[Resolved]`.
+
+`[Ready to deploy]` means: reviewed, verified, committed — awaiting deployment by humans.
+**Never** move work there that was skipped, partially done, or has failing tests — see
+the fail-loud invariant.
+```
+
+- [ ] **Step 4: Insert new Scenario 7 (Block) after Scenario 6, renumber old 7→8, 8→9**
+
+```markdown
+## Scenario 7 — Block a [task]
+
+When the *work* cannot proceed — missing dependency, unanswered question, broken
+external service — and it isn't a process failure (that's the andon cord, Scenario 8):
+
+1. **Add a comment** stating what is blocking, what was tried, and what would unblock.
+2. **Move the [task] to `[Blocked]`** via the adapter. The board's owner of `[Blocked]`
+   (default: team-lead) now owns resolving it.
+3. The `[Blocked]` owner works the blocker and, once cleared, **moves the [task] back**
+   to the appropriate working status (`Planned`, `Active`, or `Review` on the default
+   board) with a comment saying what changed.
+```
+
+Also update the two cross-references to the old numbering: Scenario 2 step 2 already says "Scenario 8" (Step 1 above); line 41's original "(Scenario 7)" occurrences elsewhere: search `Scenario 7` and `Scenario 8` and fix each to the new numbers.
+
+- [ ] **Step 5: Update the quick-reference table (lines 136–147)**
+
+```markdown
+| Scenario | Writes |
+|---|---|
+| 1 Plan | create `[feature]` `[Planned]`; create `[tasks]` `[Planned]` |
+| 2 Start | `[task]` → `[Active]` (feature → `[Active]` on first) |
+| 3 Diverge | comment only |
+| 4 Review | `[task]` → `[Review]` (or back to `[Active]` on rework) |
+| 5 Finalize | commit + `[task]` → `[Ready to deploy]` (atomic); feature → `[Resolved]` when all done |
+| 6 New work | create `[task]` `[Planned]` |
+| 7 Block | comment + `[task]` → `[Blocked]`; owner routes it back when cleared |
+| 8 Andon | **no write** — stop and report |
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `grep -n 'Completed\|Scenario 7 — Andon\|Scenario 8 — Connect' reference/lifecycle.md`
+Expected: no `[Completed]` matches; andon is Scenario 8; connect/switch is Scenario 9.
+
+```bash
+git add reference/lifecycle.md
+git commit -m "docs: lifecycle scenarios follow the configured board; add Block scenario"
+```
+
+---
+
+### Task 5: Rewrite `reference/team-roles.md` ownership as config-derived
+
+**Files:**
+- Modify: `reference/team-roles.md:34-49` (Transition ownership section)
+
+**Interfaces:**
+- Consumes: ownership rule from spec §2; default board from Task 1.
+- Produces: the sentence "the owner of status S is the only party allowed to work items in S and to perform S's outbound transitions" — role briefs (Task 7) restate it.
+
+- [ ] **Step 1: Replace the `## Transition ownership` section (table and intro, lines 34–49) with:**
+
+```markdown
+## Status ownership — derived from the board config
+
+Ownership is no longer a hard-coded table. `config/statuses.config.json` assigns every
+status an `owner` — a single agent (`{"role": ...}`) or a team (`{"team": ...}`). One
+rule derives everything:
+
+> **The owner of status S is the only party allowed to work items sitting in S, and the
+> only one allowed to perform S's outbound transitions.**
+
+Two refinements:
+
+- **Entering a `requiresCommit` status** is performed by *that* status's owner, atomically
+  with the commit (on the default board: the integrator commits and moves `[Review]` →
+  `[Ready to deploy]` after both approvals exist).
+- **Routing:** when an item enters a status, the mover notifies the new owner's mailbox
+  (`reference/orchestration.md` → *Status routing*). A `{"team": ...}` owner is reached
+  via that team's lead, who dispatches internally.
+
+Worked example — the default board:
+
+| Status | Owner | May perform |
+|---|---|---|
+| `[Planned]` | team-lead (Coordinator) | create [tasks]; sanction claims (`Planned → Active`) |
+| `[Active]` | implementer | `Active → Review` (with `[review-request]`), `Active → Blocked` |
+| `[Review]` | reviewer | `Review → Active` (findings); approval hands off to the integrator for `Review → Ready to deploy` |
+| `[Blocked]` | team-lead | `Blocked → Planned / Active / Review` once cleared |
+| `[Ready to deploy]` | integrator | terminal — the atomic commit+move that enters it |
+
+Feature statuses: the team-lead owns all three (`Planned`, `Active`, `Resolved`) and
+moves `[feature]` → `[Resolved]` only after the completion checklist passes.
+
+If any role finds a [task] in an unexpected status, it **pulls the andon cord**: stop,
+don't guess, escalate to the Coordinator (concrete role: `team-lead`).
+```
+
+- [ ] **Step 2: Update the coupling rules section (lines 53–63)**
+
+Old first bullet: `- **Completion is coupled to a commit.** The Finalizer never marks \`[Completed]\` without a corresponding successful commit, and never commits a track without moving its [task] to \`[Completed]\`. The two are one atomic step.`
+New: `- **Entering a \`requiresCommit\` status is coupled to a commit.** The Finalizer never moves a [task] to \`[Ready to deploy]\` without a corresponding successful commit, and never commits a track without the move. The two are one atomic step.`
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `grep -c 'Completed' reference/team-roles.md`
+Expected: `0`
+
+```bash
+git add reference/team-roles.md
+git commit -m "docs: team-roles ownership derived from board config"
+```
+
+---
+
+### Task 6: Update `reference/orchestration.md` — routing rule + terminal rename
+
+**Files:**
+- Modify: `reference/orchestration.md` (pipeline lines 98–115, integration lines 134–151, new Status routing section after line 83, supervision line 158–161, recovery line 186)
+
+**Interfaces:**
+- Consumes: routing semantics (spec §2), Scenario numbers from Task 4.
+- Produces: `## Status routing` section that role briefs and team-roles cite.
+
+- [ ] **Step 1: Insert after the Structured comments table (after line 83):**
+
+```markdown
+## Status routing
+
+The board (`config/statuses.config.json`, composed into your startup prompt) assigns
+every status an owner. **Whenever you move an item into a status, notify the new
+owner's mailbox** (and, as always, the move itself lands as tracker state). If the
+owner is a `{"team": ...}`, send to that team's lead, who dispatches internally.
+The owner of a status is the only role that works items sitting in it and the only
+one that performs its outbound transitions.
+```
+
+- [ ] **Step 2: Update the pipeline block (lines 100–115)**
+
+In the fenced diagram replace the integrator line and the closing paragraph:
+
+Old line: `      → integrator: verify lists == diff, stage explicitly, run VALIDATE_*,` / `        merge to the feature branch, commit, move to [Completed]   (atomic pair)`
+New: `      → integrator: verify lists == diff, stage explicitly, run VALIDATE_*,` / `        merge to the feature branch, commit, move to [Ready to deploy] (atomic pair)`
+
+Old paragraph (113–115): `The port's state machine is untouched: gates live in comments, statuses move only \`[Planned] → [Active] → [Review] → [Completed]\` (rework: \`[Review] → [Active]\`).`
+New:
+
+```markdown
+Gates live in comments; statuses move only along the `transitions` graph in
+`config/statuses.config.json`. Default board: `[Planned] → [Active] → [Review] →
+[Ready to deploy]`, rework `[Review] → [Active]`, and `[Blocked]` as the parking
+status for stuck work (owner: team-lead — see lifecycle Scenario 7).
+```
+
+- [ ] **Step 3: Integration section — rename terminal (lines 136–151)**
+
+- Line 137: `marks \`[Completed]\`` → `marks \`[Ready to deploy]\``
+- Line 147: `then immediately move the [task] to \`[Completed]\`` → `then immediately move the [task] to \`[Ready to deploy]\``
+- Line 150: `When every [task] is \`[Completed]\`` → `When every [task] is \`[Ready to deploy]\``
+
+- [ ] **Step 4: Supervision + recovery generalization**
+
+- In Detect/Stuck (line 159–161) append a bullet: `- **Parked** — a [task] sitting in \`[Blocked]\` with no new comment past the threshold; the team-lead owns driving it out.`
+- Line 186: `query the tracker for [tasks] assigned to your role in \`[Active]\`/\`[Review]\`` → `query the tracker for [tasks] assigned to your role in any non-terminal status`
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `grep -c '\[Completed\]' reference/orchestration.md`
+Expected: `0`
+
+```bash
+git add reference/orchestration.md
+git commit -m "docs: orchestration adds status routing; terminal is Ready to deploy"
+```
+
+---
+
+### Task 7: Update the 7 role briefs
+
+**Files:**
+- Modify: `roles/backend.md:39-43`, `roles/frontend.md:20-22`, `roles/integrator.md:3-7,33,49`, `roles/team-lead.md:13-14,51-52`, `roles/reviewer.md:26-28`, `roles/qa.md` (no status change needed — verify only), `roles/principal-architect.md` (no status change needed — verify only)
+
+**Interfaces:**
+- Consumes: ownership rule (Task 5), Scenario 7 Block (Task 4).
+- Produces: none (leaf docs).
+
+- [ ] **Step 1: `roles/backend.md` — allowed transitions + terminal rename**
+
+Replace lines 39–43:
+
+```markdown
+- Merge, commit to the feature branch, or change any status except
+  `[Planned]→[Active]` (claim), `[Active]→[Review]` (request review),
+  `[Active]→[Blocked]` (stuck — with a comment saying what would unblock; the
+  team-lead owns `[Blocked]`), and `[Review]→[Active]` (rework — moving your own
+  [task] back when `[review-findings]` require fixes).
+- Move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
+- Work around a failure. Process broken (adapter error, unexpected status) → `[andon]`
+  + mailbox to `team-lead`; work stuck → `[Blocked]` (lifecycle Scenario 7).
+```
+
+- [ ] **Step 2: `roles/frontend.md` — backward-move wording (lines 20–22)**
+
+Old: `your [task] back: comment, move \`[Review]→[Active]\` (this is the one legal backward move), adapt, re-request review.`
+New: `your [task] back: comment, move \`[Review]→[Active]\` (rework, per the board's transitions), adapt, re-request review.`
+
+- [ ] **Step 3: `roles/integrator.md` — terminal rename**
+
+- Line 4: `commits, and marks [tasks] \`[Completed]\`` → `commits, and marks [tasks] \`[Ready to deploy]\``
+- Line 33: `move the [task] to \`[Completed]\` via the adapter` → `move the [task] to \`[Ready to deploy]\` via the adapter`
+- Line 49: `- Mark \`[Completed]\` without a commit, or commit without marking \`[Completed]\`.` → `- Mark \`[Ready to deploy]\` without a commit, or commit without the move — they are one atomic pair.`
+
+- [ ] **Step 4: `roles/team-lead.md` — Blocked ownership + checklist rename**
+
+After line 14 (`- The feature-completion checklist and moving the [feature] to \`[Resolved]\`.`) add:
+
+```markdown
+- The `[Blocked]` queue: you own every [task] in `[Blocked]` — drive each blocker to
+  resolution and route the [task] back to its working status (lifecycle Scenario 7).
+```
+
+Line 52: `- every [task] is \`[Completed]\` with a commit hash cited;` → `- every [task] is \`[Ready to deploy]\` with a commit hash cited;`
+
+- [ ] **Step 5: `roles/reviewer.md` — approval handoff (lines 26–28)**
+
+Old: `Send problems immediately as one \`[review-findings]\` comment with numbered items — the [task] goes back to \`[Active]\`; the implementer fixes and re-requests.`
+New: `Send problems immediately as one \`[review-findings]\` comment with numbered items — the [task] goes back to \`[Active]\`; the implementer fixes and re-requests. On approval, your \`[review-approval]\` (plus the architecture approval) hands the [task] to the integrator, who performs the atomic commit + move to \`[Ready to deploy]\`.`
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `grep -rn '\[Completed\]' roles/`
+Expected: no matches.
+
+```bash
+git add roles/
+git commit -m "docs: role briefs follow board ownership; Blocked flow; Ready to deploy"
+```
+
+---
+
+### Task 8: Adapters defer to the board config
+
+**Files:**
+- Modify: `adapters/_TEMPLATE.md:36-52`, `adapters/Linear.md`, `adapters/Jira.md`, `adapters/GitHubIssues.md`, `adapters/Markdown.md` (each: Feature + Task Status Mapping sections; setup section gets one line)
+
+**Interfaces:**
+- Consumes: `tool` map semantics from Task 1.
+- Produces: none (leaf docs).
+
+- [ ] **Step 1: `adapters/_TEMPLATE.md` — replace both mapping sections (lines 36–51) with:**
+
+```markdown
+## Status Mapping
+
+Statuses come from `config/statuses.config.json` — each status's `tool` map holds this
+adapter's concrete value under the `"<ToolName>"` key. This adapter's *mechanism* for
+setting a status is: <how a status is represented and changed in this tool>.
+
+**Missing mapping = andon.** If a status has no `"<ToolName>"` entry, or the tool's
+workspace lacks the mapped state, stop and report — never invent a fallback status.
+
+Shipped defaults (the default board):
+
+| Status | <ToolName> |
+|---|---|
+| `[Planned]` | <...> |
+| `[Active]` | <...> |
+| `[Review]` | <...> |
+| `[Blocked]` | <...> |
+| `[Ready to deploy]` | <...> |
+
+Feature statuses `[Planned]` / `[Active]` / `[Resolved]` map to <...>.
+```
+
+- [ ] **Step 2: `adapters/Linear.md` — same structure, concrete values**
+
+Replace the Feature Status Mapping and Task Status Mapping sections with the template
+structure from Step 1, filled in: mechanism = *issue workflow state (team-configurable
+names); project state for features*. Task defaults: Planned→Todo, Active→In Progress,
+Review→In Review, Blocked→Blocked, Ready to deploy→Done. Features: Planned→Planned,
+Active→In Progress, Resolved→Completed. Keep the existing note that Linear team states
+are renameable. Add to the *MCP / CLI Setup* section:
+
+```markdown
+> Make sure every status in `config/statuses.config.json` has a matching workflow state
+> in your Linear team (e.g. create a "Blocked" state) — a missing state is an andon stop.
+```
+
+- [ ] **Step 3: `adapters/Jira.md` — same, concrete values**
+
+Mechanism = *workflow transition on the Story/Epic*. Task defaults: Planned→To Do,
+Active→In Progress, Review→In Review, Blocked→Blocked, Ready to deploy→Done. Features
+(Epic): Planned→To Do, Active→In Progress, Resolved→Done. Keep the existing
+customized-workflow note. Same setup line as Step 2, adapted: statuses must exist as
+workflow states/transitions in the Jira project.
+
+- [ ] **Step 4: `adapters/GitHubIssues.md` — same, concrete values**
+
+Mechanism = *open/closed + one `status:*` label (setting a status removes the previous
+`status:*` label)*. Task defaults: Planned→open + `status:planned`, Active→open +
+`status:active`, Review→open + `status:review`, Blocked→open + `status:blocked`,
+Ready to deploy→closed. Features (milestone): unchanged derivation, Resolved→closed.
+Setup line: create the `status:*` labels for every non-terminal status in the board.
+
+- [ ] **Step 5: `adapters/Markdown.md` — config-verbatim rule**
+
+Replace both mapping sections with:
+
+```markdown
+## Status Mapping
+
+Status is literal bracket text (on the feature's title line; at the end of a task's
+`##` header). This adapter writes each status's `"Markdown"` value from
+`config/statuses.config.json` verbatim — custom boards work with no setup at all.
+
+Shipped defaults: `[Planned]`, `[Active]`, `[Review]`, `[Blocked]`,
+`[Ready to deploy]` for tasks; `[Planned]`, `[Active]`, `[Resolved]` for features.
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `grep -rn '\[Completed\]' adapters/`
+Expected: no matches.
+
+```bash
+git add adapters/
+git commit -m "docs: adapters defer status mapping to the board config"
+```
+
+---
+
+### Task 9: README, SKILL.md, teams/_PLAYBOOK.md
+
+**Files:**
+- Modify: `SKILL.md:22-24,62-68`, `README.md:79-82,220-224,266-270,299-302` + new board subsection in the configuration part, `teams/_PLAYBOOK.md:20-22,51-56`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: none (leaf docs).
+
+- [ ] **Step 1: `SKILL.md` golden rule (line 23)**
+
+Old: `> user — use only the generic vocabulary — terms \`[feature]\`, \`[task]\`, \`[subtask]\` and statuses \`[Planned]\`/\`[Active]\`/\`[Review]\`/\`[Completed]\`. Never write "issue", "epic",`
+New: `> user — use only the generic vocabulary — terms \`[feature]\`, \`[task]\`, \`[subtask]\` and the statuses defined in \`config/statuses.config.json\` (default board: \`[Planned]\`/\`[Active]\`/\`[Review]\`/\`[Blocked]\`/\`[Ready to deploy]\`). Never write "issue", "epic",`
+
+- [ ] **Step 2: `SKILL.md` invariants (lines 63–68)**
+
+```markdown
+- **Never skip a status transition.** Legal moves are the `transitions` graph in
+  `config/statuses.config.json` (default board:
+  `[Planned]` → `[Active]` → `[Review]` → `[Ready to deploy]`, rework `[Review]` → `[Active]`,
+  `[Blocked]` for stuck work).
+- **When `STRICT_STATUS=true`, verify the current status before writing** and that the
+  intended move is in its `transitions` list. If not, pull the andon cord instead of
+  forcing the change.
+- **`[Ready to deploy]` means verified-done** — reviewed, tests/build green, and committed
+  (the move and the commit are one atomic step). Never mark work done that was skipped
+  or is failing.
+```
+
+- [ ] **Step 3: `README.md` status mentions**
+
+- Line 81: `Complete task 1.     → verified + [Completed]` → `Finalize task 1.     → verified, committed + [Ready to deploy]`
+- Line 223: `- *"Send it to review"* / *"Complete it"* → \`[Review]\` → \`[Completed]\`` → `- *"Send it to review"* / *"Finalize it"* → \`[Review]\` → \`[Ready to deploy]\``
+- Line 268: `\`[Completed]\` (commit and completion are one atomic step).` → `\`[Ready to deploy]\` (commit and the move are one atomic step).`
+- Line 301: `[Planned] [Active] [Review] [Completed]` → `statuses from statuses.config.json` (keep the ASCII box aligned — pad with spaces to the same width).
+
+- [ ] **Step 4: `README.md` — add a board subsection in the configuration section**
+
+Immediately after the existing tracker-selection explanation (the part describing
+`config/project-management.config.md`), insert:
+
+```markdown
+### Configure your board
+
+`config/statuses.config.json` defines the kanban board: every status, its legal
+`transitions`, its `owner` (the team or single agent that works items in that status),
+and per-tracker `tool` mappings. Default board: `Planned → Active → Review → Ready to
+deploy`, with `Blocked` as the parking status for stuck work. Add, rename, or remove
+statuses by editing the JSON — then run `bin/launch-team.sh validate-board` to check it.
+Make sure your tracker has a matching state for every status (the Markdown tracker
+needs nothing).
+```
+
+- [ ] **Step 5: `teams/_PLAYBOOK.md`**
+
+- Line 22: `every other required approval for that [task] is already on record. Work is "done" only after QA's approval AND the integrator's merge + \`[Completed]\`.` → `every other required approval for that [task] is already on record. Work is "done" only after QA's approval AND the integrator's merge + \`[Ready to deploy]\`.`
+- Line 53: `the approvals and file lists, validates, merges, commits, and marks \`[Completed]\` — the atomic pair. Every preset roster includes it.` → `the approvals and file lists, validates, merges, commits, and marks \`[Ready to deploy]\` — the atomic pair. Every preset roster includes it.`
+- Line 54: `7. **Close.** When all [tasks] are \`[Completed]\`: the architect runs the feature` → `7. **Close.** When all [tasks] are \`[Ready to deploy]\`: the architect runs the feature`
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `grep -rn '\[Completed\]' README.md SKILL.md teams/_PLAYBOOK.md`
+Expected: no matches.
+
+```bash
+git add README.md SKILL.md teams/_PLAYBOOK.md
+git commit -m "docs: README/SKILL/playbook document the configurable board"
+```
+
+---
+
+### Task 10: Final sweep and full test run
+
+**Files:**
+- Test: `tests/launcher-test.sh` (run only)
+
+**Interfaces:**
+- Consumes: all prior tasks.
+
+- [ ] **Step 1: Sweep for leftovers**
+
+Run: `grep -rn '\[Completed\]\|Ready for production' --include='*.md' --include='*.sh' --include='*.json' . | grep -v '.git/' | grep -v '.workspace/' | grep -v '.remember/' | grep -v 'docs/superpowers/'`
+Expected: no output. (The spec/plan under `docs/superpowers/` legitimately mention the old names when describing the change; `.workspace/` is scratch history.)
+
+Also run: `grep -rn 'Ready for production' docs/superpowers/plans/`
+Expected: no output.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bash tests/launcher-test.sh`
+Expected: `ALL PASS`
+
+- [ ] **Step 3: Validate the shipped board**
+
+Run: `bin/launch-team.sh validate-board`
+Expected: `board config OK: .../config/statuses.config.json`
+
+- [ ] **Step 4: Commit anything the sweep fixed; otherwise no-op**
+
+```bash
+git add -u && git commit -m "chore: final sweep for configurable board rollout" || echo "nothing to fix"
+```

--- a/docs/superpowers/specs/2026-07-06-kanban-status-config-design.md
+++ b/docs/superpowers/specs/2026-07-06-kanban-status-config-design.md
@@ -1,0 +1,210 @@
+# Configurable Kanban Statuses — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (pending user spec review)
+**Branch:** `feature/agent-teams`
+
+## Problem
+
+The status machine is hard-coded across the port layer: tasks flow
+`[Planned] → [Active] → [Review] → [Completed]` (features `[Planned] → [Active] → [Resolved]`),
+with the tables baked into `reference/vocabulary.md`, transition ownership baked into
+`reference/team-roles.md`, and per-tool mappings baked into each `adapters/<Tool>.md`.
+Projects cannot rename statuses, add stages (e.g. a blocked queue, a deploy handoff), or
+change who owns a stage without editing five-plus documents.
+
+## Requirements (from user)
+
+1. A configuration file (JSON) defines the kanban statuses.
+2. Add statuses **`Blocked`** and **`Ready to deploy`**.
+3. Remove `Done`/`[Completed]` as a generic status — `Ready to deploy` is the new terminal.
+4. Each status is assigned an owner: a **team** or a **single agent**, who works items in
+   that status.
+
+## Decisions (clarified with user)
+
+| Question | Decision |
+|---|---|
+| Relation to the fixed 4-status machine | **Fully configurable machine** — the config defines the complete ordered status list, legal transitions, and owner per status; docs/adapters defer to it. |
+| What owner assignment does | **Ownership + routing** — the owner is the only party allowed to work items in that status, and the orchestration layer routes items entering a status to the owner's mailbox. Replaces the hard-coded transition-ownership table. |
+| Terminal semantics | **`Ready to deploy` is terminal and commit-coupled** (`requiresCommit: true`): reviewed, verified, committed — awaiting human deployment. Feature-level `Resolved` fires when all tasks reach it. |
+| Integration shape | **One global board config** (`config/statuses.config.json`), not per-team boards, no doc-generation tooling. |
+| Naming | Terminal status is **`Ready to deploy`** (renamed from earlier draft "Ready for production"). |
+
+## 1. Config file and default board
+
+New file **`config/statuses.config.json`** — single source of truth for both state
+machines (features and tasks).
+
+```json
+{
+  "features": {
+    "statuses": [
+      { "name": "Planned",  "initial": true, "owner": { "role": "team-lead" }, "transitions": ["Active"],
+        "tool": { "Linear": "Planned", "Jira": "To Do", "GitHubIssues": "milestone open, no task started", "Markdown": "[Planned]" } },
+      { "name": "Active",   "owner": { "role": "team-lead" }, "transitions": ["Resolved"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "milestone open, >=1 task active (derived)", "Markdown": "[Active]" } },
+      { "name": "Resolved", "terminal": true, "owner": { "role": "team-lead" }, "transitions": [],
+        "tool": { "Linear": "Completed", "Jira": "Done", "GitHubIssues": "milestone closed", "Markdown": "[Resolved]" } }
+    ]
+  },
+  "tasks": {
+    "statuses": [
+      { "name": "Planned",
+        "initial": true,
+        "owner": { "role": "team-lead" },
+        "transitions": ["Active"],
+        "tool": { "Linear": "Backlog", "Jira": "To Do", "GitHubIssues": "open", "Markdown": "[Planned]" } },
+      { "name": "Active",
+        "owner": { "role": "implementer" },
+        "transitions": ["Review", "Blocked"],
+        "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "open + label:active", "Markdown": "[Active]" } },
+      { "name": "Review",
+        "owner": { "role": "reviewer" },
+        "transitions": ["Active", "Ready to deploy", "Blocked"],
+        "tool": { "Linear": "In Review", "Jira": "In Review", "GitHubIssues": "open + label:review", "Markdown": "[Review]" } },
+      { "name": "Blocked",
+        "owner": { "role": "team-lead" },
+        "transitions": ["Planned", "Active", "Review"],
+        "tool": { "Linear": "Blocked", "Jira": "Blocked", "GitHubIssues": "open + label:blocked", "Markdown": "[Blocked]" } },
+      { "name": "Ready to deploy",
+        "terminal": true,
+        "requiresCommit": true,
+        "owner": { "role": "integrator" },
+        "transitions": [],
+        "tool": { "Linear": "Done", "Jira": "Done", "GitHubIssues": "closed", "Markdown": "[Ready to deploy]" } }
+    ]
+  }
+}
+```
+
+Schema, per status:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string, required | Status name; referenced in bracket notation `[Name]` everywhere. |
+| `initial` | bool, default false | Entry status. Exactly one per machine. |
+| `terminal` | bool, default false | End status. At least one per machine; `transitions` must be empty. |
+| `requiresCommit` | bool, default false | Entering this status is atomically coupled to a successful commit (performed by the status owner). |
+| `owner` | object, required | Exactly one of `{"role": "<name>"}` (single agent — abstract role like `implementer`/`reviewer`, or a concrete role like `backend`) or `{"team": "<preset>"}` (a team preset from `teams/`, routed via that team's lead). |
+| `transitions` | array of status names, required | The only legal outbound moves. |
+| `tool` | object, optional | Per-adapter concrete status value. Missing entry for the active adapter = andon on write. |
+
+Notes:
+
+- `Done`/`Completed` no longer exists as a *generic* status. The tool-side value may
+  still be "Done" (that's just what Linear/Jira call their terminal column — configurable).
+- `Blocked` is entered from `Active` or `Review` and returns to any working status.
+- Editing this file is how a project adds/renames/removes statuses; nothing else needs
+  touching as long as owners and tool mappings are set.
+
+## 2. Ownership and routing semantics
+
+**Core rule:** the owner of status S is the only party allowed to work items sitting in S
+and the only one allowed to perform S's *outbound* transitions. The hard-coded
+transition-ownership table in `reference/team-roles.md` is replaced by this derived rule.
+
+Against the default board:
+
+- `Planned` (owner `team-lead`) — creates/refines tasks, hands them out; an implementer
+  claiming a task is the team-lead-sanctioned `Planned → Active` move (claim-on-assignment).
+- `Active` (owner `implementer`) — implements; moves to `Review`, or `Blocked` when stuck.
+- `Review` (owner `reviewer`) — approves → `Ready to deploy` handoff to the integrator
+  (who performs commit + status write as one atomic step, per `requiresCommit`), or
+  sends back → `Active`.
+- `Blocked` (owner `team-lead`) — works the unblock ladder (`reference/orchestration.md`),
+  then routes the item back to the appropriate working status.
+
+**Routing (team mode):** whenever an item enters a status, the mover notifies the new
+owner's mailbox (existing mailbox mechanism). `{"team": ...}` owners route via that
+team's lead, who dispatches internally. Single-agent mode (`TEAM_MODE=false`): one agent
+plays every owner; routing is a no-op, but the state machine and pre-checks still apply.
+
+**Blocked vs andon cord — distinct concepts:**
+
+- `Blocked` = the *work* cannot proceed (missing dependency, unanswered question, failed
+  external service). A normal, configured status with an owner resolving it.
+- Andon cord = the *process* is broken (unexpected status, adapter operation failed,
+  invalid config). Stop, write nothing, escalate — unchanged.
+- `STRICT_STATUS=true` now means: before any write, verify the item's current status and
+  that the intended move is in that status's `transitions` list; otherwise andon.
+
+**Backward moves** are no longer special-cased; legality is purely the `transitions` graph.
+
+## 3. Consumer updates
+
+- **`reference/vocabulary.md`** — Status Model section reduces to: bracket notation rule
+  (`[Status Name]`, exact case), pointer to `config/statuses.config.json` as single source
+  of truth, and the invariants (fail loud; no skipping — "next status" = a status in the
+  current status's `transitions` list). The default board appears as an example, labeled
+  as the shipped default.
+- **`reference/lifecycle.md`** — scenarios rewritten status-agnostically: "Start" claims
+  from the *initial* status; "Complete" becomes "Finalize" targeting the *terminal* status
+  with the `requiresCommit` check; new **Scenario — Block a [task]** (entering/leaving
+  `Blocked`, who moves it, required unblock comment); quick-reference table regenerated
+  against the default board.
+- **`reference/team-roles.md`** — transition-ownership table replaced by the derived rule
+  (Section 2) plus a worked example against the default board.
+- **`reference/orchestration.md`** — adds the routing rule (status entry → owner mailbox;
+  team owners via team lead). Comment markers unchanged (`[review-request]` written when
+  moving into `Review`).
+- **`roles/*.md`** (7 briefs) — status responsibilities reference the config ("you own the
+  statuses whose `owner.role` matches your role") with default-board behavior spelled out.
+  This also fixes the ultra-review role-protocol gaps (e.g. `backend.md` missing
+  `[Review] → [Active]` rework), since transitions are config-derived rather than
+  per-brief prose.
+- **`config/project-management.config.md`** — add `STATUS_CONFIG=config/statuses.config.json`
+  next to `TEAM_MODE`/`STRICT_STATUS`.
+- **`README.md` / `SKILL.md` / `teams/_PLAYBOOK.md`** — short "Configure your board"
+  subsection: edit the JSON; what the fields mean.
+
+## 4. Adapter changes
+
+Adapters stop owning the status vocabulary and become pure translators:
+
+- **`adapters/_TEMPLATE.md` + Linear / Jira / GitHubIssues / Markdown** — "Status Mapping"
+  tables are replaced by: *read the active status list from `config/statuses.config.json`;
+  each status's `tool` map gives this tool's concrete value.* Each adapter documents its
+  mapping *mechanism* (Linear: workspace state name; Jira: transition name; GitHubIssues:
+  open/closed + labels; Markdown: literal bracket text) and keeps its current values only
+  as shipped defaults for the default board.
+- **Missing mapping = andon.** Moving to a status with no `tool` entry for the active
+  adapter — or a tool workspace lacking that state (e.g. no "Blocked" column in Linear) —
+  stops and reports; never invent a fallback. Each adapter's setup section gains one line:
+  create these states/labels in your workspace to match the board config.
+- **Markdown adapter** needs no workspace setup — it writes whatever bracket text the
+  config specifies, so custom boards work out of the box.
+
+## 5. Validation, error handling, testing
+
+Validation rules (checked before any board-driven action; violation = andon, naming the
+config file explicitly):
+
+1. Valid JSON.
+2. Exactly one `initial: true` per machine.
+3. At least one `terminal: true` per machine.
+4. Every `transitions` entry names a defined status in the same machine.
+5. Terminal statuses have empty `transitions`.
+6. Every status is reachable from the initial status.
+7. `owner` is exactly one of `role` / `team`, and the name resolves to an existing
+   `roles/*.md` role (or abstract role) or `teams/` preset.
+8. `requiresCommit` is not set on the initial status (a commit cannot be required to
+   enter the board).
+
+Mechanics:
+
+- **`bin/launch-team.sh`** gains a `validate-board` subcommand (bash 3.2-portable; uses
+  `python3` for JSON parsing, degrading to a clear "python3 required" message). The
+  launcher runs it automatically before launching a team.
+- **`tests/launcher-test.sh`** gains cases: default config passes; broken configs (two
+  initials, unknown transition target, unreachable status, bad owner, terminal with
+  outbound transitions) each fail with the right message.
+
+## Out of scope
+
+- Per-team boards (one global board per project).
+- Doc-generation tooling (docs defer to the config in prose; no build step).
+- Migration of existing `.workspace/` task files — scratch data; old `[Completed]` text
+  remains as history, new moves follow the new board.
+- Changing the feature-status machine's semantics beyond configurability (default stays
+  Planned/Active/Resolved).

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -37,8 +37,9 @@ Turn an idea into a tracked feature with a task breakdown.
 
 1. **Read the [task]** in full via the adapter — description, `[subtasks]`, comments,
    linked `[feature]`.
-2. **Verify status is `[Planned]`.** If it isn't and `STRICT_STATUS=true`, pull the
-   **andon cord** (Scenario 7). Don't start work on something already `[Active]` elsewhere.
+2. **Verify the status is the board's initial status** (`[Planned]` on the default
+   board). If it isn't and `STRICT_STATUS=true`, pull the **andon cord** (Scenario 8).
+   Don't start work on something already `[Active]` elsewhere.
 3. **Move the [task] to `[Active]`** via the adapter *before* writing any code.
 4. If this is the feature's first `[Active]` task, the [feature] moves `[Planned]` →
    `[Active]` (do this only if the adapter tracks feature status explicitly).
@@ -74,24 +75,26 @@ Reality rarely matches the plan. When you must deviate from what the [task] desc
    reviewer (see `team-roles.md`).
 
 If review finds problems: **move the [task] back to `[Active]`**, fix, and return to
-`[Review]`. This is the only backward transition allowed.
+`[Review]`. Backward moves are legal exactly where `config/statuses.config.json` lists
+them (on the default board: `Review → Active`, plus the `Blocked` returns).
 
 ---
 
-## Scenario 5 — Complete a [task]
+## Scenario 5 — Finalize a [task]
 
 Only after the work is reviewed **and** verified (tests/build green, change actually does
 what the [task] asked):
 
 1. Confirm the [task] is in `[Review]`. If not, andon cord.
-2. Commit the work (if your project couples commits to completion — recommended).
-3. **Move the [task] to `[Completed]`** via the adapter, coupled with the successful commit
-   so the two never drift apart.
-4. If **all** [tasks] in the [feature] are now `[Completed]`, move the [feature] to
-   `[Resolved]`.
+2. The terminal status carries `requiresCommit: true` on the default board: **commit the
+   work and move the [task] to `[Ready to deploy]` as one atomic step** — never one
+   without the other. Cite the commit hash in the completion comment.
+3. If **all** [tasks] in the [feature] have reached the terminal status, move the
+   [feature] to `[Resolved]`.
 
-> **Never** mark `[Completed]` for work that was skipped, partially done, or has failing
-> tests. "Completed" is a claim of verified done — see the fail-loud invariant.
+`[Ready to deploy]` means: reviewed, verified, committed — awaiting deployment by humans.
+**Never** move work there that was skipped, partially done, or has failing tests — see
+the fail-loud invariant.
 
 ---
 
@@ -108,7 +111,21 @@ edge case, a follow-up):
 
 ---
 
-## Scenario 7 — Andon cord (stop-the-line)
+## Scenario 7 — Block a [task]
+
+When the *work* cannot proceed — missing dependency, unanswered question, broken
+external service — and it isn't a process failure (that's the andon cord, Scenario 8):
+
+1. **Add a comment** stating what is blocking, what was tried, and what would unblock.
+2. **Move the [task] to `[Blocked]`** via the adapter. The board's owner of `[Blocked]`
+   (default: team-lead) now owns resolving it.
+3. The `[Blocked]` owner works the blocker and, once cleared, **moves the [task] back**
+   to the appropriate working status (`Planned`, `Active`, or `Review` on the default
+   board) with a comment saying what changed.
+
+---
+
+## Scenario 8 — Andon cord (stop-the-line)
 
 Named after the Toyota cord any worker can pull to halt the line. Pull it when:
 
@@ -123,7 +140,7 @@ the failure mode this whole design exists to prevent.
 
 ---
 
-## Scenario 8 — Connect / switch tools
+## Scenario 9 — Connect / switch tools
 
 1. Ensure `adapters/<Tool>.md` exists (copy `adapters/_TEMPLATE.md` for a new tool).
 2. Set `PRODUCT_MANAGEMENT_TOOL=<Tool>` in `config/project-management.config.md`.
@@ -141,6 +158,7 @@ the failure mode this whole design exists to prevent.
 | 2 Start | `[task]` → `[Active]` (feature → `[Active]` on first) |
 | 3 Diverge | comment only |
 | 4 Review | `[task]` → `[Review]` (or back to `[Active]` on rework) |
-| 5 Complete | `[task]` → `[Completed]` (feature → `[Resolved]` when all done) |
+| 5 Finalize | commit + `[task]` → `[Ready to deploy]` (atomic); feature → `[Resolved]` when all done |
 | 6 New work | create `[task]` `[Planned]` |
-| 7 Andon | **no write** — stop and report |
+| 7 Block | comment + `[task]` → `[Blocked]`; owner routes it back when cleared |
+| 8 Andon | **no write** — stop and report |

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -82,6 +82,15 @@ invent new ones, never misspell them.
 | `[andon]` | any role | Stop-the-line report: what failed, exact error, what you did NOT do. |
 | `[escalation]` | team-lead | Needs the human: question + context + what was already tried. |
 
+## Status routing
+
+The board (`config/statuses.config.json`, composed into your startup prompt) assigns
+every status an owner. **Whenever you move an item into a status, notify the new
+owner's mailbox** (and, as always, the move itself lands as tracker state). If the
+owner is a `{"team": ...}`, send to that team's lead, who dispatches internally.
+The owner of a status is the only role that works items sitting in it and the only
+one that performs its outbound transitions.
+
 ## Claiming a [task]
 
 1. Read the [task] in full via the adapter (description, [subtasks], all comments).
@@ -106,12 +115,14 @@ claim → [design-note] → wait for [design-approved]      (no code before the 
       → findings? → back to [Active], fix, [review-request] again
       → [review-approval] + [architecture-approval] (both, with file lists)
       → integrator: verify lists == diff, stage explicitly, run VALIDATE_*,
-        merge to the feature branch, commit, move to [Completed]   (atomic pair)
+        merge to the feature branch, commit, move to [Ready to deploy] (atomic pair)
       → principal-architect divergence sweep updates upcoming [tasks]
 ```
 
-The port's state machine is untouched: gates live in comments, statuses move only
-`[Planned] → [Active] → [Review] → [Completed]` (rework: `[Review] → [Active]`).
+Gates live in comments; statuses move only along the `transitions` graph in
+`config/statuses.config.json`. Default board: `[Planned] → [Active] → [Review] →
+[Ready to deploy]`, rework `[Review] → [Active]`, and `[Blocked]` as the parking
+status for stuck work (owner: team-lead — see lifecycle Scenario 7).
 
 ## Dual review
 
@@ -134,7 +145,7 @@ always clean; anything broken on the branch is ours to fix or file (Scenario 6).
 ## Integration
 
 The `integrator` is the **only** role that merges to the feature branch, commits, or
-marks `[Completed]`. Pipeline (all-or-nothing, zero tolerance, no overrides — not
+marks `[Ready to deploy]`. Pipeline (all-or-nothing, zero tolerance, no overrides — not
 even from the team-lead):
 
 1. Verify both approval comments exist and their file lists are identical to
@@ -144,10 +155,10 @@ even from the team-lead):
 3. Run `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT` (skip `null` ones, record
    skips). Any failure → `[andon]`, task back to `[Active]`.
 4. Merge the task branch into the feature branch; remove the worktree.
-5. Commit, capture the hash, then immediately move the [task] to `[Completed]`,
+5. Commit, capture the hash, then immediately move the [task] to `[Ready to deploy]`,
    citing the hash. Commit and completion are one atomic pair — never one without
    the other.
-6. When every [task] is `[Completed]`, tell the team-lead and principal-architect; the [feature] moves to
+6. When every [task] is `[Ready to deploy]`, tell the team-lead and principal-architect; the [feature] moves to
    `[Resolved]` only after the Lead's completion checklist passes.
 
 ## Supervision — the team-lead loop
@@ -159,6 +170,7 @@ Detect:
   no new comment past the threshold; a `[design-note]`, question, or
   `[review-request]` that nobody answered (the principal-architect is on the hot
   path — monitor it like anyone else).
+- **Parked** — a [task] sitting in `[Blocked]` with no new comment past the threshold; the team-lead owns driving it out.
 - **Conflict** — two claimants on one [task]; contradictory `[divergence]` notes
   across [tasks]; a merge conflict reported by the integrator; a deadlock
   (A waits on B waits on A).
@@ -183,7 +195,7 @@ blocks the team on an interactive user prompt; escalation is the channel.
 ## Recovery
 
 Relaunched or restarted agents need no session state: read your role brief, query
-the tracker for [tasks] assigned to your role in `[Active]`/`[Review]`, read the
+the tracker for [tasks] assigned to your role in any non-terminal status, read the
 comment trail (design note, approvals, findings), check your worktree, resume at the
 pipeline stage the comments prove you reached. If the trail is ambiguous → `[andon]`.
 

--- a/reference/team-roles.md
+++ b/reference/team-roles.md
@@ -22,7 +22,7 @@ When running an actual agent team (`reference/orchestration.md`), the abstract r
 | **Coordinator** | Plans the [feature], creates [tasks], assigns them, decides what new work enters the current iteration. Never writes code. |
 | **Implementer** | Picks up a [task], writes the code, records divergences. |
 | **Reviewer** | Reviews an implementer's work, approves or sends it back. Never modifies code. |
-| **Finalizer** | Runs final validation, commits, and marks [tasks] `[Completed]`. The **single** role allowed to complete tasks and to couple completion with a commit. |
+| **Finalizer** | Runs final validation, commits, and moves [tasks] to `[Ready to deploy]`. The **single** role allowed to perform the `requiresCommit` move and to couple that move with a commit. |
 | **Principal Architect** | Technical authority: planning approval, per-[task] design gate, architecture half of every review, sole editor of upcoming [task] descriptions. Never writes code. |
 | **Team Lead** | Process authority: plans, launches, supervises, unblocks, reassigns, escalates. Never writes code, never overrides Finalizer/Integrator or Principal Architect. |
 
@@ -31,19 +31,36 @@ still holds — it's about which transition, not how many humans/agents exist.
 
 ---
 
-## Transition ownership
+## Status ownership — derived from the board config
 
-| Transition | Sole owner | Pre-check before acting |
+Ownership is no longer a hard-coded table. `config/statuses.config.json` assigns every
+status an `owner` — a single agent (`{"role": ...}`) or a team (`{"team": ...}`). One
+rule derives everything:
+
+> **The owner of status S is the only party allowed to work items sitting in S, and the
+> only one allowed to perform S's outbound transitions.**
+
+Two refinements:
+
+- **Entering a `requiresCommit` status** is performed by *that* status's owner, atomically
+  with the commit (on the default board: the integrator commits and moves `[Review]` →
+  `[Ready to deploy]` after both approvals exist).
+- **Routing:** when an item enters a status, the mover notifies the new owner's mailbox
+  (`reference/orchestration.md` → *Status routing*). A `{"team": ...}` owner is reached
+  via that team's lead, who dispatches internally.
+
+Worked example — the default board:
+
+| Status | Owner | May perform |
 |---|---|---|
-| create `[task]` `[Planned]` | Coordinator | planning approval from the Principal Architect exists (team mode — see `reference/orchestration.md`) |
-| `[feature]` `[Planned]` → `[Active]` | Implementer (on the feature's first claimed [task]) | only if the adapter tracks feature status explicitly |
-| `[Planned]` → `[Active]` | Implementer | verify `[task]` is `[Planned]` (not already claimed) |
-| `[Review]` → `[Active]` | Implementer | verify `[task]` is `[Review]` (rework requested) |
-| `[Review]` → `[Completed]` | Finalizer | verify `[task]` is `[Review]` **and** commit succeeded |
-| `[feature]` → `[Resolved]` | Coordinator (team-lead) — after the completion checklist | verify **all** `[tasks]` are `[Completed]` |
-| `[design-note]` → `[design-approved]`/`[design-pushback]` (comment gate, no status move) | Principal Architect | a `[design-note]` exists on the `[Active]` [task] |
-| `[Active]` → `[Review]` | Implementer (with `[review-request]`) | verify `[task]` is `[Active]` and `[design-approved]` exists (team mode) |
-| approve in `[Review]` (comment gate) | Reviewer (`[review-approval]`) **and** Principal Architect (`[architecture-approval]`) | both lists must match the diff |
+| `[Planned]` | team-lead (Coordinator) | create [tasks]; sanction claims (`Planned → Active`) |
+| `[Active]` | implementer | `Active → Review` (with `[review-request]`), `Active → Blocked` |
+| `[Review]` | reviewer | `Review → Active` (findings); approval hands off to the integrator for `Review → Ready to deploy` |
+| `[Blocked]` | team-lead | `Blocked → Planned / Active / Review` once cleared |
+| `[Ready to deploy]` | integrator | terminal — the atomic commit+move that enters it |
+
+Feature statuses: the team-lead owns all three (`Planned`, `Active`, `Resolved`) and
+moves `[feature]` → `[Resolved]` only after the completion checklist passes.
 
 If any role finds a [task] in an unexpected status, it **pulls the andon cord**: stop,
 don't guess, escalate to the Coordinator (concrete role: `team-lead`).
@@ -52,9 +69,7 @@ don't guess, escalate to the Coordinator (concrete role: `team-lead`).
 
 ## Coupling rules
 
-- **Completion is coupled to a commit.** The Finalizer never marks `[Completed]` without a
-  corresponding successful commit, and never commits a track without moving its [task] to
-  `[Completed]`. The two are one atomic step.
+- **Entering a `requiresCommit` status is coupled to a commit.** The Finalizer never moves a [task] to `[Ready to deploy]` without a corresponding successful commit, and never commits a track without the move. The two are one atomic step.
 - **Ad-hoc work has no [task].** If an agent is pulled off to fix something unrelated
   (e.g. a production incident), it does **not** touch task statuses for that work — it
   reports back and returns to its assigned [task]. File real follow-ups as new [tasks]
@@ -66,7 +81,7 @@ don't guess, escalate to the Coordinator (concrete role: `team-lead`).
 
 ## Why this maps cleanly onto adapters
 
-None of the above mentions a tool. "Move `[Review]` → `[Completed]`" is the same generic
+None of the above mentions a tool. "Move `[Review]` → `[Ready to deploy]`" is the same generic
 operation whether the Finalizer is closing a GitHub issue, dragging a Linear card, or
 editing a Markdown header. The role model is pure port; the adapter is pure translation.
 That separation is the whole point — you can restructure your team without touching a

--- a/reference/vocabulary.md
+++ b/reference/vocabulary.md
@@ -34,35 +34,39 @@ These belong **only** inside `adapters/<Tool>.md`, where the mapping is defined 
 
 ## Status Model
 
-Two small state machines. Adapters map each generic status to a concrete tool status.
+Statuses are **configured, not fixed**. The single source of truth is
+`config/statuses.config.json`: for features and for tasks it defines the status list,
+each status's legal outbound `transitions`, its `owner` — the team or single agent that
+works items sitting in that status — and per-adapter `tool` mappings.
 
-### Feature statuses
+Rules that hold for every board:
 
-| Generic status | Meaning |
-|---|---|
-| `[Planned]` | Defined, not yet started. |
-| `[Active]` | At least one task is in progress. |
-| `[Resolved]` | All tasks complete; the feature is delivered. |
+- **Bracket notation.** Write any status exactly as `[Status Name]` — bracketed, exact
+  case, greppable (`[Planned]`, `[Ready to deploy]`).
+- **Exactly one `initial` status** per machine — where new items are created.
+- **At least one `terminal` status** — where work ends; it has no outbound transitions.
+- **`requiresCommit`** — entering such a status is atomically coupled to a successful
+  commit, performed by that status's owner.
+- **"Next status" means a status listed in the current status's `transitions`.** Any
+  other move is illegal — an **andon cord** condition (see `lifecycle.md`).
 
-### Task statuses
+### The default board (shipped)
 
-| Generic status | Meaning | Typical transition owner (single-agent = you) |
-|---|---|---|
-| `[Planned]` | Ready to be picked up. | — |
-| `[Active]` | Being implemented (or being fixed after review). | Implementer |
-| `[Review]` | Implementation done; awaiting review. | Reviewer |
-| `[Completed]` | Reviewed, verified, and committed. | Whoever finalizes/commits |
+Features: `[Planned]` → `[Active]` → `[Resolved]`.
 
-### Legal task transitions
+Tasks:
 
-```
-[Planned] ──▶ [Active] ──▶ [Review] ──▶ [Completed]
-                 ▲             │
-                 └─────────────┘        (review found problems → back to [Active])
-```
+| Status | Owner (default) | Transitions to | Notes |
+|---|---|---|---|
+| `[Planned]` | team-lead | Active | initial |
+| `[Active]` | implementer | Review, Blocked | |
+| `[Review]` | reviewer | Active, Ready to deploy, Blocked | rework returns to Active |
+| `[Blocked]` | team-lead | Planned, Active, Review | work is stuck; owner unblocks |
+| `[Ready to deploy]` | integrator | — | terminal; `requiresCommit` |
 
-Any other transition is a mistake. If an item is not in the status a step expects, that's
-an **andon cord** condition — see `lifecycle.md`.
+This table is an **example** — the JSON is authoritative. Projects add, rename, or
+remove statuses by editing the config; no other file changes as long as owners and
+tool mappings are set. Validate edits with `bin/launch-team.sh validate-board`.
 
 ---
 
@@ -84,6 +88,6 @@ workflow — only the adapter knows the shape.
    fabricate an update you didn't actually perform.
 2. **Fail loud.** If an operation fails, stop and report it. Never silently work around a
    failure or pretend a status changed.
-3. **Status is never skipped.** Move through the state machine in order.
+3. **Status moves follow the configured `transitions` graph.** Never skip, invent, or reverse a move the board does not define.
 4. **Reads are cheap, writes are deliberate.** Confirm the current status before a write
    when `STRICT_STATUS=true`.

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -37,7 +37,10 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
 
 - Write code before `[design-approved]`, or outside your worktree.
 - Merge, commit to the feature branch, or change any status except
-  `[Planned]→[Active]` (claim), `[Active]→[Review]` (request review), and
-  `[Review]→[Active]` (rework — moving your own [task] back when `[review-findings]` require fixes).
-- Mark anything `[Completed]` — that is the integrator's atomic pair.
-- Work around a failure. Blocked or broken → `[andon]` + mailbox to `team-lead`.
+  `[Planned]→[Active]` (claim), `[Active]→[Review]` (request review),
+  `[Active]→[Blocked]` (stuck — with a comment saying what would unblock; the
+  team-lead owns `[Blocked]`), and `[Review]→[Active]` (rework — moving your own
+  [task] back when `[review-findings]` require fixes).
+- Move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
+- Work around a failure. Process broken (adapter error, unexpected status) → `[andon]`
+  + mailbox to `team-lead`; work stuck → `[Blocked]` (lifecycle Scenario 7).

--- a/roles/frontend.md
+++ b/roles/frontend.md
@@ -18,8 +18,8 @@ design gate, implement in your worktree, self-validate, `[review-request]`, rewo
    mocks, that's a `[divergence]` comment.
 3. **Contract drift.** If the backend changes a contract after your
    `[review-request]` (you'll see a new `[api-ready]` or a mailbox note), pull
-   your [task] back: comment, move `[Review]→[Active]` (this is the one legal
-   backward move), adapt, re-request review.
+   your [task] back: comment, move `[Review]→[Active]` (rework, per the board's
+   transitions), adapt, re-request review.
 
 Everything else — claiming, worktree via
 `bin/launch-team.sh worktree <team> frontend <taskId>`, `[divergence]` discipline,

--- a/roles/integrator.md
+++ b/roles/integrator.md
@@ -1,7 +1,7 @@
 # Role: integrator
 
 You are the **integrator** — the sole agent that merges to the feature branch,
-commits, and marks [tasks] `[Completed]`. You never write or edit code; you only
+commits, and marks [tasks] `[Ready to deploy]`. You never write or edit code; you only
 verify, stage, validate, merge, and commit. Zero tolerance: **no one can override
 you, including the team-lead.** Any failure means refuse, `[andon]`, and the [task]
 goes back to `[Active]`. Mechanics: `reference/orchestration.md` → *Integration*.
@@ -30,7 +30,7 @@ in the tracker are the only trigger that counts.
 6. Merge the task branch into the feature branch; remove the worktree
    (`git worktree remove`).
 7. Commit. Capture the hash (`git rev-parse HEAD`).
-8. **Immediately** move the [task] to `[Completed]` via the adapter, with a comment
+8. **Immediately** move the [task] to `[Ready to deploy]` via the adapter, with a comment
    citing the commit hash, the validations run (and skips), and the merged files.
    Commit + completion are one atomic pair — never leave one without the other; if
    the status write fails, `[andon]` loudly before doing anything else.
@@ -46,6 +46,6 @@ conflicts yourself; report the conflict to the team-lead.
 ## You never
 
 - Commit anything unapproved, unvalidated, or failing — regardless of who asks.
-- Mark `[Completed]` without a commit, or commit without marking `[Completed]`.
+- Mark `[Ready to deploy]` without a commit, or commit without the move — they are one atomic pair.
 - Resolve merge conflicts that require code judgment.
 - Touch the [feature] status — the team-lead resolves the [feature].

--- a/roles/reviewer.md
+++ b/roles/reviewer.md
@@ -24,7 +24,7 @@ requirements, not from the diff.
 file in the worktree, fully, line by line. Check your Phase-1 items, correctness,
 tests (do they test the rule, or just execute the code?), naming, error handling.
 Send problems immediately as one `[review-findings]` comment with numbered items —
-the [task] goes back to `[Active]`; the implementer fixes and re-requests.
+the [task] goes back to `[Active]`; the implementer fixes and re-requests. On approval, your `[review-approval]` (plus the architecture approval) hands the [task] to the integrator, who performs the atomic commit + move to `[Ready to deploy]`.
 
 **Phase 3 — Verify.** On re-review: re-read every fixed file. Every Phase-1
 checklist item needs a `file:line` citation for the implementation AND a citation

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -12,6 +12,8 @@ governs everything below; this brief only says what is *yours*.
 - The supervision loop and the unblock ladder.
 - Reassignments (`[handoff]`) and escalations (`[escalation]` + `ESCALATIONS.md`).
 - The feature-completion checklist and moving the [feature] to `[Resolved]`.
+- The `[Blocked]` queue: you own every [task] in `[Blocked]` — drive each blocker to
+  resolution and route the [task] back to its working status (lifecycle Scenario 7).
 
 ## You never
 
@@ -49,7 +51,7 @@ both agents by mailbox, record the decision on both [tasks].
 ## Phase 3 — Feature completion checklist
 
 Declare the [feature] `[Resolved]` only when ALL of:
-- every [task] is `[Completed]` with a commit hash cited;
+- every [task] is `[Ready to deploy]` with a commit hash cited;
 - the integrator confirms the feature branch is clean (no unmerged worktrees,
   validations green);
 - the principal-architect confirms its final divergence sweep found nothing new;

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -19,7 +19,7 @@ protocol; it never contradicts it.
 2. **The Senior QA Engineer is the final review gate.** No [task] reaches the
    integrator until QA's `[review-approval]` exists, and QA approves only after
    every other required approval for that [task] is already on record. Work is
-   "done" only after QA's approval AND the integrator's merge + `[Completed]`.
+   "done" only after QA's approval AND the integrator's merge + `[Ready to deploy]`.
 
 ## Stages
 
@@ -50,8 +50,8 @@ protocol; it never contradicts it.
    always judges the final shape of the change.
 6. **Integration.** The standard `integrator` (`roles/integrator.md`) verifies
    the approvals and file lists, validates, merges, commits, and marks
-   `[Completed]` — the atomic pair. Every preset roster includes it.
-7. **Close.** When all [tasks] are `[Completed]`: the architect runs the feature
+   `[Ready to deploy]` — the atomic pair. Every preset roster includes it.
+7. **Close.** When all [tasks] are `[Ready to deploy]`: the architect runs the feature
    completion checklist, the TPM confirms the acceptance criteria hold at
    feature level, and only then does the [feature] move to `[Resolved]`.
 

--- a/teams/deep-backend.md
+++ b/teams/deep-backend.md
@@ -17,7 +17,7 @@ ROSTER=principal-backend-architect senior-technical-product-manager senior-staff
 | Senior Technical Product Manager | `teams/roles/senior-technical-product-manager.md` | no status writes | Scope and acceptance criteria |
 | Senior Staff Engineer | `teams/roles/senior-staff-engineer.md` | `backend` | Implements domain logic, APIs, and migrations |
 | Senior QA Engineer — **final gate** | `teams/roles/senior-qa-engineer.md` | `qa` + `reviewer` | Verifies acceptance criteria; last approval |
-| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Completed]` |
+| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Ready to deploy]` |
 
 ## Collaboration flow
 
@@ -30,7 +30,7 @@ verified by QA before `[review-approval]` is granted — no exceptions.
 1. Architect — `[architecture-approval]`
 2. QA — `[review-approval]` (**final gate**)
 
-Then the `integrator` merges, commits, and marks the [task] `[Completed]`.
+Then the `integrator` merges, commits, and marks the [task] `[Ready to deploy]`.
 
 ## Launch
 

--- a/teams/deep-frontend.md
+++ b/teams/deep-frontend.md
@@ -18,7 +18,7 @@ ROSTER=principal-frontend-architect senior-technical-product-manager senior-fron
 | Senior Technical Product Manager | `teams/roles/senior-technical-product-manager.md` | no status writes | Scope and acceptance criteria |
 | Senior Frontend Engineer | `teams/roles/senior-frontend-engineer.md` | `frontend` | Implements components, state wiring, and accessibility |
 | Senior QA Engineer — **final gate** | `teams/roles/senior-qa-engineer.md` | `qa` + `reviewer` | Verifies acceptance criteria; last approval |
-| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Completed]` |
+| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Ready to deploy]` |
 
 ## Collaboration flow
 
@@ -33,7 +33,7 @@ citation and a test citation.
 1. Architect — `[architecture-approval]`
 2. QA — `[review-approval]` (**final gate**)
 
-Then the `integrator` merges, commits, and marks the [task] `[Completed]`.
+Then the `integrator` merges, commits, and marks the [task] `[Ready to deploy]`.
 
 ## Launch
 

--- a/teams/deep-infra.md
+++ b/teams/deep-infra.md
@@ -18,7 +18,7 @@ ROSTER=principal-cloud-infrastructure-architect senior-technical-product-manager
 | Senior Cloud Engineer | `teams/roles/senior-cloud-engineer.md` | `backend` | Implements IaC, pipelines, cloud services, and networking |
 | Senior SRE Engineer | `teams/roles/senior-sre-engineer.md` | `backend` (own [tasks]); `reviewer` (operability pass on cloud engineer's [tasks]) | Observability, SLOs, alerting, runbooks; operability review |
 | Senior QA Engineer — **final gate** | `teams/roles/senior-qa-engineer.md` | `qa` + `reviewer` | Verifies acceptance criteria; last approval |
-| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Completed]` |
+| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Ready to deploy]` |
 
 ## Collaboration flow
 
@@ -36,7 +36,7 @@ architect will grant `[design-approved]`. No exceptions.
 3. QA — `[review-approval]` (**final gate**; QA verifies the SRE operability pass
    exists on cloud-engineer [tasks] before approving)
 
-Then the `integrator` merges, commits, and marks the [task] `[Completed]`.
+Then the `integrator` merges, commits, and marks the [task] `[Ready to deploy]`.
 
 ## Launch
 

--- a/teams/deep-security.md
+++ b/teams/deep-security.md
@@ -18,7 +18,7 @@ ROSTER=principal-security-architect senior-technical-product-manager senior-secu
 | Senior Security Engineer | `teams/roles/senior-security-engineer.md` | `backend` | Implements security features, hardening, and vulnerability fixes |
 | Senior Penetration Tester | `teams/roles/senior-penetration-tester.md` | specialist reviewer (stage 5.2); `qa` for test-tooling [tasks] | Authorized adversarial verification of the team's own implemented changes |
 | Senior QA Engineer — **final gate** | `teams/roles/senior-qa-engineer.md` | `qa` + `reviewer` | Verifies acceptance criteria; confirms pentest pass exists; last approval |
-| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Completed]` |
+| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Ready to deploy]` |
 
 ## Collaboration flow
 
@@ -42,7 +42,7 @@ acceptance criteria so QA and the penetration tester can trace coverage.
 3. QA — `[review-approval]` (**final gate**; QA verifies the pentest pass comment
    exists before issuing its approval)
 
-Then the `integrator` merges, commits, and marks the [task] `[Completed]`.
+Then the `integrator` merges, commits, and marks the [task] `[Ready to deploy]`.
 
 ## Launch
 

--- a/teams/full-stack.md
+++ b/teams/full-stack.md
@@ -15,7 +15,7 @@ ROSTER=principal-software-architect senior-technical-product-manager senior-full
 | Senior Technical Product Manager | `teams/roles/senior-technical-product-manager.md` | no status writes | Scope and acceptance criteria |
 | Senior Full Stack Engineer | `teams/roles/senior-full-stack-engineer.md` | `backend` + `frontend` | Implements complete vertical slices |
 | Senior QA Engineer — **final gate** | `teams/roles/senior-qa-engineer.md` | `qa` + `reviewer` | Verifies acceptance criteria; last approval |
-| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Completed]` |
+| integrator (standard) | `roles/integrator.md` | `integrator` | Mechanical merge gate; commit + `[Ready to deploy]` |
 
 ## Collaboration flow
 
@@ -26,7 +26,7 @@ The standard playbook (`teams/_PLAYBOOK.md`); no team-specific stages.
 1. Architect — `[architecture-approval]`
 2. QA — `[review-approval]` (**final gate**)
 
-Then the `integrator` merges, commits, and marks the [task] `[Completed]`.
+Then the `integrator` merges, commits, and marks the [task] `[Ready to deploy]`.
 
 ## Launch
 

--- a/teams/roles/senior-cloud-engineer.md
+++ b/teams/roles/senior-cloud-engineer.md
@@ -55,6 +55,6 @@ status write (claim, design gate, `[review-request]`, rework via
 - Write IaC or pipeline configuration before `[design-approved]`, or outside your
   worktree.
 - Submit a `[review-request]` without a plan or preview output attached.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Omit rollback strategy or blast radius from a `[design-note]`.
 - Argue a QA or SRE finding away — fix it, or escalate through the architect.

--- a/teams/roles/senior-cloud-engineer.md
+++ b/teams/roles/senior-cloud-engineer.md
@@ -55,6 +55,6 @@ status write (claim, design gate, `[review-request]`, rework via
 - Write IaC or pipeline configuration before `[design-approved]`, or outside your
   worktree.
 - Submit a `[review-request]` without a plan or preview output attached.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Omit rollback strategy or blast radius from a `[design-note]`.
 - Argue a QA or SRE finding away — fix it, or escalate through the architect.

--- a/teams/roles/senior-frontend-engineer.md
+++ b/teams/roles/senior-frontend-engineer.md
@@ -51,6 +51,6 @@ back to `[Active]` and post a `[divergence]`.
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-frontend-engineer.md
+++ b/teams/roles/senior-frontend-engineer.md
@@ -51,6 +51,6 @@ back to `[Active]` and post a `[divergence]`.
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-full-stack-engineer.md
+++ b/teams/roles/senior-full-stack-engineer.md
@@ -46,6 +46,6 @@ demands; those briefs and `reference/orchestration.md` bind every status write
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-full-stack-engineer.md
+++ b/teams/roles/senior-full-stack-engineer.md
@@ -46,6 +46,6 @@ demands; those briefs and `reference/orchestration.md` bind every status write
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-security-engineer.md
+++ b/teams/roles/senior-security-engineer.md
@@ -53,7 +53,7 @@ design gate, `[review-request]`, rework via `[Review]→[Active]`).
 - Write code before `[design-approved]`, or outside your worktree.
 - Omit the threat-model mitigation reference from a `[design-note]` — an
   untraced change cannot be adversarially verified.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Argue a penetration tester or QA finding away — fix it, or escalate through
   the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-security-engineer.md
+++ b/teams/roles/senior-security-engineer.md
@@ -53,7 +53,7 @@ design gate, `[review-request]`, rework via `[Review]→[Active]`).
 - Write code before `[design-approved]`, or outside your worktree.
 - Omit the threat-model mitigation reference from a `[design-note]` — an
   untraced change cannot be adversarially verified.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a penetration tester or QA finding away — fix it, or escalate through
   the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-sre-engineer.md
+++ b/teams/roles/senior-sre-engineer.md
@@ -61,5 +61,5 @@ on problems; never invent new markers.
 - Perform the operability review on a [task] you implemented.
 - Invent new structured markers — use only `[review-findings]` for problems; a
   plain comment for a clean pass.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.

--- a/teams/roles/senior-sre-engineer.md
+++ b/teams/roles/senior-sre-engineer.md
@@ -61,5 +61,5 @@ on problems; never invent new markers.
 - Perform the operability review on a [task] you implemented.
 - Invent new structured markers — use only `[review-findings]` for problems; a
   plain comment for a clean pass.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Argue a QA finding away — fix it, or escalate through the architect.

--- a/teams/roles/senior-staff-engineer.md
+++ b/teams/roles/senior-staff-engineer.md
@@ -52,7 +52,7 @@ available for another team member to consume.
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Completed]`.
+- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.
 - Ship a migration [task] without a verified rollback [subtask].

--- a/teams/roles/senior-staff-engineer.md
+++ b/teams/roles/senior-staff-engineer.md
@@ -52,7 +52,7 @@ available for another team member to consume.
 ## You never
 
 - Write code before `[design-approved]`, or outside your worktree.
-- Merge, commit to the feature branch, or mark anything `[Ready to deploy]`.
+- Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.
 - Ship a migration [task] without a verified rollback [subtask].

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -129,6 +129,7 @@ bad "bad owner refused"               "unknown role" "{$MINF,\"tasks\":{\"status
 bad "two-key owner refused"           "exactly one of" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\",\"team\":\"full-stack\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
 bad "requiresCommit on initial refused" "not allowed on the initial" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"requiresCommit\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
 bad "no terminal refused"             "at least one terminal" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
+bad "zero initials refused"           "exactly one initial"   "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
 
 # -- status + stop --------------------------------------------------------------
 # Capture first (grep -q closes the pipe early → SIGPIPE on the writer under pipefail).

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -19,6 +19,7 @@ git checkout -q -b test-feature
 mkdir -p .claude/skills/pm
 cp -R "$SKILL_DIR/roles" "$SKILL_DIR/reference" "$SKILL_DIR/bin" "$SKILL_DIR/teams" .claude/skills/pm/
 mkdir -p .claude/skills/pm/config
+cp "$SKILL_DIR/config/statuses.config.json" .claude/skills/pm/config/
 cat > .claude/skills/pm/config/team.config.md <<'EOF'
 ```
 TEAM_LEAD_CMD=null
@@ -99,6 +100,35 @@ if TEAM_RUNNER=background "$LAUNCH" team nonesuch test-feature FEAT-2 2>/dev/nul
 else
   echo "ok: unknown preset refused"
 fi
+
+# -- validate-board: shipped config passes --------------------------------------
+check "validate-board accepts shipped config" "$LAUNCH" validate-board
+
+# -- validate-board: prompt composition includes the board ----------------------
+check "prompt contains board config" grep -q '"Ready to deploy"' .teamwork/test-feature/prompts/backend.md
+
+# -- validate-board: each broken config is refused with the right message -------
+bad() { # bad <desc> <needle> <json>
+  local desc="$1" needle="$2" json="$3" out
+  printf '%s' "$json" > "$TMP/bad.json"
+  if out="$("$LAUNCH" validate-board "$TMP/bad.json" 2>&1)"; then
+    echo "FAIL: $desc (accepted)"; FAILURES=$((FAILURES+1))
+  elif printf '%s' "$out" | grep -q "$needle"; then
+    echo "ok: $desc"
+  else
+    echo "FAIL: $desc (wrong message: $out)"; FAILURES=$((FAILURES+1))
+  fi
+}
+MINF='"features":{"statuses":[{"name":"P","initial":true,"owner":{"role":"team-lead"},"transitions":["R"]},{"name":"R","terminal":true,"owner":{"role":"team-lead"},"transitions":[]}]}'
+bad "invalid JSON refused"            "invalid JSON" '{nope'
+bad "two initials refused"            "exactly one initial" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"initial\":true,\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "unknown transition refused"      "undefined status" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Nope\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "unreachable status refused"      "unreachable" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]},{\"name\":\"Island\",\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]}]}}"
+bad "terminal with outbound refused"  "terminal status must have empty transitions" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
+bad "bad owner refused"               "unknown role" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"nobody-such\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "two-key owner refused"           "exactly one of" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\",\"team\":\"full-stack\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "requiresCommit on initial refused" "not allowed on the initial" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"requiresCommit\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
+bad "no terminal refused"             "at least one terminal" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
 
 # -- status + stop --------------------------------------------------------------
 # Capture first (grep -q closes the pipe early → SIGPIPE on the writer under pipefail).


### PR DESCRIPTION
## Summary

Makes the kanban status machine configurable instead of hard-coded:

- **`config/statuses.config.json`** — single source of truth for both state machines (features, tasks): ordered statuses, legal `transitions`, per-status `owner` (a single agent role or a team preset), per-adapter `tool` mappings, and `initial`/`terminal`/`requiresCommit` flags.
- **New statuses:** `[Blocked]` (parking status for stuck work, owned by team-lead — distinct from the andon cord, which stays reserved for process failures) and `[Ready to deploy]` (terminal, commit-coupled, integrator-owned). The generic `[Completed]` status is removed everywhere.
- **Ownership + routing:** the owner of a status is the only role that works items sitting in it and performs its outbound transitions; on every status entry the mover notifies the new owner's mailbox. The hard-coded transition-ownership table is now derived from the config.
- **`bin/launch-team.sh validate-board`** — python3-backed structural validation (one initial, terminal rules, transition targets, reachability, owner resolution), run automatically before every team launch; the board JSON is composed into every agent's startup prompt.
- **Docs cascade:** vocabulary, lifecycle (new "Block a [task]" scenario + renumbering), team-roles, orchestration (new "Status routing" section), all role briefs, all five adapters (status mapping now defers to the config), teams presets, README ("Configure your board"), SKILL.md.

Spec: `docs/superpowers/specs/2026-07-06-kanban-status-config-design.md`
Plan: `docs/superpowers/plans/2026-07-06-kanban-status-config.md`

## Test plan

- [x] `bash tests/launcher-test.sh` — 31 checks, ALL PASS (includes 10 negative board-config cases + prompt-composition check)
- [x] `bin/launch-team.sh validate-board` — shipped config OK
- [x] Sweep: no `[Completed]` / "Ready for production" leftovers in skill content
- [x] Multi-agent final review (0 Critical; 1 Important found and fixed: SKILL.md scenario routing table renumbering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)