### PR TITLE
Execution modes (sequential|parallel), relaunch hygiene, enforced delivery contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ CLI or IDE that can read files (Claude Code, Codex CLI, Gemini CLI, Aider,
 Cursor, Windsurf, Cline, …).
 
 **For multi-agent teams, additionally:** the launcher (`bin/launch-team.sh`) needs
-`bash` + `git` (it uses git worktrees to isolate agents). `tmux` is optional but
-recommended — without it, agents run as background processes.
+`bash` + `git` (with `EXECUTION=parallel` it uses git worktrees to isolate
+agents). `tmux` is optional but recommended — without it, agents run as
+background processes.
 
 **Tracker access is optional.** The default `Markdown` tracker stores everything
 in local files, so you can run the whole thing offline. Connect Linear/Jira/GitHub
@@ -105,8 +106,16 @@ anywhere and point the agent at `SKILL.md`.
 | **Cursor / Windsurf / Cline** | the tool's rules dir | reference `SKILL.md` in chat |
 | **Anything else** | anywhere | point the agent at `SKILL.md` |
 
-Multi-agent teams use **git worktrees**, so the bundle must live inside a git
-repository. `.teamwork/` and `.workspace/` are already git-ignored.
+Multi-agent teams work on a git branch (and, with `EXECUTION=parallel`, in **git
+worktrees**), so the bundle must live inside a git repository. `.teamwork/` and
+`.workspace/` are already git-ignored.
+
+Two execution modes (`config/team.config.md` → `EXECUTION`): **`sequential`**
+(default) runs one [task] at a time in the feature-branch checkout — the proven
+path for harness-run and single-implementer teams; **`parallel`** turns on
+worktree-per-[task] + task-branch isolation and is required the moment two
+implementers can work at once. See `reference/orchestration.md` → *Execution
+modes*, including the checklist to validate before you parallelize.
 
 ---
 
@@ -160,10 +169,10 @@ why the many specialized preset-team roles need no per-role keys — set
 `TEAM_DEFAULT_CMD` once and only override the roles you want on a different model.
 
 > ⚠️ **Safety:** those templates use auto-approve flags (`acceptEdits`,
-> `--full-auto`, `--yolo`) so agents can work unattended. Each implementer is
-> isolated in its own git worktree and only the integrator merges — but still run
-> teams on a branch you can throw away, and review the tracker before merging to
-> your main branch.
+> `--full-auto`, `--yolo`) so agents can work unattended. Only the integrator
+> commits, and with `EXECUTION=parallel` each implementer is additionally
+> isolated in its own git worktree — but still run teams on a branch you can
+> throw away, and review the tracker before merging to your main branch.
 
 ---
 
@@ -224,7 +233,7 @@ needs nothing).
 | Section | Keys | Purpose |
 |---|---|---|
 | Role → command | `TEAM_LEAD_CMD`, `PRINCIPAL_ARCHITECT_CMD`, `INTEGRATOR_CMD`, `BACKEND_CMD`, `FRONTEND_CMD`, `QA_CMD`, `REVIEWER_CMD`, `TEAM_DEFAULT_CMD` | Which CLI runs each role ([see above](#multi-agent-teams--map-each-role-to-a-cli-command)) |
-| Coordination | `TEAMWORK_ROOT` (`.teamwork`), `POLL_INTERVAL_SECONDS` (120), `STUCK_AFTER_MINUTES` (15), `ESCALATE_AFTER_ATTEMPTS` (2), `TRACKER_WRITERS` (`all`) | Timing of the lead's supervision loop; `TRACKER_WRITERS=lead` enables single-writer ("scribe") mode — only the lead holds tracker credentials and posts on the team's behalf |
+| Coordination | `TEAMWORK_ROOT` (`.teamwork`), `POLL_INTERVAL_SECONDS` (120), `STUCK_AFTER_MINUTES` (15), `ESCALATE_AFTER_ATTEMPTS` (2), `TRACKER_WRITERS` (`all`), `EXECUTION` (`sequential`) | Timing of the lead's supervision loop; `TRACKER_WRITERS=lead` enables single-writer ("scribe") mode — only the lead holds tracker credentials and posts on the team's behalf; `EXECUTION=parallel` turns on worktree-per-[task] isolation, required for ≥2 concurrent implementers |
 | Validation | `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT`, `VALIDATE_SCRIPT` | Your stack's commands; the integrator runs them before every merge (`null` = skip). `VALIDATE_SCRIPT` replaces the three with one repo-owned script that receives the changed-file list |
 
 Point the `VALIDATE_*` commands at your real build/test/lint (e.g.
@@ -279,7 +288,7 @@ Just talk to your agent in the generic vocabulary:
 | `start <team> <featureId> <role>…` | Launch specific roles (custom teams) |
 | `relaunch <team> <featureId> <role> [preset]` | Restart one crashed/wedged agent |
 | `compose <team> <featureId> <role> [preset]` | Write a role's startup prompt **without spawning** — for running teammates as subagents inside your own harness (see `reference/orchestration.md` → *Harness mode*) |
-| `worktree <team> <role> <taskId>` | Create an implementer's isolated worktree |
+| `worktree <team> <role> <taskId>` | Create an implementer's isolated worktree (parallel execution) |
 | `status <team>` | Show each agent's state + last heartbeat |
 | `stop <team>` | Stop the whole team |
 
@@ -291,7 +300,8 @@ their native tools instead.
 
 **The flow every team follows:** the Principal Architect leads (plans with the
 Product Manager, gates each `[task]`'s design before any code, reviews
-architecture) → specialists implement in isolated worktrees → the **Senior QA
+architecture) → specialists implement in their working copies (isolated
+worktrees in parallel execution) → the **Senior QA
 Engineer is the final review gate** → the integrator merges and marks
 `[Ready to deploy]` (commit and the move are one atomic step). The lead detects
 stuck/conflicting/crashed agents and unblocks them — message → decide → reassign →
@@ -346,7 +356,8 @@ source of truth:
    claims = status transitions · coordination = structured comments
                        ▲ via the adapter port ▲
  architect (leads) ── product manager ── engineers ── QA (final gate) ── integrator (commits)
-                         └──── one git worktree per implementer ────┘
+                         └── one working copy per implementer ──┘
+                          (git worktree each in parallel execution)
                        ▼ optional low-latency transport ▼
         .teamwork/<team>/  mailboxes · heartbeats  (degrades to tracker polling)
 ```

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -162,9 +162,22 @@ class Linear:
         self.gql('mutation($id: String!, $body: String!) { commentCreate(input: {issueId: $id, body: $body}) { success } }',
                  {'id': issue['id'], 'body': body})
 
+    def project_id(self, feature_id):
+        # The adapter's ID mapping allows a project UUID or a project name.
+        if re.fullmatch(r'[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}', feature_id.lower()):
+            return feature_id
+        d = self.gql('query($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id name } } }',
+                     {'name': feature_id})
+        if not d.get('projects'):
+            die("Linear returned no projects data for the name lookup — check LINEAR_API_KEY scope")
+        nodes = d['projects']['nodes']
+        if len(nodes) != 1:
+            die("Linear project named '%s': %d matches — pass the project UUID instead" % (feature_id, len(nodes)))
+        return nodes[0]['id']
+
     def export(self, feature_id):
         d = self.gql('query($id: String!) { project(id: $id) { name issues { nodes { identifier title description state { name } assignee { name } comments { nodes { body createdAt } } } } } }',
-                     {'id': feature_id})
+                     {'id': self.project_id(feature_id)})
         if not d.get('project'):
             die("no Linear project '%s'" % feature_id)
         tasks = []

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -49,12 +49,14 @@ TRACKER_WRITERS=all              # all = every role writes to the tracker itself
                                  # lead = single-writer mode: only the team-lead holds
                                  # credentials and posts on the team's behalf
                                  # (reference/orchestration.md → "Tracker write modes")
-EXECUTION=sequential             # sequential = one [task] [Active] at a time; implementers
-                                 # edit the feature-branch checkout directly, the integrator
-                                 # commits in place — no task branches, no worktrees.
+EXECUTION=sequential             # sequential = one [task] in flight at a time; it reserves the
+                                 # feature-branch checkout from claim until integration (a [task]
+                                 # in [Review] still owns it), claims are dispatched by the
+                                 # team-lead (no self-claiming), the integrator commits in
+                                 # place — no task branches, no worktrees.
                                  # parallel = worktree-per-[task] + task branches + integrator
-                                 # merge; REQUIRED the moment >=2 implementers can be [Active]
-                                 # at once (reference/orchestration.md → "Execution modes")
+                                 # merge; REQUIRED the moment >=2 implementers should work
+                                 # concurrently (reference/orchestration.md → "Execution modes")
 ```
 
 Review depth (`REVIEW_MODE=sequential|parallel|tiered`) is a **per-team** choice

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -49,6 +49,12 @@ TRACKER_WRITERS=all              # all = every role writes to the tracker itself
                                  # lead = single-writer mode: only the team-lead holds
                                  # credentials and posts on the team's behalf
                                  # (reference/orchestration.md → "Tracker write modes")
+EXECUTION=sequential             # sequential = one [task] [Active] at a time; implementers
+                                 # edit the feature-branch checkout directly, the integrator
+                                 # commits in place — no task branches, no worktrees.
+                                 # parallel = worktree-per-[task] + task branches + integrator
+                                 # merge; REQUIRED the moment >=2 implementers can be [Active]
+                                 # at once (reference/orchestration.md → "Execution modes")
 ```
 
 Review depth (`REVIEW_MODE=sequential|parallel|tiered`) is a **per-team** choice

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -158,14 +158,19 @@ up front, or the [tasks] share contracts that must not fork — run the gates as
 one batch instead:
 
 1. **One `[design-note]` per [task]**, written against the real codebase (not the
-   [task] text alone), each registering its exports in the contract registry
-   (`reference/orchestration.md` → *Contract registry*, team mode).
+   [task] text alone). Registering exports in the contract registry
+   (`reference/orchestration.md` → *Contract registry*, team mode) is part of
+   **writing** the note — when notes are produced by parallel planners, the
+   registry is the only shared surface between them, so a note that defers
+   registration defeats the pass.
 2. **Cross-[task] consistency review first.** The reviewer of the set (the
    principal-architect in team mode; you, wearing that hat, in single-agent mode)
    reads the **full set before verdicts**, checking sibling notes against each
    other and the registry — contract forks between parallel plans are the
    highest-value findings and are invisible note-by-note. Cross-cutting rulings
    are binding and recorded once, referenced by each affected [task].
+   **Gate condition:** no plan is approved while its exports are unregistered or
+   a consumed sibling name lacks a registry citation.
 3. **Per-[task] verdicts** — `[design-approved]` (with conditions) or
    `[design-pushback]`, exactly as in the normal gate.
 4. **Scope sign-off per [task]** where a product owner exists —

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -123,12 +123,20 @@ implementers, a CLI process for a long-lived reviewer.
 the team runs. It changes **where code is written and how integration commits** —
 nothing else: markers, gates, reviews, and statuses are identical in both modes.
 
-- **`sequential` (default).** Exactly one [task] is `[Active]` at a time.
-  Implementers edit the feature-branch checkout directly; the integrator
-  verifies, stages, validates, and commits **in place** — no task branches, no
-  worktrees, no merge step. One writer at a time needs no isolation; per-task
-  branches would be pure overhead. This is the proven path for harness-run,
-  single-implementer teams.
+- **`sequential` (default).** Exactly one [task] is **in flight** at a time,
+  and it **reserves the shared checkout from claim until its atomic
+  commit+move to the terminal status** — not merely while `[Active]`. A [task]
+  in `[Review]` (or bounced back for rework) still owns the checkout: its
+  uncommitted diff sits there until the integrator commits it. Implementers
+  edit the feature-branch checkout directly; the integrator verifies, stages,
+  validates, and commits **in place** — no task branches, no worktrees, no
+  merge step. Because agents checking tracker state before claiming is not
+  atomic across [tasks], sequential claiming is **lead-dispatched**: the
+  team-lead (owner of `[Planned]`) sends one assignment at a time and sends
+  the next only after the previous [task] integrated — implementers never
+  self-claim in this mode. One serialized writer needs no isolation; per-task
+  branches would be pure overhead. This is the proven path for harness-run
+  teams.
 - **`parallel`.** Required the moment two implementers can be `[Active]` at
   once. The full isolation machinery applies: one worktree + task branch per
   [task] (`bin/launch-team.sh worktree`), the integrator merges serially in
@@ -245,7 +253,7 @@ one that performs its outbound transitions.
 ## Claiming a [task]
 
 1. Read the [task] in full via the adapter (description, [subtasks], all comments).
-2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox. Under `EXECUTION=sequential`, additionally verify **no [task] is `[Active]` on any track** — one at a time is the mode's whole safety story; if one is `[Active]`, wait for it to integrate before claiming.
+2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox. Under `EXECUTION=sequential`, you claim only on the team-lead's assignment (never self-serve — see *Execution modes*), and before touching anything verify **the shared checkout is free**: no [task] anywhere is in flight (`[Active]` **or** `[Review]` — a [task] in review still owns the checkout until integrated), and `git status --porcelain -uall` on the feature-branch checkout is clean. Dirty checkout or an in-flight [task] → don't claim; tell the lead.
 3. Set assignee = your role name AND move `[Planned] → [Active]` (one adapter write
    where the tool allows, else assignee first).
 4. **Read back.** If the assignee is not you, another agent won — back off silently
@@ -391,7 +399,8 @@ files reaching review as if they were deliberate is exactly how a relaunch
 contaminates a [task]. Before the replacement starts, the lead quarantines the
 residue: parallel execution — move the dead instance's worktree aside and let the
 successor recreate it; sequential — `git stash -u` on the feature-branch
-checkout. The successor then rules **explicitly**, as a comment on the [task]:
+checkout (safe to attribute wholesale: the checkout-reservation rule means the
+only uncommitted work there is the dead instance's own [task]). The successor then rules **explicitly**, as a comment on the [task]:
 **salvage** (restore the quarantined changes and justify every kept file against
 the approved `[design-note]`) or **discard** (drop them and redo from the tracker
 trail). Since implementers don't commit, "start clean" always means giving up the

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -27,7 +27,7 @@ Two principles rule everything:
 ├── mailbox/<role>/NNN-<from>.md # incoming messages for <role>, numbered, append-only
 ├── heartbeats/<role>            # one line: <ISO-8601 UTC> | <taskId or -> | <state>
 ├── pids/<role>.pid              # process id when launched in background mode
-├── worktrees/<role>-<taskId>/   # implementer working copies
+├── worktrees/<role>-<taskId>/   # implementer working copies (parallel execution only)
 ├── CONTRACTS.md                 # append-only registry of names plans export/consume (see "Contract registry")
 ├── BASELINE.md                  # known state of the branch at creation: test counts, known failures, validation commands (see "Baseline manifest")
 ├── review-ledger.md             # reviewers' one-line-per-ruling ledger of still-live conditions
@@ -80,8 +80,11 @@ a run: signatures are grep keys.
 **You never go idle without first delivering your current structured artifact**
 (`[design-note]`, `[review-request]`, a review verdict, `[andon]`, …) to the
 tracker and notifying the team-lead. Finishing the work is half the job; the
-protocol only sees what was delivered. Idle with undelivered work is a protocol
-violation — the lead treats it as **Stuck** immediately.
+protocol only sees what was delivered. This includes rework: a rework pass ends
+with a fresh `[review-request]` — fixes applied silently are undelivered work.
+Idle with undelivered work is a protocol violation — the lead treats it as
+**Stuck** immediately, and a repeat on the same assignment as grounds to
+reassign or relaunch.
 
 The launch handshake is the same contract from the lead's side:
 
@@ -108,11 +111,47 @@ it — same protocol, different transport:
 | Filesystem-degradation statement | Not needed — the harness delivers messages |
 
 Everything else is unchanged: the tracker is still the single source of durable
-truth, markers and statuses are still the protocol, worktrees still come from
-`launch-team.sh worktree`, and the *Report before idle* contract applies with the
-harness's idle notification standing in for a stale heartbeat. The two modes mix
-freely — e.g. harness subagents for implementers, a CLI process for a long-lived
-reviewer.
+truth, markers and statuses are still the protocol, worktrees (in parallel
+execution) still come from `launch-team.sh worktree`, and the *Report before
+idle* contract applies with the harness's idle notification standing in for a
+stale heartbeat. The two modes mix freely — e.g. harness subagents for
+implementers, a CLI process for a long-lived reviewer.
+
+## Execution modes — sequential by default, parallel by declaration
+
+`EXECUTION` in `config/team.config.md` names how much implementation concurrency
+the team runs. It changes **where code is written and how integration commits** —
+nothing else: markers, gates, reviews, and statuses are identical in both modes.
+
+- **`sequential` (default).** Exactly one [task] is `[Active]` at a time.
+  Implementers edit the feature-branch checkout directly; the integrator
+  verifies, stages, validates, and commits **in place** — no task branches, no
+  worktrees, no merge step. One writer at a time needs no isolation; per-task
+  branches would be pure overhead. This is the proven path for harness-run,
+  single-implementer teams.
+- **`parallel`.** Required the moment two implementers can be `[Active]` at
+  once. The full isolation machinery applies: one worktree + task branch per
+  [task] (`bin/launch-team.sh worktree`), the integrator merges serially in
+  dependency order, and same-file collisions are handed back to the implementer
+  for rebase.
+
+Deliberately **not** mode-dependent: `TRACKER_WRITERS=lead` stays the
+recommended write path under parallelism (more concurrent writers means more
+races, not fewer), and QA's last-in-time `[review-approval]` remains a
+serialized final gate no matter how many implementers run.
+
+**Before switching to `parallel`, validate the machinery once** — docs are not
+evidence, and a sequential run proves nothing about it:
+
+1. `bin/launch-team.sh worktree` creates a usable isolated tree in *your*
+   environment (harness subagents included) and an implementer can build and
+   test inside it.
+2. Deliberately collide two task branches on one file and confirm the
+   integrator merges the first and hands the second back for rebase — never
+   resolving the conflict itself.
+3. The contract registry is populated **during** planning (see *Contract
+   registry*): worktrees isolate code-in-progress; only the registry prevents
+   the plan-time contract forks that parallel planning actually produces.
 
 ## Structured comments — the coordination markers
 
@@ -151,7 +190,10 @@ is an **append-only registry**:
   question for the principal-architect, not a guess.
 - The principal-architect's reviews (batch or per-[task]) **diff plans against
   the registry** — two [tasks] spelling the same concept differently is a
-  `[design-pushback]` on the later one, caught before code exists.
+  `[design-pushback]` on the later one, caught before code exists. Unregistered
+  exports or an uncited consumed name are themselves `[design-pushback]`
+  grounds: the registry only prevents forks if it is populated **while plans are
+  being written**, not reconstructed afterwards.
 - Renames are new lines that supersede old ones (`supersedes: <line>`), never
   edits — the history is the audit trail.
 
@@ -203,13 +245,15 @@ one that performs its outbound transitions.
 ## Claiming a [task]
 
 1. Read the [task] in full via the adapter (description, [subtasks], all comments).
-2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox.
+2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox. Under `EXECUTION=sequential`, additionally verify **no [task] is `[Active]` on any track** — one at a time is the mode's whole safety story; if one is `[Active]`, wait for it to integrate before claiming.
 3. Set assignee = your role name AND move `[Planned] → [Active]` (one adapter write
    where the tool allows, else assignee first).
 4. **Read back.** If the assignee is not you, another agent won — back off silently
    and pick the next `[Planned]` [task] on your track.
-5. Create your worktree: `bin/launch-team.sh worktree <team> <role> <taskId>`
-   (roles that write code only).
+5. Set up your working copy (roles that write code only). `EXECUTION=parallel`:
+   create your worktree — `bin/launch-team.sh worktree <team> <role> <taskId>`.
+   `EXECUTION=sequential`: work in the feature-branch checkout directly; there
+   is no worktree and no task branch (see *Execution modes*).
 
 One implementer per [task], ever. Claiming is the lock.
 
@@ -217,7 +261,8 @@ One implementer per [task], ever. Claiming is the lock.
 
 ```
 claim → [design-note] → wait for [design-approved]      (no code before the gate)
-      → implement in your worktree                       ([divergence] comments as needed)
+      → implement in your working copy                   ([divergence] comments as needed)
+        (worktree in parallel execution; feature-branch checkout in sequential)
       → self-validate (VALIDATE_SCRIPT or the VALIDATE_* that apply; bar =
         no new failures vs BASELINE.md)
       → [review-request] + move to [Review]
@@ -226,7 +271,8 @@ claim → [design-note] → wait for [design-approved]      (no code before the 
       → [review-approval] + [architecture-approval] (both, with file lists)
       → integrator: verify lists == diff, stage explicitly, validate
         (VALIDATE_SCRIPT or VALIDATE_*, judged against BASELINE.md),
-        merge to the feature branch, commit, move to [Ready to deploy] (atomic pair)
+        merge to the feature branch (parallel execution only), commit,
+        move to [Ready to deploy] (atomic pair)
       → principal-architect divergence sweep updates upcoming [tasks]
 ```
 
@@ -263,7 +309,9 @@ even from the team-lead):
    full changed-file set — `git diff --name-only <feature-branch>...HEAD` plus
    `git status --porcelain -uall` for uncommitted work (always `-uall`: plain
    porcelain hides the files inside a new directory), run from inside the
-   [task]'s worktree. Any mismatch → `[andon]`.
+   [task]'s worktree (parallel execution) or the feature-branch checkout
+   (sequential — the changed set is just the uncommitted work). Any mismatch →
+   `[andon]`.
 2. Stage by explicit file list (never `add -A`), verify the staged set matches.
    Index-only operations (untracking a file) are the implementer's one sanctioned
    staging exception — allowed only when named in the `[review-request]`.
@@ -271,7 +319,9 @@ even from the team-lead):
    `VALIDATE_BUILD`, `VALIDATE_TEST`, `VALIDATE_LINT` (skip `null` ones, record
    skips). Judge against `BASELINE.md`: the bar is no NEW failures. Any new
    failure → `[andon]`, task back to `[Active]`.
-4. Merge the task branch into the feature branch; remove the worktree.
+4. Parallel execution only: merge the task branch into the feature branch;
+   remove the worktree. (Sequential: nothing to merge — the staged work already
+   sits on the feature-branch checkout.)
 5. Commit, capture the hash, then immediately move the [task] to `[Ready to deploy]`,
    citing the hash. Commit and completion are one atomic pair — never one without
    the other.
@@ -301,8 +351,10 @@ Unblock ladder — in order, one rung at a time:
    to the principal-architect, whose ruling is final.
 3. **Reassign** — `[handoff]` comment summarizing state, move the [task] back to
    `[Planned]`, clear the assignee, relaunch a fresh agent for it.
-4. **Kill & relaunch** — `bin/launch-team.sh relaunch <team> <featureId> <role>`.
-   The replacement resumes from tracker state alone.
+4. **Kill & relaunch** — quarantine the dead instance's working copy first (see
+   *Recovery* → *Relaunch hygiene*), then
+   `bin/launch-team.sh relaunch <team> <featureId> <role>` (or respawn in the
+   harness). The replacement resumes from tracker state alone.
 5. **Escalate** — `[escalation]` comment + append to `ESCALATIONS.md`. Reserved for
    scope/business-rule questions, destructive actions, or after
    `ESCALATE_AFTER_ATTEMPTS` failed rungs.
@@ -312,18 +364,39 @@ veto — the andon cord outranks the Lead. During autonomous operation the Lead 
 blocks the team on an interactive user prompt; escalation is the channel.
 
 **Idle-notification hygiene.** Heartbeats and harness idle pings are liveness
-signals, not events. Act on exactly two things: (a) an artifact arrived — process
-it; (b) idle **without** the artifact you are waiting for — Stuck, rung 1 now.
-Everything else (routine idle pings, repeated heartbeats, "still working" noise)
-gets no reply and no acknowledgment — answering it burns your turns and everyone
-else's context.
+signals, not events. The lead's test is mechanical: *did the teammate's last
+message/comment for its current assignment carry the expected marker artifact?*
+Act on exactly two things: (a) an artifact arrived — process it; (b) idle
+**without** it — that is a delivery-contract violation, not a heartbeat: Stuck,
+rung 1 now, demanding the artifact by name. A **second** artifact-less idle on
+the same assignment means the instance is not executing the protocol — skip to
+rung 3/4 (reassign or relaunch); do not keep nudging. Everything else (routine
+idle pings, repeated heartbeats, "still working" noise) gets no reply and no
+acknowledgment — answering it burns your turns and everyone else's context.
+An idle ping is never a completion signal; only the artifact is.
 
 ## Recovery
 
 Relaunched or restarted agents need no session state: read your role brief, query
 the tracker for [tasks] assigned to your role in any non-terminal status, read the
-comment trail (design note, approvals, findings), check your worktree, resume at the
-pipeline stage the comments prove you reached. If the trail is ambiguous → `[andon]`.
+comment trail (design note, approvals, findings), check your working copy, resume
+at the pipeline stage the comments prove you reached. If the trail is ambiguous →
+`[andon]`.
+
+### Relaunch hygiene
+
+A killed or unresponsive instance may have left uncommitted
+writes in its working copy; a successor must never inherit them silently — orphan
+files reaching review as if they were deliberate is exactly how a relaunch
+contaminates a [task]. Before the replacement starts, the lead quarantines the
+residue: parallel execution — move the dead instance's worktree aside and let the
+successor recreate it; sequential — `git stash -u` on the feature-branch
+checkout. The successor then rules **explicitly**, as a comment on the [task]:
+**salvage** (restore the quarantined changes and justify every kept file against
+the approved `[design-note]`) or **discard** (drop them and redo from the tracker
+trail). Since implementers don't commit, "start clean" always means giving up the
+dead instance's work — that trade is the successor's call to make on the record,
+never an accident of inheritance.
 
 ## Andon cord
 
@@ -337,7 +410,7 @@ never fabricate a result, never claim a status you did not verify.
 | Capability | Needed by | If missing |
 |---|---|---|
 | File read/write | all | — (hard requirement) |
-| Shell + git | all; worktrees for implementers | — (hard requirement) |
+| Shell + git | all; worktrees for implementers (parallel execution) | — (hard requirement) |
 | Tracker access (adapter: MCP, REST + API key, CLI, or files) | all | use another mechanism from the adapter's *Access mechanisms*; never fabricate |
 | Shared filesystem with the team | mailbox/heartbeats | poll the tracker; say so once on your [task] |
 | Harness-native teammates (subagent spawn + messaging) | harness mode | launch CLI processes via `bin/launch-team.sh` (tmux / background) |

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -8,6 +8,8 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
 ## Loop
 
 1. **Claim** the next `[Planned]` backend [task] (protocol: *Claiming a [task]*).
+   `EXECUTION=sequential`: claim only the [task] the team-lead's assignment
+   message names — never self-claim — and only with the shared checkout free.
    Set up your working copy per `EXECUTION` (protocol: *Execution modes*) —
    `parallel`: create your worktree with
    `bin/launch-team.sh worktree <team> backend <taskId>`; `sequential`: work in
@@ -35,7 +37,11 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
    numbered item in your working copy, then `[review-request]` again. Only the
    integrator completes the [task].
 8. Update your heartbeat between steps; check your mailbox between steps. Then
-   claim the next [task].
+   claim the next [task] — in `sequential` execution, only after the integrator
+   has moved your current [task] to its terminal status **and** the lead has
+   sent the next assignment: your uncommitted diff owns the shared checkout
+   until it is committed, so claiming during `[Review]` would stack a second
+   [task]'s edits on top of it.
 
 ## You never
 

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -8,12 +8,15 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
 ## Loop
 
 1. **Claim** the next `[Planned]` backend [task] (protocol: *Claiming a [task]*).
-   Create your worktree: `bin/launch-team.sh worktree <team> backend <taskId>`.
+   Set up your working copy per `EXECUTION` (protocol: *Execution modes*) —
+   `parallel`: create your worktree with
+   `bin/launch-team.sh worktree <team> backend <taskId>`; `sequential`: work in
+   the feature-branch checkout directly.
 2. **Design gate.** Post a `[design-note]`: approach, API/contract changes,
    data-model changes, affected components. Ping the principal-architect by
    mailbox. **Write no code until `[design-approved]`.** On `[design-pushback]`,
    revise and re-ping.
-3. **Implement** in your worktree only, following the approved note and its
+3. **Implement** in your working copy only, following the approved note and its
    conditions. The [task]'s [subtasks] are your checklist. Anything you must do
    differently → `[divergence]` comment at the moment you diverge (never edit the
    [task] description). New out-of-scope work you discover → Scenario 6: file it
@@ -29,14 +32,16 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
    list, validation results), move the [task] to `[Review]`, ping `reviewer` and
    `principal-architect` by mailbox.
 7. **Rework.** On `[review-findings]`, the [task] returns to `[Active]`; fix every
-   numbered item in your worktree, then `[review-request]` again. Only the
+   numbered item in your working copy, then `[review-request]` again. Only the
    integrator completes the [task].
 8. Update your heartbeat between steps; check your mailbox between steps. Then
    claim the next [task].
 
 ## You never
 
-- Write code before `[design-approved]`, or outside your worktree.
+- Write code before `[design-approved]`, or outside your working copy (your
+  [task]'s worktree in parallel execution; the feature-branch checkout in
+  sequential).
 - Merge, commit to the feature branch, or change any status except
   `[Planned]→[Active]` (claim), `[Active]→[Review]` (request review),
   `[Active]→[Blocked]` (stuck — with a comment saying what would unblock; the

--- a/roles/frontend.md
+++ b/roles/frontend.md
@@ -1,8 +1,8 @@
 # Role: frontend
 
 You are a **frontend implementer**. Identical loop to `roles/backend.md` — claim,
-design gate, implement in your worktree, self-validate, `[review-request]`, rework
-— with these differences:
+design gate, implement in your working copy, self-validate, `[review-request]`,
+rework — with these differences:
 
 ## Frontend-specific rules
 
@@ -21,7 +21,8 @@ design gate, implement in your worktree, self-validate, `[review-request]`, rewo
    your [task] back: comment, move `[Review]→[Active]` (rework, per the board's
    transitions), adapt, re-request review.
 
-Everything else — claiming, worktree via
-`bin/launch-team.sh worktree <team> frontend <taskId>`, `[divergence]` discipline,
+Everything else — claiming, the working copy per `EXECUTION` (worktree via
+`bin/launch-team.sh worktree <team> frontend <taskId>` in parallel execution;
+the feature-branch checkout in sequential), `[divergence]` discipline,
 never editing descriptions, never completing, andon — is exactly the protocol and
 the backend brief's *You never* list.

--- a/roles/integrator.md
+++ b/roles/integrator.md
@@ -14,8 +14,14 @@ in the tracker are the only trigger that counts.
 
 ## Pipeline (run exactly, in order)
 
-1. In the [task]'s worktree (`<TEAMWORK_ROOT>/<team>/worktrees/<role>-<taskId>` (derive `<role>` from the [task]'s assignee)),
-   compute the full changed-file set: `git diff --name-only <feature-branch>...HEAD`
+Your working location follows `EXECUTION` (protocol: *Execution modes*):
+`parallel` — the [task]'s worktree
+(`<TEAMWORK_ROOT>/<team>/worktrees/<role>-<taskId>`, `<role>` from the [task]'s
+assignee); `sequential` — the feature-branch checkout, where step 6's merge and
+worktree removal don't exist (the staged work is already on the branch).
+
+1. In the working location, compute the full changed-file set:
+   `git diff --name-only <feature-branch>...HEAD`
    **plus** `git status --porcelain -uall` for anything uncommitted. Always `-uall`:
    plain porcelain collapses a new directory to one `dir/` line and hides every
    file inside it — naive list equality would then pass or fail wrongly.
@@ -41,11 +47,12 @@ in the tracker are the only trigger that counts.
    to `[Active]`; notify the implementer by mailbox.
 5. Re-check the diff — if any approved file changed during validation, stop and
    require fresh approvals.
-6. Merge the task branch into the feature branch; remove the worktree
-   (`git worktree remove`).
+6. Parallel execution only: merge the task branch into the feature branch;
+   remove the worktree (`git worktree remove`). Sequential: skip — nothing to
+   merge.
 7. Commit. Capture the hash (`git rev-parse HEAD`).
 8. **Immediately** move the [task] to `[Ready to deploy]` via the adapter, with a comment
-   citing the commit hash, the validations run (and skips), and the merged files.
+   citing the commit hash, the validations run (and skips), and the committed files.
    Commit + completion are one atomic pair — never leave one without the other; if
    the status write fails, `[andon]` loudly before doing anything else.
 9. Notify the team-lead and principal-architect by mailbox: taskId, hash, results, and `qa` if QA [tasks] exist.

--- a/roles/qa.md
+++ b/roles/qa.md
@@ -4,15 +4,16 @@ You are the **qa implementer**. You write and run tests — you never fix produc
 code. QA work is tracked as ordinary [tasks] (created in planning or via
 Scenario 6) and flows through the exact same pipeline: claim → `[design-note]`
 (your note is a **test plan**: what you will test, at which level, which cases) →
-`[design-approved]` → implement in your worktree
-(`bin/launch-team.sh worktree <team> qa <taskId>`) → self-validate →
+`[design-approved]` → implement in your working copy (parallel execution: your
+worktree via `bin/launch-team.sh worktree <team> qa <taskId>`; sequential: the
+feature-branch checkout) → self-validate →
 `[review-request]` → rework → integrator completes.
 
 ## QA-specific rules
 
 1. **Test merged work.** Run against the feature branch state the integrator has
-   assembled, not against an implementer's unmerged worktree — you verify what
-   will actually ship.
+   assembled, not against an implementer's unintegrated working copy — you
+   verify what will actually ship.
 2. **Bugs are [tasks], never patches.** A defect in product code → Scenario 6:
    create a new `[Planned]` [task] on the owning track with reproduction steps,
    expected vs. actual, and severity; mailbox the team-lead. Never fix product

--- a/roles/reviewer.md
+++ b/roles/reviewer.md
@@ -21,15 +21,19 @@ and permission check into your own numbered checklist. Write down the files you
 requirements, not from the diff.
 
 **Phase 2 — Review.** Read the `[review-request]`'s file list, then every changed
-file in the worktree, fully, line by line. Check your Phase-1 items, correctness,
+file in the implementer's working copy, fully, line by line. Check your Phase-1 items, correctness,
 tests (do they test the rule, or just execute the code?), naming, error handling.
 Send problems immediately as one `[review-findings]` comment with numbered items —
 the [task] goes back to `[Active]`; the implementer fixes and re-requests. On approval, your `[review-approval]` (plus the architecture approval) hands the [task] to the integrator, who performs the atomic commit + move to `[Ready to deploy]`.
 
 **Phase 3 — Verify.** On re-review: re-read every fixed file. Every Phase-1
 checklist item needs a `file:line` citation for the implementation AND a citation
-for the test that proves it. Compare the final file list against
-`git diff --name-only <feature-branch>...HEAD` in the worktree (the worktree is `<TEAMWORK_ROOT>/<team>/worktrees/<assignee-role>-<taskId>`; the [task]'s assignee names the role) — they must match.
+for the test that proves it. Compare the final file list against the actual
+changed set in the implementer's working copy — in parallel execution that is
+`git diff --name-only <feature-branch>...HEAD` plus `git status --porcelain
+-uall` inside `<TEAMWORK_ROOT>/<team>/worktrees/<assignee-role>-<taskId>` (the
+[task]'s assignee names the role); in sequential execution it is
+`git status --porcelain -uall` on the feature-branch checkout — they must match.
 Then write `[review-approval]` with the explicit list of approved file paths.
 
 ## Anti-rationalization — reject all of these

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -57,7 +57,9 @@ rungs on the same problem, escalate.
 
 Idle pings are liveness, not events: act only when an artifact arrives or when a
 teammate is idle **without** the artifact you're waiting for (that's Stuck —
-immediately, no `STUCK_AFTER_MINUTES` wait). Ignore the rest.
+immediately, no `STUCK_AFTER_MINUTES` wait; a second artifact-less idle on the
+same assignment → skip to reassign/relaunch). An idle ping is never a completion
+signal. Ignore the rest.
 
 Deadlocks: if A waits on B and B waits on A, you break it — pick the order, tell
 both agents by mailbox, record the decision on both [tasks].
@@ -66,8 +68,8 @@ both agents by mailbox, record the decision on both [tasks].
 
 Declare the [feature] `[Resolved]` only when ALL of:
 - every [task] is `[Ready to deploy]` with a commit hash cited;
-- the integrator confirms the feature branch is clean (no unmerged worktrees,
-  validations green);
+- the integrator confirms the feature branch is clean (validations green; in
+  parallel execution additionally: no unmerged worktrees);
 - the principal-architect confirms its final divergence sweep found nothing new;
 - no `[andon]` or `[escalation]` is unresolved.
 

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -46,6 +46,14 @@ governs everything below; this brief only says what is *yours*.
    every launch or relaunch, send each teammate an explicit assignment message
    naming the [task] or gate to act on and the artifact you expect back. Nobody
    works from the spawn prompt alone.
+8. **Sequential execution: you are the claim dispatcher.** Under
+   `EXECUTION=sequential`, implementers never self-claim — you send exactly one
+   implementation assignment at a time, and the next only after the current
+   [task]'s atomic commit+move lands (not after `[review-request]`: a [task] in
+   `[Review]` still owns the shared checkout). Before dispatching, confirm the
+   checkout is clean (`git status --porcelain -uall`). This single dispatch
+   point is what makes one-at-a-time atomic across agents — two implementers
+   reading the tracker "simultaneously" cannot race a claim you never issued.
 
 ## Phase 2 — Supervise
 

--- a/teams/README.md
+++ b/teams/README.md
@@ -26,10 +26,16 @@ is the final review gate** before the standard `integrator` merges.
    it, so you don't need a key per role. Add `<ROLE>_CMD` (e.g.
    `SENIOR_STAFF_ENGINEER_CMD`) only to pin a specific CLI to a specific role; set
    it explicitly to `null` to disable the role (a `team` launch skips it). Pick
-   `EXECUTION` too: `sequential` (default, one [task] at a time, no worktrees)
-   or `parallel` — required before two implementers may be `[Active]` at once,
-   and only after the before-you-parallelize checklist in
-   `reference/orchestration.md` → *Execution modes* has passed.
+   `EXECUTION` too: `sequential` (default — one [task] in flight at a time,
+   reserving the shared checkout until integration, with claims dispatched by
+   the lead; no worktrees) or `parallel` — required the moment you want two
+   implementers working concurrently, and only after the before-you-parallelize
+   checklist in `reference/orchestration.md` → *Execution modes* has passed.
+   Presets whose rosters carry more than one implementation-capable role (e.g.
+   Deep Infra's cloud + SRE engineers, Deep Security's engineer + pen-tester)
+   are still safe under `sequential` **because** claims come only from the
+   lead's single dispatch point — but they work one at a time; choose
+   `parallel` to actually use them concurrently.
 2. Launch the whole roster:
 
    ```bash

--- a/teams/README.md
+++ b/teams/README.md
@@ -25,7 +25,11 @@ is the final review gate** before the standard `integrator` merges.
    `TEAM_DEFAULT_CMD` — roles with no `<ROLE>_CMD` key of their own fall back to
    it, so you don't need a key per role. Add `<ROLE>_CMD` (e.g.
    `SENIOR_STAFF_ENGINEER_CMD`) only to pin a specific CLI to a specific role; set
-   it explicitly to `null` to disable the role (a `team` launch skips it).
+   it explicitly to `null` to disable the role (a `team` launch skips it). Pick
+   `EXECUTION` too: `sequential` (default, one [task] at a time, no worktrees)
+   or `parallel` — required before two implementers may be `[Active]` at once,
+   and only after the before-you-parallelize checklist in
+   `reference/orchestration.md` → *Execution modes* has passed.
 2. Launch the whole roster:
 
    ```bash

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -44,13 +44,17 @@ is context, not a trigger.
    before approval.
 
    *Pre-flight variant (lifecycle Scenario 10):* when the plan should be settled
-   before any code, run all design gates as one batch — notes for every [task],
+   before any code, run all design gates as one batch — notes for every [task]
+   (each registering its exports in the contract registry **as it is written**),
    the architect's cross-[task] consistency review first (diffing the set against
-   the contract registry), then per-[task] verdicts and TPM scope sign-offs. At
-   claim time each gate is already open.
-4. **Implementation.** Own worktree per implementer, the [task]'s [subtasks] as
-   checklist, `[divergence]` comments for every deviation, self-validation with
-   the `VALIDATE_*` commands before requesting review.
+   the registry; unregistered exports or uncited imports block approval), then
+   per-[task] verdicts and TPM scope sign-offs. At claim time each gate is
+   already open.
+4. **Implementation.** Own working copy per implementer (a per-[task] worktree
+   under `EXECUTION=parallel`; the feature-branch checkout under `sequential`),
+   the [task]'s [subtasks] as checklist, `[divergence]` comments for every
+   deviation, self-validation with the `VALIDATE_*` commands before requesting
+   review.
 5. **Review — in this order:**
    1. **Architect** — architecture review → `[architecture-approval]`.
    2. **Team-specific specialist reviews** (listed in the team file, if any).
@@ -128,7 +132,8 @@ Report back: [review-request] with changed-file list, validation results, and
 
 ```
 Re: <taskId>  (mode: <sequential|parallel|tiered>)
-Diff: <files changed, one-line summary> (worktree: <path>)
+Diff: <files changed, one-line summary> (working copy: <worktree path, or
+        "feature-branch checkout" in sequential execution>)
 Rule on: <open [divergence]s awaiting a ruling, or "none">
 Check: approved [design-note] conditions <pointer>; review-ledger.md lines that
         apply; CONTRACTS.md exports this [task] registered or consumes

--- a/teams/roles/senior-cloud-engineer.md
+++ b/teams/roles/senior-cloud-engineer.md
@@ -11,7 +11,7 @@ status write (claim, design gate, `[review-request]`, rework via
 
 ## Responsibilities
 
-- Claim [tasks] one at a time and implement the full change in your own worktree.
+- Claim [tasks] one at a time and implement the full change in your own working copy.
 - Post a `[design-note]` covering approach, IaC module and provider changes,
   pipeline impact, affected environments, `Architectural impact: yes/no`, and —
   **mandatory** — the **rollback strategy** and **blast radius**. The architect
@@ -53,7 +53,7 @@ status write (claim, design gate, `[review-request]`, rework via
 ## You never
 
 - Write IaC or pipeline configuration before `[design-approved]`, or outside your
-  worktree.
+  working copy.
 - Submit a `[review-request]` without a plan or preview output attached.
 - Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Omit rollback strategy or blast radius from a `[design-note]`.

--- a/teams/roles/senior-frontend-engineer.md
+++ b/teams/roles/senior-frontend-engineer.md
@@ -13,7 +13,7 @@ back to `[Active]` and post a `[divergence]`.
 
 ## Responsibilities
 
-- Claim [tasks] one at a time and implement the full UI slice in your own worktree:
+- Claim [tasks] one at a time and implement the full UI slice in your own working copy:
   component implementation, state wiring, accessibility, and visual fidelity to
   the acceptance criteria.
 - Post a `[design-note]` covering component boundaries, state ownership, design-system
@@ -50,7 +50,7 @@ back to `[Active]` and post a `[divergence]`.
 
 ## You never
 
-- Write code before `[design-approved]`, or outside your worktree.
+- Write code before `[design-approved]`, or outside your working copy.
 - Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-full-stack-engineer.md
+++ b/teams/roles/senior-full-stack-engineer.md
@@ -10,7 +10,7 @@ demands; those briefs and `reference/orchestration.md` bind every status write
 
 ## Responsibilities
 
-- Claim [tasks] one at a time and implement the whole slice in your own worktree.
+- Claim [tasks] one at a time and implement the whole slice in your own working copy.
 - Post a `[design-note]` covering BOTH sides of the slice — contract, data-model
   change, UI approach, `Architectural impact: yes/no` — and wait for the
   architect's `[design-approved]` before writing code.
@@ -45,7 +45,7 @@ demands; those briefs and `reference/orchestration.md` bind every status write
 
 ## You never
 
-- Write code before `[design-approved]`, or outside your worktree.
+- Write code before `[design-approved]`, or outside your working copy.
 - Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.

--- a/teams/roles/senior-penetration-tester.md
+++ b/teams/roles/senior-penetration-tester.md
@@ -27,7 +27,7 @@ you between the architect's `[architecture-approval]` and QA's final gate.
   environment, tooling), and that every bypass attempt held. QA reads this
   before issuing the final gate.
 - For [tasks] that produce security test tooling: claim, post a `[design-note]`,
-  implement in your worktree, self-validate, and `[review-request]` — normal pipeline.
+  implement in your working copy, self-validate, and `[review-request]` — normal pipeline.
 
 ## Decision authority
 

--- a/teams/roles/senior-qa-engineer.md
+++ b/teams/roles/senior-qa-engineer.md
@@ -17,7 +17,7 @@ you as ordinary [tasks].
   `file:line` citation AND a test citation. Run the applicable `VALIDATE_*`
   suites yourself — the implementer's report is a claim, not evidence.
 - Own test [tasks]: plan (a test-plan `[design-note]`), author, and maintain the
-  team's tests in your own worktree, through the normal pipeline.
+  team's tests in your own working copy, through the normal pipeline.
 - File defects as new [tasks] (Scenario 6) with reproduction steps, expected vs.
   actual, and severity — never patch product code.
 - Push back on untestable acceptance criteria the moment you see them — an

--- a/teams/roles/senior-security-engineer.md
+++ b/teams/roles/senior-security-engineer.md
@@ -10,7 +10,7 @@ design gate, `[review-request]`, rework via `[Review]→[Active]`).
 
 ## Responsibilities
 
-- Claim [tasks] one at a time and implement the full change in your own worktree.
+- Claim [tasks] one at a time and implement the full change in your own working copy.
 - Post a `[design-note]` before writing any code. The note must state: the
   approach, affected components, API or data-model changes, and — critically —
   **which threat-model mitigation(s) this change addresses** by ID. Wait for the
@@ -50,7 +50,7 @@ design gate, `[review-request]`, rework via `[Review]→[Active]`).
 
 ## You never
 
-- Write code before `[design-approved]`, or outside your worktree.
+- Write code before `[design-approved]`, or outside your working copy.
 - Omit the threat-model mitigation reference from a `[design-note]` — an
   untraced change cannot be adversarially verified.
 - Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.

--- a/teams/roles/senior-sre-engineer.md
+++ b/teams/roles/senior-sre-engineer.md
@@ -57,7 +57,7 @@ on problems; never invent new markers.
 
 ## You never
 
-- Write configuration before `[design-approved]`, or outside your worktree.
+- Write configuration before `[design-approved]`, or outside your working copy.
 - Perform the operability review on a [task] you implemented.
 - Invent new structured markers — use only `[review-findings]` for problems; a
   plain comment for a clean pass.

--- a/teams/roles/senior-staff-engineer.md
+++ b/teams/roles/senior-staff-engineer.md
@@ -13,7 +13,7 @@ available for another team member to consume.
 ## Responsibilities
 
 - Claim [tasks] one at a time and implement domain logic, API endpoints, and
-  migrations in your own worktree.
+  migrations in your own working copy.
 - Post a `[design-note]` covering all of: contract changes, data-model changes,
   migration plan with rollback steps, and performance impact — wait for the
   architect's `[design-approved]` before writing any code.
@@ -51,7 +51,7 @@ available for another team member to consume.
 
 ## You never
 
-- Write code before `[design-approved]`, or outside your worktree.
+- Write code before `[design-approved]`, or outside your working copy.
 - Merge, commit to the feature branch, or move anything to `[Ready to deploy]` — that is the integrator's atomic commit+move.
 - Argue a QA finding away — fix it, or escalate through the architect.
 - Silently absorb out-of-scope work — Scenario 6 exists for that.


### PR DESCRIPTION
Follow-up to #3 (merged) — implements the second production-feedback round.

## What & why

Second feedback round from the other project production run (~15 [tasks] shipped through the full pipeline in harness mode). The headline ground truth: **the run used zero worktrees and zero task branches** — strictly sequential on the feature-branch checkout — and worked flawlessly, while the docs made worktrees a hard per-role requirement. The proven path was technically a protocol violation. This PR makes the docs match reality and hardens the spots the run actually hit.

### Accepted from the feedback

- **R1 — `EXECUTION=sequential|parallel`** (default `sequential`). Sequential: implementers edit the feature-branch checkout, the integrator commits in place, no task branches/worktrees, and claiming now enforces one-`[Active]`-at-a-time. Parallel: the full worktree + task-branch + merge machinery, required for ≥2 concurrent implementers. All role briefs, the claiming checklist, the pipeline diagram, integration steps, and reviewer file-list checks are conditionalized.
- **R3 — registry gating**: contract exports are registered *while* design notes are written; unregistered exports or uncited imports now block plan approval (Scenario 10 + Contract registry + playbook).
- **R4 — before-you-parallelize checklist** in *Execution modes*: validate worktree creation in your environment, the integrator's rebase-handback on a real collision, and plan-time registry population — none of which a sequential run proves.
- **R5 — delivery contract enforced**: the lead's test is mechanical (last message carries the expected marker or it's Stuck, rung 1, naming the artifact); a second artifact-less idle on the same assignment skips to reassign/relaunch; rework explicitly ends with a fresh `[review-request]`; an idle ping is never a completion signal.
- **R6 — mode-independent invariants** stated: `TRACKER_WRITERS=lead` stays recommended under parallelism, and QA's last-in-time approval remains a serialized gate.
- **Nit**: `tracker-ops.sh` Linear export now resolves a project by **name** as well as UUID (the adapter's ID mapping always allowed both).

### Adjusted (pushback): R2 — per-instance worktrees

The feedback proposed a scratch worktree per implementer *instance* even in sequential mode, to keep relaunches clean. Declined as stated: it re-adds the exact steady-state overhead R1 removes, and since implementers never commit, "start from a clean tree" silently discards the dead instance's work. Implemented instead as **relaunch hygiene** in Recovery: before a replacement starts, the lead quarantines the dead instance's uncommitted writes (worktree moved aside in parallel; `git stash -u` in sequential), and the successor rules **salvage or discard explicitly on the [task]**. Same protection against the observed INS-20 orphan-file contamination, zero cost when nothing crashes, and the destroy-work decision is deliberate instead of accidental.

## Verification

- `bash tests/launcher-test.sh` and `bash tests/tracker-ops-test.sh` → ALL PASS
- Adversarial consistency review of the diff (leftover unconditional worktree refs, sequential-path walkthrough, dangling section refs, config-key agreement, tracker-ops code read): 7 findings (2 major — a missed worktree reference in the lead's completion checklist, and the claiming checklist lacking the sequential one-at-a-time gate), all fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)