### PR TITLE
Production-run improvements: harness mode, delivery contract, tracker-ops CLI, pre-flight design pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ Command templates for common CLIs:
 **Mixing LLMs is the design intent** — e.g. Claude to lead and architect, Codex to
 implement, Gemini to review for diversity. Same-LLM teams work too.
 
+### Harness mode — teammates as subagents, no CLI processes
+
+If your harness can spawn subagents and message them (e.g. Claude Code's Agent
+tool), skip the command map entirely: compose each role's startup prompt with
+`bin/launch-team.sh compose <team> <featureId> <role> [preset]` and spawn the
+role natively with it. Harness messages replace mailboxes, harness idle
+notifications replace heartbeats, and the tracker stays the source of truth —
+see `reference/orchestration.md` → *Harness mode*.
+
 **Command resolution per role:** explicit `<ROLE>_CMD` value → used; `<ROLE>_CMD=null`
 → role disabled; **absent** → falls back to `TEAM_DEFAULT_CMD`. That fallback is
 why the many specialized preset-team roles need no per-role keys — set
@@ -215,8 +224,8 @@ needs nothing).
 | Section | Keys | Purpose |
 |---|---|---|
 | Role → command | `TEAM_LEAD_CMD`, `PRINCIPAL_ARCHITECT_CMD`, `INTEGRATOR_CMD`, `BACKEND_CMD`, `FRONTEND_CMD`, `QA_CMD`, `REVIEWER_CMD`, `TEAM_DEFAULT_CMD` | Which CLI runs each role ([see above](#multi-agent-teams--map-each-role-to-a-cli-command)) |
-| Coordination | `TEAMWORK_ROOT` (`.teamwork`), `POLL_INTERVAL_SECONDS` (120), `STUCK_AFTER_MINUTES` (15), `ESCALATE_AFTER_ATTEMPTS` (2) | Timing of the lead's supervision loop |
-| Validation | `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT` | Your stack's commands; the integrator runs them before every merge (`null` = skip) |
+| Coordination | `TEAMWORK_ROOT` (`.teamwork`), `POLL_INTERVAL_SECONDS` (120), `STUCK_AFTER_MINUTES` (15), `ESCALATE_AFTER_ATTEMPTS` (2), `TRACKER_WRITERS` (`all`) | Timing of the lead's supervision loop; `TRACKER_WRITERS=lead` enables single-writer ("scribe") mode — only the lead holds tracker credentials and posts on the team's behalf |
+| Validation | `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT`, `VALIDATE_SCRIPT` | Your stack's commands; the integrator runs them before every merge (`null` = skip). `VALIDATE_SCRIPT` replaces the three with one repo-owned script that receives the changed-file list |
 
 Point the `VALIDATE_*` commands at your real build/test/lint (e.g.
 `VALIDATE_TEST="pytest"`) — this is the only place the framework-agnostic
@@ -269,9 +278,16 @@ Just talk to your agent in the generic vocabulary:
 | `team <preset> <team> <featureId>` | Launch a whole preset roster |
 | `start <team> <featureId> <role>…` | Launch specific roles (custom teams) |
 | `relaunch <team> <featureId> <role> [preset]` | Restart one crashed/wedged agent |
+| `compose <team> <featureId> <role> [preset]` | Write a role's startup prompt **without spawning** — for running teammates as subagents inside your own harness (see `reference/orchestration.md` → *Harness mode*) |
 | `worktree <team> <role> <taskId>` | Create an implementer's isolated worktree |
 | `status <team>` | Show each agent's state + last heartbeat |
 | `stop <team>` | Stop the whole team |
+
+There is also `bin/tracker-ops.sh` — an ergonomic wrapper for the recurring
+tracker operations (`claim`, `state`, `comment` with the body from a file/stdin,
+`integrate <hash>`, `export`) over the scriptable access mechanisms (Linear/Jira
+REST, `gh`, Markdown files). The adapter docs remain the spec; MCP sessions use
+their native tools instead.
 
 **The flow every team follows:** the Principal Architect leads (plans with the
 Product Manager, gates each `[task]`'s design before any code, reviews
@@ -364,8 +380,11 @@ fast when agents share a machine and degrade to tracker polling when they don't.
 │   ├── README.md · _PLAYBOOK.md      how presets work + shared collaboration flow
 │   ├── full-stack.md · deep-backend.md · deep-frontend.md · deep-security.md · deep-infra.md
 │   └── roles/                        14 specialized role briefs
-├── bin/launch-team.sh                the team launcher
-└── tests/launcher-test.sh            offline smoke test (no LLM calls)
+├── bin/
+│   ├── launch-team.sh                the team launcher (spawn, compose, worktrees, board validation)
+│   └── tracker-ops.sh                ergonomic tracker CLI (claim/state/comment/integrate/export)
+└── tests/                            offline smoke tests (no LLM calls)
+    └── launcher-test.sh · tracker-ops-test.sh
 ```
 
 ---
@@ -397,7 +416,7 @@ exact protocol markers — never invent new ones.
 | A role won't launch in a preset | It's likely `<ROLE>_CMD=null` (explicitly disabled). Remove the line to fall back to `TEAM_DEFAULT_CMD` |
 | No `tmux` | Agents run as background processes automatically; use `status`/`stop` and read logs under `.teamwork/<team>/pids/` |
 | Team seems stuck | `bin/launch-team.sh status <team>` shows heartbeats; the lead auto-unblocks, and anything needing you is in `.teamwork/<team>/ESCALATIONS.md` |
-| Want to verify the plumbing | `bash tests/launcher-test.sh` → `ALL PASS` (uses a stub agent; no LLM, no cost) |
+| Want to verify the plumbing | `bash tests/launcher-test.sh && bash tests/tracker-ops-test.sh` → `ALL PASS` twice (stub agent + local files; no LLM, no cost) |
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,6 +17,7 @@ skill's directory):
 - `reference/team-roles.md` — status ownership (only if `TEAM_MODE=true`)
 - `reference/orchestration.md` — multi-agent protocol (mailboxes, gates, unblocking)
 - `roles/<role>.md` + `config/team.config.md` + `bin/launch-team.sh` — the agent team
+- `bin/tracker-ops.sh` — ergonomic CLI for recurring tracker operations (scriptable mechanisms)
 - `adapters/<Tool>.md` — how to perform each operation in the active tool
 
 > **Golden rule:** in everything you write — comments, commit messages, messages to the
@@ -52,8 +53,9 @@ each generic operation through the adapter's *Operations* table:
 | File a bug / follow-up found mid-work | 6 — File newly-discovered work |
 | Work is stuck / blocked / cannot proceed | 7 — Block a `[task]` |
 | (anything wrong / blocked / failed) | 8 — Andon cord: stop & report |
-| Run an agent team on a feature ("launch the team") | Team: set `TEAM_MODE=true`, follow `reference/orchestration.md`; launch via `bin/launch-team.sh` |
+| Run an agent team on a feature ("launch the team") | Team: set `TEAM_MODE=true`, follow `reference/orchestration.md`; launch via `bin/launch-team.sh` (CLI processes) or spawn harness subagents from `bin/launch-team.sh compose` prompts |
 | Connect a new tool / switch tools | 9 — Connect / switch |
+| Design/plan everything up front, sign off all designs before coding | 10 — Pre-flight design pass |
 
 ## Non-negotiables (the fail-loud contract)
 

--- a/adapters/GitHubIssues.md
+++ b/adapters/GitHubIssues.md
@@ -100,7 +100,13 @@ CLI column assumes `-R <GITHUB_REPO>` is appended when `GITHUB_REPO` is set.
 | Set `[task]` → `[Ready to deploy]` | `gh issue close <taskId>` |
 | Reopen (rework) | `gh issue reopen <taskId> --add-label status:active` |
 | Set `[feature]` → `[Resolved]` | `gh api -X PATCH repos/:owner/:repo/milestones/<n> -f state=closed` |
-| Add a comment to a `[task]` | `gh issue comment <taskId> --body "<...>"` |
+| Add a comment to a `[task]` | `gh issue comment <taskId> --body-file <file>` (or `--body-file -` for stdin — prefer files over `--body` to avoid shell-quoting) |
+| Export the `[tasks]` of a `[feature]` to a file | `bin/tracker-ops.sh export <featureId> <outfile>` (wraps `gh issue list --milestone ... --json ...`) |
+
+> **Helper script.** `bin/tracker-ops.sh` wraps the recurring operations over the `gh`
+> CLI — `claim`, `state` (does the label juggling and open/close for you), `comment`
+> (body from a file or stdin), `integrate <hash>`, `export`. This table remains the spec;
+> the script is the ergonomic path.
 
 ## Rules
 

--- a/adapters/Jira.md
+++ b/adapters/Jira.md
@@ -114,6 +114,12 @@ The `jira()` and `adf()` helpers above must be defined in your shell before runn
 | Set `[task]`/`[feature]` status | transition the item | `jira "/rest/api/3/issue/<taskId>/transitions" -X POST -d '{"transition":{"id":"<transitionId>"}}'` |
 | Set `[task]` assignee | update assignee | `jira "/rest/api/3/issue/<taskId>/assignee" -X PUT -d '{"accountId":"<accountId>"}'` |
 | Add a comment to a `[task]` | add comment | `jira "/rest/api/3/issue/<taskId>/comment" -X POST -d '{"body":'"$(adf "<text>")"'}'` |
+| Export the `[tasks]` of a `[feature]` to a file | read via search, write the JSON yourself | `bin/tracker-ops.sh export <featureId> <outfile>` |
+
+> **Helper script.** For the `rest` mechanism, `bin/tracker-ops.sh` wraps the recurring
+> operations — `claim`, `state` (resolves the transition id for you), `comment` (body from
+> a file or stdin — no ADF hand-assembly), `integrate <hash>`, `export`. This table remains
+> the spec; the script is the ergonomic path. MCP sessions call the MCP tools directly.
 
 > `parent` and `jql=parent=` work in team-managed (NextGen) projects. In company-managed (classic) projects, link Stories to the Epic via the Epic Link field (commonly `customfield_10014`) and query with `jql="Epic Link" = <featureId>`.
 

--- a/adapters/Linear.md
+++ b/adapters/Linear.md
@@ -98,6 +98,14 @@ Completed (Linear project states).
 | Set `[task]` assignee | `update_issue` with `assignee` | `lin '{"query":"mutation { issueUpdate(id: \"<taskId>\", input: {assigneeId: \"<userId>\"}) { success } }"}'` |
 | Set `[feature]` status | `update_project` | `lin '{"query":"mutation { projectUpdate(id: \"<featureId>\", input: {statusId: \"<statusId>\"}) { success } }"}'` |
 | Add a comment to a `[task]` | `create_comment` | `lin '{"query":"mutation { commentCreate(input: {issueId: \"<taskId>\", body: \"<md>\"}) { success } }"}'` |
+| Export the `[tasks]` of a `[feature]` to a file | read via `list_issues` + `get_issue`, write the JSON yourself | `bin/tracker-ops.sh export <featureId> <outfile>` |
+
+> **Helper script.** For the `rest` mechanism, `bin/tracker-ops.sh` wraps the recurring
+> operations — `claim`, `state`, `comment` (body from a file or stdin, so no shell-quoting
+> of GraphQL payloads), `integrate <hash>`, `export`. This table remains the spec; the
+> script is the ergonomic path. MCP sessions call the MCP tools directly instead.
+> The `export` output gives credential-less roles a stable read-only snapshot
+> (`<TEAMWORK_ROOT>/<team>/tasks.json` by convention — see `reference/orchestration.md`).
 
 ## Rules
 

--- a/adapters/Markdown.md
+++ b/adapters/Markdown.md
@@ -90,6 +90,13 @@ Call the billing charge endpoint on submit.
 | Set `[task]` assignee | Edit the `**Assignee:**` line in that section; use the role name verbatim (e.g. `backend`) |
 | Set `[feature]` status | Edit the `#` title line's trailing `[Status]` |
 | Add a comment to a `[task]` | Append a `> <marker> (yyyy-MM-dd): <content>` line under the task section, where `<marker>` is the exact orchestration marker (e.g. `[design-note]`, `[review-approval]`) or `note` for free-form comments |
+| Export the `[tasks]` of a `[feature]` to a file | `bin/tracker-ops.sh export <featureId> <outfile>` |
+
+> **Helper script.** `bin/tracker-ops.sh` performs these edits mechanically — `claim`,
+> `state`, `comment` (body from a file or stdin), `integrate <hash>`, `export`. When
+> using it, address a [task] as `<featureId>#<taskId>` (the feature file plus the task
+> number, e.g. `.workspace/task-manager/2026-07-06-payments/feature.md#2`), since a task
+> number alone doesn't name the file.
 
 ## Rules
 

--- a/adapters/_TEMPLATE.md
+++ b/adapters/_TEMPLATE.md
@@ -75,6 +75,11 @@ MCP tool / CLI command / file edit.
 | Set `[task]` status | <...> |
 | Set `[feature]` status | <...> |
 | Add a comment to a `[task]` | <...> |
+| Export the `[tasks]` of a `[feature]` to a file | <how to dump id/title/status/assignee/description/comments as JSON — gives credential-less roles a read-only snapshot> |
+
+> If the tool has a scriptable (non-MCP) mechanism, consider adding a backend for it to
+> `bin/tracker-ops.sh` so `claim` / `state` / `comment` / `integrate` / `export` work
+> without hand-built API calls. The Operations table above remains the spec either way.
 
 ## Rules
 

--- a/bin/launch-team.sh
+++ b/bin/launch-team.sh
@@ -6,6 +6,7 @@
 #   launch-team.sh team          <preset> <team> <featureId>     # launch a preset roster (teams/<preset>.md)
 #   launch-team.sh start         <team> <featureId> <role>...
 #   launch-team.sh relaunch      <team> <featureId> <role> [preset]
+#   launch-team.sh compose       <team> <featureId> <role> [preset]  # write the composed startup prompt, print its path — no spawn (harness mode)
 #   launch-team.sh worktree      <team> <role> <taskId>
 #   launch-team.sh validate-board [config-path]                  # validate board config JSON
 #   launch-team.sh status        <team>
@@ -236,6 +237,13 @@ case "${1:-}" in
     [ $# -eq 4 ] || [ $# -eq 5 ] || die "usage: relaunch <team> <featureId> <role> [preset]"
     launch_one "$2" "$3" "$4" "${5:-}"
     ;;
+  compose)
+    # Harness mode: emit the exact same startup prompt `start` would use, without
+    # spawning anything, so any harness can spawn the role natively with it.
+    [ $# -eq 4 ] || [ $# -eq 5 ] || die "usage: compose <team> <featureId> <role> [preset]"
+    prompt="$(compose_prompt "$2" "$3" "$4" "${5:-}")"
+    echo "$prompt"
+    ;;
   worktree)
     [ $# -eq 4 ] || die "usage: worktree <team> <role> <taskId>"
     team="$2"; role="$3"; task="$4"
@@ -285,6 +293,6 @@ case "${1:-}" in
     validate_board "${2:-}"
     ;;
   *)
-    die "usage: launch-team.sh {team|start|relaunch|worktree|validate-board|status|stop} ..."
+    die "usage: launch-team.sh {team|start|relaunch|compose|worktree|validate-board|status|stop} ..."
     ;;
 esac

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+# tracker-ops.sh — ergonomic CLI for the tracker operations every team run performs
+# constantly. Wraps the *scriptable* access mechanisms of the shipped adapters
+# (Linear rest, Jira rest, GitHubIssues gh CLI, Markdown files); the adapter doc's
+# Operations table remains the spec. Sessions using an MCP mechanism don't need
+# this script — the agent has native tools there.
+#
+# Comment bodies are always read from a file or stdin, never from a shell
+# argument — that kills the quoting/escaping failure mode of hand-built API calls.
+#
+# Usage:
+#   tracker-ops.sh state     <taskId> <Status>               # set [task] status (generic name)
+#   tracker-ops.sh comment   <taskId> [bodyfile]             # add comment; body from file or stdin
+#   tracker-ops.sh claim     <taskId> <role> [--to <Status>] # claim: initial→working status + claim comment
+#   tracker-ops.sh integrate <taskId> <hash> [bodyfile]      # terminal move + completion comment citing <hash>
+#   tracker-ops.sh export    <featureId> <outfile>           # read-side: dump the [feature]'s [tasks] as JSON
+#
+# Adapter comes from PRODUCT_MANAGEMENT_TOOL in config/project-management.config.md
+# (override with TRACKER_ADAPTER=<Name>). Credentials come from the environment,
+# exactly as the adapter's Access mechanisms section names them. Any failure is an
+# andon stop: non-zero exit, no fallback, no fabricated success.
+set -euo pipefail
+
+# The script rides on fd 3 so stdin stays free for comment bodies.
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 /dev/fd/3 "$SKILL_DIR" "$@" 3<<'PYEOF'
+import json, os, re, subprocess, sys, urllib.request, urllib.error
+from datetime import date, datetime, timezone
+
+def die(msg):
+    print("tracker-ops: %s" % msg, file=sys.stderr)
+    sys.exit(1)
+
+SKILL_DIR = sys.argv[1]
+ARGS = sys.argv[2:]
+
+# ---- config -----------------------------------------------------------------
+def read_config_keys(path):
+    keys = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                m = re.match(r'^([A-Z_]+)=(.*)$', line.strip())
+                if m:
+                    v = m.group(2).split('#', 1)[0].strip().strip('"')
+                    keys[m.group(1)] = None if v == 'null' else v
+    except OSError as e:
+        die("cannot read %s: %s" % (path, e))
+    return keys
+
+PM_CONFIG = read_config_keys(os.path.join(SKILL_DIR, 'config', 'project-management.config.md'))
+ADAPTER = os.environ.get('TRACKER_ADAPTER') or PM_CONFIG.get('PRODUCT_MANAGEMENT_TOOL')
+if not ADAPTER:
+    die("no adapter: set PRODUCT_MANAGEMENT_TOOL in config/project-management.config.md")
+
+board_path = os.path.join(SKILL_DIR, PM_CONFIG.get('STATUS_CONFIG') or 'config/statuses.config.json')
+try:
+    with open(board_path) as f:
+        BOARD = json.load(f)
+except (OSError, ValueError) as e:
+    die("cannot load board config %s: %s" % (board_path, e))
+
+TASK_STATUSES = BOARD['tasks']['statuses']
+
+def status_by_name(name):
+    for s in TASK_STATUSES:
+        if s['name'] == name:
+            return s
+    die("unknown [task] status '%s' (board: %s)" % (name, ', '.join(x['name'] for x in TASK_STATUSES)))
+
+def tool_value(status):
+    v = status.get('tool', {}).get(ADAPTER)
+    if v is None:
+        die("status '%s' has no '%s' mapping in the board config — andon" % (status['name'], ADAPTER))
+    return v
+
+def initial_status():
+    return next(s for s in TASK_STATUSES if s.get('initial'))
+
+def terminal_status():
+    terms = [s for s in TASK_STATUSES if s.get('terminal')]
+    commits = [s for s in terms if s.get('requiresCommit')]
+    if len(commits) == 1:
+        return commits[0]
+    if len(terms) == 1:
+        return terms[0]
+    die("ambiguous terminal status (%d candidates) — pass an explicit state instead" % len(terms))
+
+def generic_of(raw):  # reverse-map a tool-side status value to the generic name
+    for s in TASK_STATUSES:
+        if s.get('tool', {}).get(ADAPTER) == raw:
+            return s['name']
+    return None
+
+def read_body(path):
+    if path in (None, '-'):
+        body = sys.stdin.read()
+    else:
+        try:
+            with open(path) as f:
+                body = f.read()
+        except OSError as e:
+            die("cannot read body file: %s" % e)
+    body = body.rstrip('\n')
+    if not body:
+        die("empty comment body")
+    return body
+
+def env(name):
+    v = os.environ.get(name)
+    if not v:
+        die("missing env var %s (see the %s adapter's access section)" % (name, ADAPTER))
+    return v
+
+# ---- adapter backends --------------------------------------------------------
+def http_json(url, payload=None, headers=None, method=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method or ('POST' if data else 'GET'))
+    req.add_header('Content-Type', 'application/json')
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        die("HTTP %s from %s: %s" % (e.code, url, e.read().decode()[:500]))
+    except urllib.error.URLError as e:
+        die("request to %s failed: %s" % (url, e.reason))
+
+class Linear:
+    def __init__(self):
+        self.key = env('LINEAR_API_KEY')
+
+    def gql(self, query, variables=None):
+        out = http_json('https://api.linear.app/graphql',
+                        {'query': query, 'variables': variables or {}},
+                        {'Authorization': self.key})
+        if out.get('errors'):
+            die("Linear API error: %s" % out['errors'][0].get('message'))
+        return out['data']
+
+    def issue(self, task_id):
+        d = self.gql('query($id: String!) { issue(id: $id) { id identifier team { id states { nodes { id name } } } } }',
+                     {'id': task_id})
+        if not d.get('issue'):
+            die("no Linear issue '%s'" % task_id)
+        return d['issue']
+
+    def set_state(self, task_id, status):
+        want = tool_value(status)
+        issue = self.issue(task_id)
+        states = issue['team']['states']['nodes']
+        sid = next((s['id'] for s in states if s['name'] == want), None)
+        if not sid:
+            die("Linear team has no workflow state '%s' — andon (create it or fix the board mapping)" % want)
+        self.gql('mutation($id: String!, $sid: String!) { issueUpdate(id: $id, input: {stateId: $sid}) { success } }',
+                 {'id': issue['id'], 'sid': sid})
+
+    def comment(self, task_id, body):
+        issue = self.issue(task_id)
+        self.gql('mutation($id: String!, $body: String!) { commentCreate(input: {issueId: $id, body: $body}) { success } }',
+                 {'id': issue['id'], 'body': body})
+
+    def export(self, feature_id):
+        d = self.gql('query($id: String!) { project(id: $id) { name issues { nodes { identifier title description state { name } assignee { name } comments { nodes { body createdAt } } } } } }',
+                     {'id': feature_id})
+        if not d.get('project'):
+            die("no Linear project '%s'" % feature_id)
+        tasks = []
+        for i in d['project']['issues']['nodes']:
+            raw = i['state']['name']
+            tasks.append({'taskId': i['identifier'], 'title': i['title'],
+                          'status': generic_of(raw), 'statusRaw': raw,
+                          'assignee': (i.get('assignee') or {}).get('name'),
+                          'description': i.get('description'),
+                          'comments': [{'body': c['body'], 'createdAt': c['createdAt']}
+                                       for c in i['comments']['nodes']]})
+        return tasks
+
+class Jira:
+    def __init__(self):
+        self.base = env('JIRA_BASE_URL').rstrip('/')
+        import base64
+        tok = base64.b64encode(('%s:%s' % (env('JIRA_EMAIL'), env('JIRA_API_TOKEN'))).encode()).decode()
+        self.headers = {'Authorization': 'Basic ' + tok}
+
+    def api(self, path, payload=None, method=None):
+        return http_json(self.base + path, payload, self.headers, method)
+
+    def set_state(self, task_id, status):
+        want = tool_value(status)
+        trans = self.api('/rest/api/3/issue/%s/transitions' % task_id).get('transitions', [])
+        tid = next((t['id'] for t in trans if t.get('to', {}).get('name') == want), None)
+        if not tid:
+            avail = ', '.join(t.get('to', {}).get('name', '?') for t in trans)
+            die("no Jira transition to '%s' from the current status (available: %s) — andon" % (want, avail))
+        self.api('/rest/api/3/issue/%s/transitions' % task_id, {'transition': {'id': tid}})
+
+    @staticmethod
+    def adf(text):
+        return {'type': 'doc', 'version': 1, 'content': [
+            {'type': 'paragraph', 'content': [{'type': 'text', 'text': para}]}
+            for para in text.split('\n\n')]}
+
+    def comment(self, task_id, body):
+        self.api('/rest/api/3/issue/%s/comment' % task_id, {'body': self.adf(body)})
+
+    def export(self, feature_id):
+        out = self.api('/rest/api/3/search?jql=%s&fields=summary,description,status,assignee,comment&maxResults=100'
+                       % urllib.request.quote('parent=%s' % feature_id))
+        tasks = []
+        for i in out.get('issues', []):
+            f = i['fields']
+            raw = f['status']['name']
+            tasks.append({'taskId': i['key'], 'title': f['summary'],
+                          'status': generic_of(raw), 'statusRaw': raw,
+                          'assignee': (f.get('assignee') or {}).get('displayName'),
+                          'description': f.get('description'),
+                          'comments': [{'body': c.get('body'), 'createdAt': c.get('created')}
+                                       for c in (f.get('comment') or {}).get('comments', [])]})
+        return tasks
+
+class GitHubIssues:
+    def __init__(self):
+        self.repo_args = []
+        if PM_CONFIG.get('GITHUB_REPO'):
+            self.repo_args = ['-R', PM_CONFIG['GITHUB_REPO']]
+
+    def gh(self, *args, stdin=None):
+        cmd = ['gh'] + list(args) + self.repo_args
+        try:
+            r = subprocess.run(cmd, input=stdin, capture_output=True, text=True)
+        except FileNotFoundError:
+            die("gh CLI not found (see the GitHubIssues adapter's setup)")
+        if r.returncode != 0:
+            die("gh failed: %s\n%s" % (' '.join(cmd), r.stderr.strip()))
+        return r.stdout
+
+    @staticmethod
+    def parse_tool_value(value):  # "open + label status:active" / "closed" -> (closed?, label)
+        closed = 'closed' in value and 'open' not in value
+        m = re.search(r'(status:[\w-]+)', value)
+        return closed, (m.group(1) if m else None)
+
+    def current_status_label(self, task_id):
+        labels = json.loads(self.gh('issue', 'view', str(task_id), '--json', 'labels'))['labels']
+        return next((l['name'] for l in labels if l['name'].startswith('status:')), None)
+
+    def set_state(self, task_id, status):
+        closed, label = self.parse_tool_value(tool_value(status))
+        if closed:
+            self.gh('issue', 'close', str(task_id))
+            return
+        if not label:
+            die("cannot derive a status:* label from mapping '%s' — andon" % tool_value(status))
+        state = json.loads(self.gh('issue', 'view', str(task_id), '--json', 'state'))['state']
+        if state == 'CLOSED':
+            self.gh('issue', 'reopen', str(task_id))
+        old = self.current_status_label(task_id)
+        args = ['issue', 'edit', str(task_id), '--add-label', label]
+        if old and old != label:
+            args += ['--remove-label', old]
+        self.gh(*args)
+
+    def comment(self, task_id, body):
+        self.gh('issue', 'comment', str(task_id), '--body-file', '-', stdin=body)
+
+    def export(self, feature_id):
+        raw = self.gh('issue', 'list', '--milestone', str(feature_id), '--state', 'all',
+                      '--json', 'number,title,body,state,labels,assignees')
+        tasks = []
+        for i in json.loads(raw):
+            label = next((l['name'] for l in i['labels'] if l['name'].startswith('status:')), None)
+            raw_status = 'closed' if i['state'] == 'CLOSED' else 'open + label %s' % (label or '?')
+            generic = None
+            for s in TASK_STATUSES:
+                closed, lab = self.parse_tool_value(tool_value(s))
+                if (closed and i['state'] == 'CLOSED') or (not closed and lab and lab == label):
+                    generic = s['name']; break
+            comments = json.loads(self.gh('issue', 'view', str(i['number']), '--json', 'comments'))['comments']
+            tasks.append({'taskId': i['number'], 'title': i['title'],
+                          'status': generic, 'statusRaw': raw_status,
+                          'assignee': (i['assignees'][0]['login'] if i['assignees'] else None),
+                          'description': i.get('body'),
+                          'comments': [{'body': c['body'], 'createdAt': c.get('createdAt')} for c in comments]})
+        return tasks
+
+class Markdown:
+    def __init__(self):
+        self.root = PM_CONFIG.get('MARKDOWN_ROOT') or '.workspace/task-manager'
+
+    def load(self, feature_id):
+        try:
+            with open(feature_id) as f:
+                return f.read()
+        except OSError as e:
+            die("cannot read feature file '%s': %s — andon" % (feature_id, e))
+
+    def save(self, feature_id, text):
+        with open(feature_id, 'w') as f:
+            f.write(text)
+
+    @staticmethod
+    def split_task_id(task_id):  # "<feature.md path>#<n>" -> (path, n)
+        if '#' not in str(task_id):
+            die("Markdown taskId must be '<feature-file>#<task-number>' (e.g. .workspace/task-manager/2026-07-06-x/feature.md#2)")
+        path, _, num = str(task_id).rpartition('#')
+        if not num.isdigit():
+            die("bad Markdown task number '%s'" % num)
+        return path, num
+
+    def section_pattern(self, num):
+        return re.compile(r'^(## %s .*?)\[([^\]]+)\][ \t]*$' % re.escape(num), re.M)
+
+    def set_state(self, task_id, status):
+        path, num = self.split_task_id(task_id)
+        text = self.load(path)
+        pat = self.section_pattern(num)
+        if not pat.search(text):
+            die("no task %s in %s — andon" % (num, path))
+        self.save(path, pat.sub(lambda m: '%s[%s]' % (m.group(1), tool_value(status).strip('[]')), text, count=1))
+
+    def set_assignee(self, task_id, assignee):
+        path, num = self.split_task_id(task_id)
+        text = self.load(path)
+        m = self.section_pattern(num).search(text)
+        if not m:
+            die("no task %s in %s — andon" % (num, path))
+        rest = text[m.end():]
+        nxt = re.search(r'^## ', rest, re.M)
+        section = rest[:nxt.start()] if nxt else rest
+        new_section, n = re.subn(r'^\*\*Assignee:\*\* .*$', '**Assignee:** %s' % assignee, section, count=1, flags=re.M)
+        if not n:
+            die("task %s in %s has no '**Assignee:**' line — andon" % (num, path))
+        self.save(path, text[:m.end()] + new_section + (rest[nxt.start():] if nxt else ''))
+
+    def comment(self, task_id, body):
+        path, num = self.split_task_id(task_id)
+        text = self.load(path)
+        m = self.section_pattern(num).search(text)
+        if not m:
+            die("no task %s in %s — andon" % (num, path))
+        marker_m = re.match(r'^(\[[\w-]+\])', body)
+        marker = marker_m.group(1) if marker_m else 'note'
+        content = body[len(marker):].lstrip(' :') if marker_m else body
+        lines = content.split('\n')
+        quoted = '> %s (%s): %s' % (marker, date.today().isoformat(), lines[0])
+        for extra in lines[1:]:
+            quoted += '\n> %s' % extra
+        rest = text[m.end():]
+        nxt = re.search(r'^## ', rest, re.M)
+        insert_at = m.end() + (nxt.start() if nxt else len(rest))
+        block = text[:insert_at].rstrip('\n') + '\n\n' + quoted + '\n\n'
+        self.save(path, block + text[insert_at:].lstrip('\n'))
+
+    def export(self, feature_id):
+        text = self.load(feature_id)
+        tasks = []
+        for m in re.finditer(r'^## (\d+) (.*?)\[([^\]]+)\][ \t]*$', text, re.M):
+            num, title, raw = m.group(1), m.group(2).strip(), '[%s]' % m.group(3)
+            rest = text[m.end():]
+            nxt = re.search(r'^## ', rest, re.M)
+            section = rest[:nxt.start()] if nxt else rest
+            am = re.search(r'^\*\*Assignee:\*\* (.*)$', section, re.M)
+            comments = [{'body': c.strip(), 'createdAt': None}
+                        for c in re.findall(r'^> (.*)$', section, re.M)]
+            tasks.append({'taskId': '%s#%s' % (feature_id, num), 'title': title,
+                          'status': generic_of(raw), 'statusRaw': raw,
+                          'assignee': (am.group(1).strip() if am and am.group(1).strip() != '—' else None),
+                          'description': section.strip(), 'comments': comments})
+        return tasks
+
+BACKENDS = {'Linear': Linear, 'Jira': Jira, 'GitHubIssues': GitHubIssues, 'Markdown': Markdown}
+if ADAPTER not in BACKENDS:
+    die("adapter '%s' has no tracker-ops backend — use the adapter doc's Operations table directly" % ADAPTER)
+backend = BACKENDS[ADAPTER]()
+
+# ---- operations ----------------------------------------------------------------
+def op_state(args):
+    if len(args) != 2:
+        die("usage: state <taskId> <Status>")
+    backend.set_state(args[0], status_by_name(args[1]))
+    print("%s → [%s]" % (args[0], args[1]))
+
+def op_comment(args):
+    if len(args) not in (1, 2):
+        die("usage: comment <taskId> [bodyfile]  (no file / '-' = stdin)")
+    backend.comment(args[0], read_body(args[1] if len(args) == 2 else None))
+    print("comment added to %s" % args[0])
+
+def op_claim(args):
+    to = None
+    if '--to' in args:
+        i = args.index('--to')
+        to = args[i + 1] if i + 1 < len(args) else die("--to needs a status name")
+        args = args[:i] + args[i + 2:]
+    if len(args) != 2:
+        die("usage: claim <taskId> <role> [--to <Status>]")
+    task_id, role = args
+    init = initial_status()
+    if to is None:
+        if len(init['transitions']) != 1:
+            die("initial status '%s' has %d outbound transitions — pass --to <Status>"
+                % (init['name'], len(init['transitions'])))
+        to = init['transitions'][0]
+    target = status_by_name(to)
+    if to not in init['transitions']:
+        die("claim must follow the board: '%s' is not in %s.transitions — andon" % (to, init['name']))
+    if hasattr(backend, 'set_assignee'):
+        backend.set_assignee(task_id, role)
+    backend.set_state(task_id, target)
+    backend.comment(task_id, "Claimed — moving to [%s].\n\n— %s" % (to, role))
+    print("%s claimed by %s → [%s]" % (task_id, role, to))
+
+def op_integrate(args):
+    if len(args) not in (2, 3):
+        die("usage: integrate <taskId> <commit-hash> [bodyfile]")
+    task_id, commit = args[0], args[1]
+    if not re.fullmatch(r'[0-9a-f]{7,40}', commit):
+        die("'%s' does not look like a commit hash" % commit)
+    extra = read_body(args[2]) if len(args) == 3 else None
+    term = terminal_status()
+    body = "Integrated: commit %s." % commit
+    if extra:
+        body += "\n\n" + extra
+    body += "\n\n— integrator"
+    backend.set_state(task_id, term)
+    backend.comment(task_id, body)
+    print("%s → [%s] (commit %s)" % (task_id, term['name'], commit))
+
+def op_export(args):
+    if len(args) != 2:
+        die("usage: export <featureId> <outfile>")
+    feature_id, outfile = args
+    tasks = backend.export(feature_id)
+    payload = {'featureId': feature_id, 'adapter': ADAPTER,
+               'exportedAt': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+               'tasks': tasks}
+    with open(outfile, 'w') as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+    print("exported %d [tasks] of %s to %s" % (len(tasks), feature_id, outfile))
+
+OPS = {'state': op_state, 'comment': op_comment, 'claim': op_claim,
+       'integrate': op_integrate, 'export': op_export}
+if not ARGS or ARGS[0] not in OPS:
+    die("usage: tracker-ops.sh {state|comment|claim|integrate|export} ...")
+OPS[ARGS[0]](ARGS[1:])
+PYEOF

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -45,7 +45,15 @@ TEAMWORK_ROOT=.teamwork          # Team workspace root (repo-relative). Add to .
 POLL_INTERVAL_SECONDS=120        # How often idle agents re-check mailbox + tracker
 STUCK_AFTER_MINUTES=15           # Lead treats silence longer than this as "stuck"
 ESCALATE_AFTER_ATTEMPTS=2        # Failed unblock attempts before the Lead escalates to the human
+TRACKER_WRITERS=all              # all = every role writes to the tracker itself;
+                                 # lead = single-writer mode: only the team-lead holds
+                                 # credentials and posts on the team's behalf
+                                 # (reference/orchestration.md → "Tracker write modes")
 ```
+
+Review depth (`REVIEW_MODE=sequential|parallel|tiered`) is a **per-team** choice
+and lives in the team file (`teams/<preset>.md`, next to `ROSTER=`), not here —
+see `teams/_PLAYBOOK.md` → *Review modes*.
 
 ## Validation commands (framework-agnostic Integrator)
 
@@ -57,7 +65,17 @@ its completion comment on the [task]).
 VALIDATE_BUILD=null              # e.g. "npm run build" / "dotnet build" / "cargo build"
 VALIDATE_TEST=null               # e.g. "npm test" / "pytest" / "go test ./..."
 VALIDATE_LINT=null               # e.g. "npm run lint" / "ruff check ."
+VALIDATE_SCRIPT=null             # alternative to the three above: a repo-relative script
+                                 # that receives the changed-file list as arguments and
+                                 # runs whatever applies (per-area suites, tools that only
+                                 # exist mid-feature). When set, it replaces VALIDATE_*.
 ```
+
+Validation **evolves during a feature**: the [task] that introduces a tool (a
+linter, a new suite) updates `VALIDATE_SCRIPT` (or these keys) *and* the team's
+`BASELINE.md` in the same diff, so every later [task] is judged by the new bar.
+Results are always judged against `<TEAMWORK_ROOT>/<team>/BASELINE.md` — the bar
+is "no new failures", not "all green".
 
 ## Rules
 

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -150,6 +150,36 @@ the failure mode this whole design exists to prevent.
 
 ---
 
+## Scenario 10 — Pre-flight design pass (batch the design gates)
+
+By default the design gate (Scenario 2 step 5) opens per-[task] at claim time.
+When the plan should be settled before any code — the user asks for all plans
+up front, or the [tasks] share contracts that must not fork — run the gates as
+one batch instead:
+
+1. **One `[design-note]` per [task]**, written against the real codebase (not the
+   [task] text alone), each registering its exports in the contract registry
+   (`reference/orchestration.md` → *Contract registry*, team mode).
+2. **Cross-[task] consistency review first.** The reviewer of the set (the
+   principal-architect in team mode; you, wearing that hat, in single-agent mode)
+   reads the **full set before verdicts**, checking sibling notes against each
+   other and the registry — contract forks between parallel plans are the
+   highest-value findings and are invisible note-by-note. Cross-cutting rulings
+   are binding and recorded once, referenced by each affected [task].
+3. **Per-[task] verdicts** — `[design-approved]` (with conditions) or
+   `[design-pushback]`, exactly as in the normal gate.
+4. **Scope sign-off per [task]** where a product owner exists —
+   `[product-approval]` / `[product-pushback]`.
+5. **Everything lands as comments** on the [tasks], like any gate.
+6. At claim time the gate is already open: the implementer re-reads the approved
+   note, its conditions, and any cross-cutting rulings, and proceeds — no second
+   approval needed unless a `[divergence]` or re-plan invalidated the note.
+
+The per-[task] gate is unchanged — this scenario only moves *when* it runs.
+[Tasks] added later (Scenario 6) go through the normal per-[task] gate.
+
+---
+
 ## Quick reference — status writes per scenario
 
 | Scenario | Writes |
@@ -162,3 +192,4 @@ the failure mode this whole design exists to prevent.
 | 6 New work | create `[task]` `[Planned]` |
 | 7 Block | comment + `[task]` → `[Blocked]`; owner routes it back when cleared |
 | 8 Andon | **no write** — stop and report |
+| 10 Pre-flight design pass | comments only — one `[design-note]` + verdict (+ scope sign-off) per [task] |

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -28,16 +28,30 @@ Two principles rule everything:
 ├── heartbeats/<role>            # one line: <ISO-8601 UTC> | <taskId or -> | <state>
 ├── pids/<role>.pid              # process id when launched in background mode
 ├── worktrees/<role>-<taskId>/   # implementer working copies
+├── CONTRACTS.md                 # append-only registry of names plans export/consume (see "Contract registry")
+├── BASELINE.md                  # known state of the branch at creation: test counts, known failures, validation commands (see "Baseline manifest")
+├── review-ledger.md             # reviewers' one-line-per-ruling ledger of still-live conditions
+├── tasks.json                   # read-only [task] export for credential-less roles (adapter "export" operation)
 └── ESCALATIONS.md               # the Lead's log of everything escalated to the human
 ```
 
 ## Identity
 
-Exactly seven role names exist: `team-lead`, `principal-architect`, `integrator`,
-`backend`, `frontend`, `qa`, `reviewer`. Your role is stated at the top of your
-startup prompt. Use it verbatim as your tracker assignee name, your mailbox
-directory, your heartbeat file, and the signature line of every comment you write:
-`— <role>` (e.g. `— principal-architect`).
+Exactly seven **protocol roles** exist: `team-lead`, `principal-architect`,
+`integrator`, `backend`, `frontend`, `qa`, `reviewer` — the protocol's rules,
+gates, and status ownership are written against these. Preset teams (`teams/`)
+add **specialized role names** (`principal-software-architect`,
+`senior-qa-engineer`, …), each acting as one or more protocol roles per the
+*Protocol mapping* line in its brief.
+
+One signing rule: **use the role name at the top of your startup prompt,
+verbatim and only that name** — as your tracker assignee name, your mailbox
+directory, your heartbeat file, and the signature of every comment: `— <role>`.
+A specialized role signs its specialized name; when it writes a protocol-role
+marker and the mapping isn't already on the [task], it states the mapping once —
+e.g. `— principal-software-architect (as principal-architect)` — and plain
+`— <specialized-name>` thereafter. Never alternate between the two names within
+a run: signatures are grep keys.
 
 ## Mailboxes and heartbeats
 
@@ -61,6 +75,45 @@ directory, your heartbeat file, and the signature line of every comment you writ
   skip mailboxes and heartbeats entirely and poll the tracker for comments addressed
   to your role. State this degradation once in a comment on your current [task].
 
+## Report before idle — the delivery contract
+
+**You never go idle without first delivering your current structured artifact**
+(`[design-note]`, `[review-request]`, a review verdict, `[andon]`, …) to the
+tracker and notifying the team-lead. Finishing the work is half the job; the
+protocol only sees what was delivered. Idle with undelivered work is a protocol
+violation — the lead treats it as **Stuck** immediately.
+
+The launch handshake is the same contract from the lead's side:
+
+- **The spawn prompt is context, not a trigger.** After spawning or relaunching a
+  teammate, the lead always sends an explicit assignment message (mailbox or
+  harness message): the [task] or gate to act on, pointers to conditions, and the
+  expected artifact. Teammates act on assignment messages; a teammate that has a
+  startup prompt but no assignment asks the lead instead of guessing — or idling.
+- Every assignment names the artifact that ends it. When that artifact is
+  delivered, the loop closes; until then, the teammate is accountable for it.
+
+## Harness mode — teammates as in-session subagents
+
+Teams don't have to run as external CLI processes. When the orchestrating agent's
+harness can spawn subagents and message them directly, run the whole team inside
+it — same protocol, different transport:
+
+| CLI-process mechanism | Harness-mode equivalent |
+|---|---|
+| `launch-team.sh start/team` (spawn) | `launch-team.sh compose <team> <featureId> <role> [preset]` writes the identical startup prompt without spawning; the lead spawns the role natively with it |
+| Mailbox files | The harness's agent-to-agent messages. Same rule as mailboxes: transport, never truth — a decision is binding only once it lands as a tracker comment |
+| Heartbeats | The harness's lifecycle/idle notifications |
+| pid files, tmux, `status`/`stop` | Not applicable — the harness owns process supervision |
+| Filesystem-degradation statement | Not needed — the harness delivers messages |
+
+Everything else is unchanged: the tracker is still the single source of durable
+truth, markers and statuses are still the protocol, worktrees still come from
+`launch-team.sh worktree`, and the *Report before idle* contract applies with the
+harness's idle notification standing in for a stale heartbeat. The two modes mix
+freely — e.g. harness subagents for implementers, a CLI process for a long-lived
+reviewer.
+
 ## Structured comments — the coordination markers
 
 All coordination artifacts are comments on the [task], written through the adapter,
@@ -69,18 +122,74 @@ invent new ones, never misspell them.
 
 | Marker | Written by | Meaning / required content |
 |---|---|---|
-| `[design-note]` | implementer | Proposed approach before any code: approach, API/contract changes, data-model changes, affected components. Frontend must include `Architectural impact: yes/no — <why>`. |
+| `[design-note]` | implementer | Proposed approach before any code: approach, API/contract changes, data-model changes, affected components. Frontend must include `Architectural impact: yes/no — <why>`. Registers every name it exports in `CONTRACTS.md` and cites the registry line for every sibling export it consumes (see *Contract registry*). |
 | `[design-approved]` | principal-architect | Gate open. May carry conditions the implementation must honour. |
 | `[design-pushback]` | principal-architect | Gate closed. Lists required changes; implementer revises the `[design-note]` and re-pings. |
 | `[api-ready]` | backend | Contract available for frontend: endpoints, request/response shapes. Also sent by mailbox. |
 | `[divergence]` | implementer | What was done differently from the [task]/design note and why. Additive — **never edit the original [task] description.** |
-| `[review-request]` | implementer | Ready for review: what changed, list of changed files, validation commands run and their results. Written when moving to `[Review]`. |
+| `[review-request]` | implementer | Ready for review: what changed, list of changed files, validation commands run and their results (judged against `BASELINE.md`), and any index-only staging operation performed (e.g. untracking a file) — the one staging act an implementer may perform. Written when moving to `[Review]`. |
 | `[review-findings]` | reviewer / principal-architect | Numbered problems that must be fixed. Task goes back to `[Active]`. |
 | `[review-approval]` | reviewer | Approval with the **explicit list of approved file paths**. |
 | `[architecture-approval]` | principal-architect | Same, from the architecture review. |
+| `[product-approval]` | product owner role (e.g. `senior-technical-product-manager`; the team-lead where no product role exists) | Scope/acceptance sign-off: scope ruling, acceptance-criteria verdict, any conditions. |
+| `[product-pushback]` | product owner role (same) | Scope gate closed: what must change in scope or acceptance criteria before work proceeds. |
 | `[handoff]` | team-lead | Reassignment: summary of state so a fresh agent can resume. |
 | `[andon]` | any role | Stop-the-line report: what failed, exact error, what you did NOT do. |
 | `[escalation]` | team-lead | Needs the human: question + context + what was already tried. |
+
+## Contract registry — parallel plans share names, not assumptions
+
+When [tasks] are planned or implemented in parallel, the cheapest defect filter is
+a single place where cross-[task] names live. `<TEAMWORK_ROOT>/<team>/CONTRACTS.md`
+is an **append-only registry**:
+
+- Every `[design-note]` **registers what it exports** — schema/field names, event
+  constants, endpoint paths, enum values, anything a sibling [task] will spell —
+  one line each: `<taskId> exports <kind> <name> — <one-line shape>`.
+- Every plan that **consumes** a sibling's export cites the registry line instead
+  of restating the name from memory. No matching line yet? That's a sequencing
+  question for the principal-architect, not a guess.
+- The principal-architect's reviews (batch or per-[task]) **diff plans against
+  the registry** — two [tasks] spelling the same concept differently is a
+  `[design-pushback]` on the later one, caught before code exists.
+- Renames are new lines that supersede old ones (`supersedes: <line>`), never
+  edits — the history is the audit trail.
+
+## Baseline manifest — no oral tradition about branch state
+
+At feature-branch creation the team-lead records
+`<TEAMWORK_ROOT>/<team>/BASELINE.md`: current test counts, **known failures with
+their cause**, and the validation commands that exist right now. Every brief and
+review judges work against it: **the bar is "no new failures", not "all green"** —
+nobody restates known-failure lore in assignment messages, and nobody gets blamed
+for red that predates the branch. When a [task] changes the validation landscape
+(adds a linter, a suite, a build step), updating `BASELINE.md` is part of that
+[task]'s diff. The integrator cites `BASELINE.md` when recording skips or judging
+a validation run.
+
+## Tracker write modes
+
+`TRACKER_WRITERS` in `config/team.config.md` sets who physically writes to the
+tracker:
+
+- **`all` (default).** Every role performs its own adapter operations. Requires
+  every agent to hold tracker access.
+- **`lead` — single-writer ("scribe") mode.** Only the team-lead holds tracker
+  credentials. Roles compose their artifacts exactly as the protocol requires —
+  same markers, same content, signed `— <role>` — but deliver them to the lead
+  (mailbox or harness message) instead of posting. The lead posts each block
+  **verbatim**, appending `(posted by team-lead)` to the signature:
+  `— <role> (posted by team-lead)`. Status changes work the same way: the role
+  requests the move, the lead performs the write.
+
+  In `lead` mode, status ownership and marker authorship rules apply to the
+  **authoring** role, not the writing one — the lead is a scribe, never an
+  author, and gains no authority from holding the pen: it still cannot approve a
+  design, soften a finding, or override a veto, and it must not edit, summarize,
+  or reorder a block it posts. Trade-offs to accept knowingly: signatures no
+  longer prove authorship (acceptable inside one supervised team), and the lead
+  becomes a serialization point (which is also the point — no credential sprawl,
+  no write races, uniform formatting).
 
 ## Status routing
 
@@ -109,12 +218,14 @@ One implementer per [task], ever. Claiming is the lock.
 ```
 claim → [design-note] → wait for [design-approved]      (no code before the gate)
       → implement in your worktree                       ([divergence] comments as needed)
-      → self-validate (VALIDATE_* that apply to your change)
+      → self-validate (VALIDATE_SCRIPT or the VALIDATE_* that apply; bar =
+        no new failures vs BASELINE.md)
       → [review-request] + move to [Review]
       → reviewer three-phase review ∥ principal-architect architecture review
       → findings? → back to [Active], fix, [review-request] again
       → [review-approval] + [architecture-approval] (both, with file lists)
-      → integrator: verify lists == diff, stage explicitly, run VALIDATE_*,
+      → integrator: verify lists == diff, stage explicitly, validate
+        (VALIDATE_SCRIPT or VALIDATE_*, judged against BASELINE.md),
         merge to the feature branch, commit, move to [Ready to deploy] (atomic pair)
       → principal-architect divergence sweep updates upcoming [tasks]
 ```
@@ -148,12 +259,18 @@ The `integrator` is the **only** role that merges to the feature branch, commits
 marks `[Ready to deploy]`. Pipeline (all-or-nothing, zero tolerance, no overrides — not
 even from the team-lead):
 
-1. Verify both approval comments exist and their file lists are identical to
-   `git diff --name-only <feature-branch>...HEAD` (run from inside the [task]'s worktree).
-   Any mismatch → `[andon]`.
+1. Verify both approval comments exist and their file lists are identical to the
+   full changed-file set — `git diff --name-only <feature-branch>...HEAD` plus
+   `git status --porcelain -uall` for uncommitted work (always `-uall`: plain
+   porcelain hides the files inside a new directory), run from inside the
+   [task]'s worktree. Any mismatch → `[andon]`.
 2. Stage by explicit file list (never `add -A`), verify the staged set matches.
-3. Run `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT` (skip `null` ones, record
-   skips). Any failure → `[andon]`, task back to `[Active]`.
+   Index-only operations (untracking a file) are the implementer's one sanctioned
+   staging exception — allowed only when named in the `[review-request]`.
+3. Validate — `VALIDATE_SCRIPT` with the changed-file list if set, else
+   `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT` (skip `null` ones, record
+   skips). Judge against `BASELINE.md`: the bar is no NEW failures. Any new
+   failure → `[andon]`, task back to `[Active]`.
 4. Merge the task branch into the feature branch; remove the worktree.
 5. Commit, capture the hash, then immediately move the [task] to `[Ready to deploy]`,
    citing the hash. Commit and completion are one atomic pair — never one without
@@ -169,7 +286,9 @@ Detect:
 - **Stuck** — heartbeat older than `STUCK_AFTER_MINUTES`; an `[Active]` [task] with
   no new comment past the threshold; a `[design-note]`, question, or
   `[review-request]` that nobody answered (the principal-architect is on the hot
-  path — monitor it like anyone else).
+  path — monitor it like anyone else). **A teammate that goes idle while you are
+  still waiting on its artifact is Stuck immediately** — the delivery contract was
+  violated; do not wait out `STUCK_AFTER_MINUTES`, go straight to rung 1.
 - **Parked** — a [task] sitting in `[Blocked]` with no new comment past the threshold; the team-lead owns driving it out.
 - **Conflict** — two claimants on one [task]; contradictory `[divergence]` notes
   across [tasks]; a merge conflict reported by the integrator; a deadlock
@@ -191,6 +310,13 @@ Unblock ladder — in order, one rung at a time:
 The Lead never overrides an integrator validation failure or a principal-architect
 veto — the andon cord outranks the Lead. During autonomous operation the Lead never
 blocks the team on an interactive user prompt; escalation is the channel.
+
+**Idle-notification hygiene.** Heartbeats and harness idle pings are liveness
+signals, not events. Act on exactly two things: (a) an artifact arrived — process
+it; (b) idle **without** the artifact you are waiting for — Stuck, rung 1 now.
+Everything else (routine idle pings, repeated heartbeats, "still working" noise)
+gets no reply and no acknowledgment — answering it burns your turns and everyone
+else's context.
 
 ## Recovery
 
@@ -214,6 +340,7 @@ never fabricate a result, never claim a status you did not verify.
 | Shell + git | all; worktrees for implementers | — (hard requirement) |
 | Tracker access (adapter: MCP, REST + API key, CLI, or files) | all | use another mechanism from the adapter's *Access mechanisms*; never fabricate |
 | Shared filesystem with the team | mailbox/heartbeats | poll the tracker; say so once on your [task] |
+| Harness-native teammates (subagent spawn + messaging) | harness mode | launch CLI processes via `bin/launch-team.sh` (tmux / background) |
 | tmux | launcher niceness | background processes + pid files |
 | Long-running loop | team-lead, principal-architect, integrator | relaunch on a schedule; recovery makes restarts free |
 

--- a/reference/team-roles.md
+++ b/reference/team-roles.md
@@ -40,6 +40,11 @@ rule derives everything:
 > **The owner of status S is the only party allowed to work items sitting in S, and the
 > only one allowed to perform S's outbound transitions.**
 
+Ownership is about *authoring* a transition, not typing it: in single-writer mode
+(`TRACKER_WRITERS=lead`, see `reference/orchestration.md` → *Tracker write modes*) the
+team-lead performs every physical write on behalf of the authoring role, and these
+ownership checks apply to the role that authored the change.
+
 Two refinements:
 
 - **Entering a `requiresCommit` status** is performed by *that* status's owner, atomically

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -22,8 +22,9 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
    send `[api-ready]` — comment on the [task] AND mailbox to `frontend` — with
    endpoints and request/response shapes. Don't wait for review; frontend is
    blocked on you.
-5. **Self-validate.** Run the `VALIDATE_*` commands that apply to your change.
-   Fix what you broke.
+5. **Self-validate.** Run the `VALIDATE_*` commands (or `VALIDATE_SCRIPT`) that
+   apply to your change. Judge against the team's `BASELINE.md` — the bar is no
+   NEW failures. Fix what you broke.
 6. **Request review.** `[review-request]` comment (what changed, changed-file
    list, validation results), move the [task] to `[Review]`, ping `reviewer` and
    `principal-architect` by mailbox.
@@ -44,3 +45,6 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
 - Move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Work around a failure. Process broken (adapter error, unexpected status) → `[andon]`
   + mailbox to `team-lead`; work stuck → `[Blocked]` (lifecycle Scenario 7).
+- Go idle with undelivered work. Whatever you just finished — a `[design-note]`,
+  a `[review-request]`, an `[andon]` — deliver it and notify the team-lead first
+  (protocol: *Report before idle*).

--- a/roles/integrator.md
+++ b/roles/integrator.md
@@ -15,16 +15,30 @@ in the tracker are the only trigger that counts.
 ## Pipeline (run exactly, in order)
 
 1. In the [task]'s worktree (`<TEAMWORK_ROOT>/<team>/worktrees/<role>-<taskId>` (derive `<role>` from the [task]'s assignee)),
-   compute `git diff --name-only <feature-branch>...HEAD`.
+   compute the full changed-file set: `git diff --name-only <feature-branch>...HEAD`
+   **plus** `git status --porcelain -uall` for anything uncommitted. Always `-uall`:
+   plain porcelain collapses a new directory to one `dir/` line and hides every
+   file inside it — naive list equality would then pass or fail wrongly.
 2. Compare with the file lists inside BOTH approval comments. All three sets must be
    identical. Any extra, missing, or renamed file → `[andon]` (a file changed after
    approval needs fresh approval — never "probably fine").
 3. Stage by explicit file list — never `git add -A` / `git add .`. Verify
    `git diff --cached --name-only` equals the approved list.
-4. Run `VALIDATE_BUILD`, then `VALIDATE_TEST`, then `VALIDATE_LINT` from
-   `config/team.config.md` (skip `null` keys, and record every skip in your
-   completion comment). Any non-zero exit → `[andon]` with the exact output; move
-   the [task] back to `[Active]`; notify the implementer by mailbox.
+   *Sanctioned exception — index-only operations.* A [task] that must untrack a
+   file (e.g. `git rm --cached <path>`) is the one case where the implementer may
+   touch the index: **that operation only**, and it must be named in the
+   `[review-request]`. Expect the staged set to equal the approved list plus
+   exactly the named index-only operations; anything else → `[andon]`.
+4. Validate. If `VALIDATE_SCRIPT` is set in `config/team.config.md`, run it with
+   the changed-file list as arguments and let it decide what applies; otherwise
+   run `VALIDATE_BUILD`, then `VALIDATE_TEST`, then `VALIDATE_LINT` (skip `null`
+   keys). Judge results against `<TEAMWORK_ROOT>/<team>/BASELINE.md`: the bar is
+   **no new failures**, not "all green" — a failure listed there with its cause
+   is not this [task]'s failure. Record every skip in the completion comment in
+   the form `VALIDATE_<X> skipped: <reason> (<taskId or BASELINE.md § that
+   sanctions it>)` — e.g. `VALIDATE_LINT skipped: linter arrives with ENG-113`.
+   Any NEW non-zero exit → `[andon]` with the exact output; move the [task] back
+   to `[Active]`; notify the implementer by mailbox.
 5. Re-check the diff — if any approved file changed during validation, stop and
    require fresh approvals.
 6. Merge the task branch into the feature branch; remove the worktree
@@ -49,3 +63,5 @@ conflicts yourself; report the conflict to the team-lead.
 - Mark `[Ready to deploy]` without a commit, or commit without the move — they are one atomic pair.
 - Resolve merge conflicts that require code judgment.
 - Touch the [feature] status — the team-lead resolves the [feature].
+- Go idle mid-pipeline. Finish the atomic pair (or `[andon]`) and send the step-9
+  notification before idling (protocol: *Report before idle*).

--- a/roles/principal-architect.md
+++ b/roles/principal-architect.md
@@ -17,7 +17,10 @@ human). **You never write code. Git is read-only for you.** The protocol in
    `[design-pushback]` (numbered required changes). Backend [tasks] always get a
    full design review. Frontend [tasks] declare `Architectural impact: yes/no`;
    for a credible "no", reply `[design-approved]` fast — keep the gate cheap where
-   it should be cheap.
+   it should be cheap. When the team runs `REVIEW_MODE=tiered`
+   (`teams/_PLAYBOOK.md` → *Review modes*) and the [task] qualifies for a
+   combined review, attach a **numbered architecture checklist** to your
+   `[design-approved]` — it is what QA executes in your stead at review time.
 3. **Architecture review — every [task] in `[Review]`.** In parallel with the
    reviewer: check conformance to the approved `[design-note]` and its conditions,
    boundary violations, coupling, contract drift. Problems →
@@ -41,6 +44,15 @@ completed integrations without your divergence sweep. You are the hot path of th
 whole team: answer gates before doing anything slow. Update your heartbeat between
 steps.
 
+## Your ledger
+
+Maintain `<TEAMWORK_ROOT>/<team>/review-ledger.md`: one line per binding ruling
+or approval condition that is still **live**, written when you issue it, struck
+when it lands or is superseded. Check every new `[design-note]` and diff against
+the ledger *first* — it is cheaper than re-reading the whole comment trail, and
+unlike your session memory it survives a relaunch. The tracker stays the source
+of truth; the ledger is your index into it.
+
 ## You never
 
 - Write or edit code, stage, merge, or commit.
@@ -48,3 +60,6 @@ steps.
   not a ruling you can make).
 - Let politeness soften a veto. If the design is wrong, `[design-pushback]` with
   concrete required changes. Pushback is your job, not an exception.
+- Go idle with a verdict unwritten. A gate you decided but never posted is still
+  closed — deliver the marker comment and notify the team-lead before idling
+  (protocol: *Report before idle*).

--- a/roles/reviewer.md
+++ b/roles/reviewer.md
@@ -48,3 +48,6 @@ Then write `[review-approval]` with the explicit list of approved file paths.
   integrator (via the tracker).
 - Approve with a file list you did not verify against the actual diff.
 - Start Phase 2 before Phase 1's checklist is written.
+- Go idle with your verdict unwritten. A finished review that never became a
+  `[review-findings]` / `[review-approval]` comment did not happen — deliver it
+  and notify the team-lead before idling (protocol: *Report before idle*).

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -32,10 +32,20 @@ governs everything below; this brief only says what is *yours*.
 3. Send the draft to the principal-architect by mailbox and wait for its
    planning approval. Revise until approved. Only then create the [feature] and
    [tasks] via the adapter, all `[Planned]`.
-4. Compose the roster: which of `backend` / `frontend` / `qa` / `reviewer` are
+4. **Record the baseline.** At feature-branch creation, write
+   `<TEAMWORK_ROOT>/<team>/BASELINE.md` (protocol: *Baseline manifest*): test
+   counts, known failures with cause, available validation commands. Point
+   briefs and assignments at it instead of restating branch lore in messages.
+5. Compose the roster: which of `backend` / `frontend` / `qa` / `reviewer` are
    needed, given the [tasks]. Persistent roles (you, principal-architect,
    integrator) always run.
-5. Launch: `bin/launch-team.sh start <team> <featureId> <role>...`.
+6. Launch: `bin/launch-team.sh start <team> <featureId> <role>...` (or spawn each
+   role natively in your harness from a `compose`d prompt — see
+   `reference/orchestration.md` → *Harness mode*).
+7. **Complete the handshake.** The spawn prompt is context, not a trigger: after
+   every launch or relaunch, send each teammate an explicit assignment message
+   naming the [task] or gate to act on and the artifact you expect back. Nobody
+   works from the spawn prompt alone.
 
 ## Phase 2 — Supervise
 
@@ -44,6 +54,10 @@ Run the supervision loop from `reference/orchestration.md` (cadence
 conflict / crash → apply the unblock ladder one rung at a time, recording every
 rung as a comment on the affected [task]. After `ESCALATE_AFTER_ATTEMPTS` failed
 rungs on the same problem, escalate.
+
+Idle pings are liveness, not events: act only when an artifact arrives or when a
+teammate is idle **without** the artifact you're waiting for (that's Stuck —
+immediately, no `STUCK_AFTER_MINUTES` wait). Ignore the rest.
 
 Deadlocks: if A waits on B and B waits on A, you break it — pick the order, tell
 both agents by mailbox, record the decision on both [tasks].

--- a/teams/README.md
+++ b/teams/README.md
@@ -37,6 +37,14 @@ is the final review gate** before the standard `integrator` merges.
    Each member's startup prompt is composed from: its role brief + the team file
    + this directory's `_PLAYBOOK.md` + `reference/orchestration.md` + the team
    config. Watch agents in tmux (`tmux attach -t team-<feature-branch>`).
+
+   Running the team as subagents inside your own harness instead? Compose each
+   member's prompt without spawning and spawn natively (see
+   `reference/orchestration.md` → *Harness mode*):
+
+   ```bash
+   bin/launch-team.sh compose <feature-branch> <featureId> <role> <preset>
+   ```
 3. Relaunch a single member (keeps team context):
    `bin/launch-team.sh relaunch <feature-branch> <featureId> <role> <preset>`.
 
@@ -45,7 +53,12 @@ is the final review gate** before the standard `integrator` merges.
 - **New team:** copy an existing team file; keep the section shape — charter,
   `ROSTER=` line (space-separated role names the launcher resolves), roster
   table with protocol mappings, team-specific review stages, launch line.
-  Include `integrator` in every roster.
+  Include `integrator` in every roster. Optionally declare a review mode
+  (`REVIEW_MODE=sequential|parallel|tiered` — see `_PLAYBOOK.md` → *Review
+  modes*; absent = `sequential`).
+- **Identity:** specialized roles sign with their specialized name everywhere;
+  when writing a protocol-role marker they state the mapping once per [task] if
+  it isn't already on record (`reference/orchestration.md` → *Identity*).
 - **New role:** add `teams/roles/<kebab-name>.md` with the standard sections —
   identity, **Protocol mapping**, Responsibilities, Decision authority,
   Deliverables, Handoffs, You never. The launcher resolves any role name that

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -21,6 +21,11 @@ protocol; it never contradicts it.
    every other required approval for that [task] is already on record. Work is
    "done" only after QA's approval AND the integrator's merge + `[Ready to deploy]`.
 
+Every member is bound by the delivery contract (`reference/orchestration.md` →
+*Report before idle*): no one goes idle with an undelivered artifact, and the
+lead sends an explicit assignment message after every spawn — the startup prompt
+is context, not a trigger.
+
 ## Stages
 
 1. **Intake.** The TPM turns the ask into a [feature] draft: problem statement,
@@ -29,10 +34,20 @@ protocol; it never contradicts it.
 2. **Planning.** The architect breaks the [feature] into [tasks] (complete
    vertical slices) with the TPM. The TPM must approve scope and acceptance
    criteria **before anything is created in the tracker** — the architect cannot
-   approve its own plan's scope; the TPM is the second pair of eyes.
-3. **Design gate — every [task].** The implementer posts a `[design-note]`; the
-   architect answers `[design-approved]` (possibly with conditions) or
-   `[design-pushback]`. No code before approval.
+   approve its own plan's scope; the TPM is the second pair of eyes. The TPM's
+   sign-off is a `[product-approval]` comment (or `[product-pushback]` with the
+   required changes) once the [tasks] exist to carry it.
+3. **Design gate — every [task].** The implementer posts a `[design-note]` that
+   registers its exports in the contract registry
+   (`reference/orchestration.md` → *Contract registry*); the architect answers
+   `[design-approved]` (possibly with conditions) or `[design-pushback]`. No code
+   before approval.
+
+   *Pre-flight variant (lifecycle Scenario 10):* when the plan should be settled
+   before any code, run all design gates as one batch — notes for every [task],
+   the architect's cross-[task] consistency review first (diffing the set against
+   the contract registry), then per-[task] verdicts and TPM scope sign-offs. At
+   claim time each gate is already open.
 4. **Implementation.** Own worktree per implementer, the [task]'s [subtasks] as
    checklist, `[divergence]` comments for every deviation, self-validation with
    the `VALIDATE_*` commands before requesting review.
@@ -46,14 +61,38 @@ protocol; it never contradicts it.
       `file:line` citation and a test citation; runs the applicable suites.
       Approval → `[review-approval]`, always the **last** approval.
 
-   The protocol allows parallel dual review; preset teams sequence it so QA
-   always judges the final shape of the change.
+   The protocol allows parallel dual review; in the default `sequential` mode
+   preset teams sequence it so QA always judges the final shape of the change
+   (see *Review modes* below for the trade-offs of the other modes).
 6. **Integration.** The standard `integrator` (`roles/integrator.md`) verifies
    the approvals and file lists, validates, merges, commits, and marks
    `[Ready to deploy]` — the atomic pair. Every preset roster includes it.
 7. **Close.** When all [tasks] are `[Ready to deploy]`: the architect runs the feature
    completion checklist, the TPM confirms the acceptance criteria hold at
-   feature level, and only then does the [feature] move to `[Resolved]`.
+   feature level with a feature-level `[product-approval]` comment, and only
+   then does the [feature] move to `[Resolved]`.
+
+## Review modes
+
+A team file may declare `REVIEW_MODE=` next to its `ROSTER=` line; absent, the
+default is `sequential` (the order in stage 5):
+
+- `sequential` — each review stage starts after the previous approval. QA judges
+  the final shape of the change; roughly doubles per-[task] review wall time.
+- `parallel` — architect, specialists, and QA review the same diff concurrently;
+  QA still **posts** `[review-approval]` only after every other required
+  approval is on record, so it remains the last-in-time gate. Trades "QA sees
+  the final shape" for wall time; any `[review-findings]` sends the [task] back
+  and every reviewer re-reviews the reworked diff.
+- `tiered` — reviews are sized to risk: for small [tasks] a single combined
+  review (QA executes the numbered architecture checklist the architect
+  attaches to the `[design-approved]` — the architect's brief requires it in
+  this mode), with full dual review reserved for larger [tasks] and for **any**
+  [task] touching a contract registered in `CONTRACTS.md`. Cheaper where the
+  second reviewer's value is independent evidence rather than extra findings.
+
+Whatever the mode, the invariants hold: every required approval exists before
+integration, QA's approval is last, file lists must equal the diff.
 
 ## Escalation
 
@@ -63,3 +102,41 @@ TPM first; the TPM escalates to the human when the answer is not derivable from
 the approved [feature]. Technical rulings are the architect's, and final — but
 the architect never overrides the integrator's validation failures or QA's gate
 verdict.
+
+## Appendix — message templates
+
+Canonical shapes for the two messages the lead writes most. Filling a template
+beats re-authoring fifteen long messages per [feature] — and keeps every
+teammate's inputs in the same places. Both end by naming the artifact that
+closes the loop (*Report before idle*).
+
+**ASSIGN** — lead → implementer, after spawn or claim sanction:
+
+```
+Re: <taskId>
+Assignment: <one line — what this [task] delivers>
+Inputs: [task] description + all comments; approved [design-note] + conditions
+        <link/pointer>; cross-cutting rulings <pointer, if any>; CONTRACTS.md
+        lines you consume: <lines or "none">
+Baseline: BASELINE.md — bar is no new failures
+Validate: <VALIDATE_* / VALIDATE_SCRIPT expectations for this change>
+Report back: [review-request] with changed-file list, validation results, and
+        any index-only staging operation — deliver before idling.
+```
+
+**REVIEW** — lead → reviewer(s), when a [task] enters `[Review]`:
+
+```
+Re: <taskId>  (mode: <sequential|parallel|tiered>)
+Diff: <files changed, one-line summary> (worktree: <path>)
+Rule on: <open [divergence]s awaiting a ruling, or "none">
+Check: approved [design-note] conditions <pointer>; review-ledger.md lines that
+        apply; CONTRACTS.md exports this [task] registered or consumes
+Evidence: run the applicable suites yourself; judge against BASELINE.md
+Report back: [architecture-approval] / [review-approval] with the explicit file
+        list, or [review-findings] — deliver before idling.
+```
+
+Report-block shapes (`[review-request]`, `[divergence]`, `[andon]`, approvals)
+are defined by the marker table in `reference/orchestration.md` — don't restate
+them here, don't drift from them.

--- a/teams/roles/senior-qa-engineer.md
+++ b/teams/roles/senior-qa-engineer.md
@@ -22,6 +22,10 @@ you as ordinary [tasks].
   actual, and severity — never patch product code.
 - Push back on untestable acceptance criteria the moment you see them — an
   untestable criterion is a planning defect, and planning is when it's cheap.
+- Keep your slice of `<TEAMWORK_ROOT>/<team>/review-ledger.md` current: one line
+  per condition or finding still live, struck when resolved. Check each new
+  [task] in `[Review]` against the ledger before re-deriving anything from the
+  comment trail — it survives relaunches; your session memory doesn't.
 
 ## Decision authority
 

--- a/teams/roles/senior-technical-product-manager.md
+++ b/teams/roles/senior-technical-product-manager.md
@@ -35,6 +35,10 @@ below.
 
 - The [feature] description (problem, scope, NOT-in-scope, dependencies).
 - Acceptance criteria inside every [task] description.
+- `[product-approval]` / `[product-pushback]` comments — your scope and
+  acceptance-criteria sign-offs, per [task] and at feature level before
+  `[Resolved]` (required content: scope ruling, acceptance-criteria verdict,
+  conditions). These are your markers in the protocol table; write no others.
 - Scope rulings as comments; follow-up [tasks] (Scenario 6) for deferred scope.
 
 ## Handoffs

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -94,6 +94,24 @@ check "preset skips explicit-null role"      test ! -f .teamwork/test-feature/pr
 for i in $(seq 1 20); do [ -f qa-received.txt ] && break; sleep 0.1; done
 check "preset per-role override ran"         grep -q "Role: senior-qa-engineer" qa-received.txt
 
+# -- compose: emits the composed startup prompt without spawning (harness mode) --
+out="$("$LAUNCH" compose test-compose FEAT-3 backend)"
+check "compose prints an existing prompt path" test -f "$out"
+check "compose prompt contains role brief"     grep -q "Role: backend" "$out"
+check "compose prompt contains protocol"       grep -q "Orchestration — The Multi-Agent Protocol" "$out"
+check "compose spawns nothing"                 test ! -f .teamwork/test-compose/pids/backend.pid
+out2="$("$LAUNCH" compose test-compose FEAT-3 senior-qa-engineer full-stack)"
+check "compose with preset includes team file" grep -q "Team: Full Stack" "$out2"
+# compose is command-map-agnostic: a role with <ROLE>_CMD=null still composes
+# (harness mode spawns natively; the command map only gates CLI launches)
+out3="$("$LAUNCH" compose test-compose FEAT-3 reviewer)"
+check "compose works for CLI-disabled role"    grep -q "Role: reviewer" "$out3"
+if "$LAUNCH" compose test-compose FEAT-3 no-such-role 2>/dev/null; then
+  echo "FAIL: compose should refuse an unknown role"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: compose refuses unknown role"
+fi
+
 # -- team preset: unknown preset is refused ------------------------------------
 if TEAM_RUNNER=background "$LAUNCH" team nonesuch test-feature FEAT-2 2>/dev/null; then
   echo "FAIL: unknown preset should be refused"; FAILURES=$((FAILURES+1))

--- a/tests/tracker-ops-test.sh
+++ b/tests/tracker-ops-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# tracker-ops smoke test: exercises the Markdown backend end-to-end (offline)
+# plus the adapter-agnostic argument/board validation.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAILURES=0
+check() { # check <desc> <cmd...>
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "ok: $desc"; else echo "FAIL: $desc"; FAILURES=$((FAILURES+1)); fi
+}
+refuse() { # refuse <desc> <needle> <cmd...>
+  local desc="$1" needle="$2" out; shift 2
+  if out="$("$@" 2>&1)"; then
+    echo "FAIL: $desc (accepted)"; FAILURES=$((FAILURES+1))
+  elif printf '%s' "$out" | grep -q "$needle"; then
+    echo "ok: $desc"
+  else
+    echo "FAIL: $desc (wrong message: $out)"; FAILURES=$((FAILURES+1))
+  fi
+}
+
+# -- fixture: a skill copy configured for the Markdown adapter ------------------
+cd "$TMP"
+mkdir -p skill/config skill/bin
+cp "$SKILL_DIR/bin/tracker-ops.sh" skill/bin/
+cp "$SKILL_DIR/config/statuses.config.json" skill/config/
+cat > skill/config/project-management.config.md <<'EOF'
+```
+PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.workspace/task-manager
+STATUS_CONFIG=config/statuses.config.json
+```
+EOF
+OPS="skill/bin/tracker-ops.sh"
+
+mkdir -p feat
+cat > feat/feature.md <<'EOF'
+# Payments revamp [Planned]
+
+**Purpose:** Test fixture.
+
+## 1 Add form [Planned]
+
+**Assignee:** —
+
+Build the form.
+
+- Field A
+
+## 2 Wire endpoint [Planned]
+
+**Assignee:** —
+
+Call the endpoint.
+EOF
+T="feat/feature.md"
+
+# -- claim: assignee + initial→Active + claim comment ---------------------------
+"$OPS" claim "$T#1" backend
+check "claim sets status"        grep -q '^## 1 Add form \[Active\]$' "$T"
+check "claim sets assignee"      grep -q '^\*\*Assignee:\*\* backend$' "$T"
+check "claim leaves a comment"   grep -q 'Claimed — moving to \[Active\]' "$T"
+check "claim comment signed"     grep -q -- '— backend' "$T"
+check "sibling task untouched"   grep -q '^## 2 Wire endpoint \[Planned\]$' "$T"
+
+# -- comment: body from stdin, marker extracted, quoting-proof ------------------
+printf '[design-note] Approach: "quote" & $dollar.\nSecond line.\n' | "$OPS" comment "$T#1" -
+check "comment marker extracted"  grep -q '> \[design-note\] (....-..-..): Approach: "quote" & $dollar\.' "$T"
+check "comment multiline quoted"  grep -q '^> Second line\.$' "$T"
+
+# -- comment: body from a file ---------------------------------------------------
+printf 'From a file.\n' > body.txt
+"$OPS" comment "$T#1" body.txt
+check "comment from file"         grep -q '> note (....-..-..): From a file\.' "$T"
+
+# -- state: legal generic status names only --------------------------------------
+"$OPS" state "$T#1" Review
+check "state moves the task"      grep -q '^## 1 Add form \[Review\]$' "$T"
+
+# -- integrate: terminal move + hash citation + extra body -----------------------
+printf 'VALIDATE_TEST green. Merged: a.py\n' | "$OPS" integrate "$T#1" abc1234 -
+check "integrate terminal status" grep -q '^## 1 Add form \[Ready to deploy\]$' "$T"
+check "integrate cites the hash"  grep -q 'Integrated: commit abc1234\.' "$T"
+check "integrate appends body"    grep -q 'VALIDATE_TEST green\. Merged: a\.py' "$T"
+check "integrate signed"          grep -q -- '— integrator' "$T"
+
+# -- export: JSON snapshot with generic statuses ----------------------------------
+"$OPS" export "$T" tasks.json
+check "export writes JSON" python3 -c "
+import json
+d = json.load(open('tasks.json'))
+assert d['adapter'] == 'Markdown' and len(d['tasks']) == 2
+byid = {t['taskId']: t for t in d['tasks']}
+assert byid['$T#1']['status'] == 'Ready to deploy'
+assert byid['$T#2']['status'] == 'Planned'
+assert byid['$T#1']['assignee'] == 'backend'
+assert byid['$T#2']['assignee'] is None
+assert any('design-note' in c['body'] for c in byid['$T#1']['comments'])
+"
+
+# -- fail-loud: every bad input is refused with a clear message -------------------
+refuse "unknown status refused"       "unknown \[task\] status" "$OPS" state "$T#2" Nonesuch
+refuse "missing task refused"         "no task 9"               "$OPS" state "$T#9" Review
+refuse "bad hash refused"             "does not look like"      "$OPS" integrate "$T#2" nothash
+refuse "taskId without # refused"     "feature-file"            "$OPS" state "just-a-number" Review
+refuse "unknown op refused"           "usage:"                  "$OPS" frobnicate x y
+refuse "empty comment body refused"   "empty comment body"      bash -c "printf '' | '$OPS' comment '$T#2' -"
+refuse "missing feature file refused" "cannot read"             "$OPS" export nope/feature.md out.json
+refuse "unmapped adapter refused"     "no tracker-ops backend"  env TRACKER_ADAPTER=Nonesuch "$OPS" state "$T#2" Review
+
+echo "---"
+[ "$FAILURES" -eq 0 ] && echo "ALL PASS" || { echo "$FAILURES FAILURE(S)"; exit 1; }


### PR DESCRIPTION
## What & why

A full production run of this skill (33-[task] planning pass with PA + TPM sign-off, then a live implementation phase using harness subagents and the Linear REST adapter) produced a 16-point improvement plan backed by observed failures. This PR implements all 16 at the protocol level — nothing project-specific leaked in.

**Observed frictions → fixes:**

| Production symptom | Fix |
|---|---|
| 100% of spawned teammates idled until manually kicked; one reviewer finished but never sent its verdict | **Report-before-idle delivery contract** + explicit post-spawn assignment handshake; lead treats idle-without-artifact as Stuck immediately (R2, R15) |
| Whole run used harness subagents; mailboxes/heartbeats/pids were dead weight the lead had to map by improvisation | **Harness mode**: `launch-team.sh compose` emits the startup prompt without spawning; documented transport mapping (R1) |
| Tracker credential sprawl + hand-built GraphQL curl (one 401 from quoting) | **`TRACKER_WRITERS=lead` scribe mode** (R3) + **`bin/tracker-ops.sh`** — claim/state/comment/integrate/export over Linear/Jira REST, `gh`, and Markdown files, with comment bodies from file/stdin (R4, R14) |
| Two sibling plans forked a schema contract; caught only at implementation review (a full rework cycle) | **`CONTRACTS.md` append-only registry** — design notes register exports, consumers cite lines, the PA diffs plans against it (R6) |
| Batch up-front design pass was improvised but caught 2 plan-level defects before any code | **Scenario 10 — pre-flight design pass**, codified with the cross-[task] consistency review first (R5) |
| "2 pre-existing failures" restated in ~15 messages; validation commands changed mid-feature | **`BASELINE.md` manifest** ("no new failures" bar) + **`VALIDATE_SCRIPT`** for evolving validation (R7, R11) |
| TPM sign-offs went out as plain text — the only un-greppable gate | **`[product-approval]` / `[product-pushback]`** markers (R9) |
| `git status --porcelain` collapsed a new app dir to one line; an implementer legitimately needed `git rm --cached`; skip-record format invented on the spot | **Integrator hardening**: `-uall` file sets, sanctioned index-only exception named in the `[review-request]`, canonical skip format (R10) |
| Sequential dual review doubled wall time; QA found no post-PA defects across 6 [tasks] | **`REVIEW_MODE=sequential\|parallel\|tiered`** per team file, invariants preserved (R8) |
| Mixed role-name signatures; long messages hand-written each time; reviewers re-deriving conditions per [task] | Identity signing rule, ASSIGN/REVIEW templates, `review-ledger.md` (R12, R13, R16) |

## Verification

- `bash tests/launcher-test.sh` → ALL PASS (incl. new `compose` coverage: composes without spawning, works for CLI-disabled roles, refuses unknown roles)
- `bash tests/tracker-ops-test.sh` → ALL PASS (new: full offline Markdown-backend run — claim/comment/state/integrate/export — plus fail-loud negatives)
- Adversarial cross-file consistency review of the whole diff (dangling section refs, marker-table completeness, config-key agreement, banned-vocabulary scan, brief-vs-protocol contradictions): 7 findings, all fixed in this branch — 0 remaining

## Notes for review

- The marker table gains exactly two markers (`[product-approval]`, `[product-pushback]`); everything else reuses existing ones — the "never invent markers" rule holds.
- `tracker-ops.sh` is the ergonomic path only; each adapter's Operations table remains the spec, and MCP sessions keep using native tools.
- Defaults are unchanged everywhere: `TRACKER_WRITERS=all`, `REVIEW_MODE=sequential`, `VALIDATE_SCRIPT=null` — every new behavior is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)