### PR TITLE
Throughput levers: review compression, design checklists, design-wait elimination, gated pipelined dispatch

### DIFF
--- a/bin/launch-team.sh
+++ b/bin/launch-team.sh
@@ -36,6 +36,18 @@ key_is_null() { # key_is_null KEY -> 0 if the config sets KEY explicitly to null
   grep -qE "^$1=null[[:space:]]*(#.*)?$" "$CONFIG"
 }
 
+validate_config() { # MAX_ACTIVE_IMPLEMENTERS is a parallel-only knob (spec: throughput levers)
+  local exec_mode max_active
+  exec_mode="$(read_key EXECUTION)"
+  max_active="$(read_key MAX_ACTIVE_IMPLEMENTERS)"
+  [ -z "$max_active" ] && return 0
+  [ "$exec_mode" = "parallel" ] || die "MAX_ACTIVE_IMPLEMENTERS is set but EXECUTION is '${exec_mode:-sequential}' — the knob only applies under EXECUTION=parallel"
+  case "$max_active" in
+    ''|*[!0-9]*) die "MAX_ACTIVE_IMPLEMENTERS must be a positive integer, got '$max_active'" ;;
+  esac
+  [ "$max_active" -ge 1 ] || die "MAX_ACTIVE_IMPLEMENTERS must be >= 1"
+}
+
 role_brief() { # role_brief <role> -> path to its brief, in roles/ or teams/roles/; empty if none
   if [ -f "$SKILL_DIR/roles/$1.md" ]; then
     printf '%s' "$SKILL_DIR/roles/$1.md"
@@ -212,6 +224,8 @@ launch_one() { # launch_one <team> <featureId> <role> [preset]
     echo "launched $role in background (pid $(cat "$dir/pids/$role.pid"))"
   fi
 }
+
+case "${1:-}" in validate-board|'') ;; *) validate_config ;; esac
 
 case "${1:-}" in
   team)

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -57,6 +57,13 @@ EXECUTION=sequential             # sequential = one [task] in flight at a time; 
                                  # parallel = worktree-per-[task] + task branches + integrator
                                  # merge; REQUIRED the moment >=2 implementers should work
                                  # concurrently (reference/orchestration.md → "Execution modes")
+MAX_ACTIVE_IMPLEMENTERS=null     # Only under EXECUTION=parallel. 1 = pipelined dispatch:
+                                 # full worktree isolation, but the team-lead dispatches
+                                 # the next [task] when the current one enters [Review]
+                                 # instead of after integration (reference/orchestration.md
+                                 # → "Execution modes"). >=2 = bounded full parallelism;
+                                 # null = unbounded parallel. Setting it under sequential
+                                 # is a config error — the launcher refuses to run.
 ```
 
 Review depth (`REVIEW_MODE=sequential|parallel|tiered`) is a **per-team** choice

--- a/docs/superpowers/plans/2026-07-09-throughput-levers.md
+++ b/docs/superpowers/plans/2026-07-09-throughput-levers.md
@@ -1,0 +1,645 @@
+# Throughput Levers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the four-lever throughput design (spec: `docs/superpowers/specs/2026-07-09-throughput-levers-design.md`): review-window compression guidance, mandatory design checklists, design-wait elimination, and gated pipelined dispatch via `MAX_ACTIVE_IMPLEMENTERS`.
+
+**Architecture:** This is a protocol-documentation change plus one launcher guard. The knob is a concurrency cap under the existing `EXECUTION=parallel` machinery (no new mode); all behavior rules land in `reference/orchestration.md` and are narrowed by role briefs and the playbook, following the repo's existing layering (protocol → briefs → playbook → config).
+
+**Tech Stack:** Markdown protocol docs, bash (`bin/launch-team.sh`, `tests/launcher-test.sh`).
+
+## Global Constraints
+
+- Config keys are read with plain `grep '^KEY='` — one `KEY=value` per line inside fenced blocks, no spaces around `=` (`config/team.config.md` → Rules).
+- Markers are machine-readable protocol: never invent new ones, never rename existing ones. This plan adds NO new markers.
+- Bracketed vocabulary (`[task]`, `[feature]`, `[design-note]`, `[Review]`, …) must be used exactly as in existing docs.
+- The knob key is spelled `MAX_ACTIVE_IMPLEMENTERS` everywhere — no variants.
+- The freeze-protocol comment is spelled exactly: `Parked (pipelined): preempted by rework on <N>. Resume on <N> re-entering [Review].`
+- Both test suites must stay green: `tests/launcher-test.sh` and `tests/tracker-ops-test.sh` end with `ALL PASS`.
+- Work on a feature branch: `feature/throughput-levers` off `main`.
+
+---
+
+### Task 0: Create the feature branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd /Users/aischenko/Projects/agent_squad_pm
+git checkout -b feature/throughput-levers main
+```
+
+---
+
+### Task 1: Launcher guard — `MAX_ACTIVE_IMPLEMENTERS` requires `EXECUTION=parallel`
+
+**Files:**
+- Modify: `bin/launch-team.sh` (add `validate_config` after the `role_cmd_key`/`key_is_null` helpers, near line 35; call it before the main `case`)
+- Test: `tests/launcher-test.sh` (insert before the `# -- status + stop` section)
+
+**Interfaces:**
+- Consumes: `read_key` (existing: returns `''` for `null`/missing keys), `die`.
+- Produces: launcher exits non-zero with a message containing `MAX_ACTIVE_IMPLEMENTERS` when the key is set while `EXECUTION` is not `parallel`, or when it is not a positive integer.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/launcher-test.sh`, insert this block immediately BEFORE the line `# -- status + stop --------------------------------------------------------------`:
+
+```bash
+# -- config guard: MAX_ACTIVE_IMPLEMENTERS requires EXECUTION=parallel ---------
+CFG=.claude/skills/pm/config/team.config.md
+printf 'MAX_ACTIVE_IMPLEMENTERS=1\n' >> "$CFG"
+if out="$("$LAUNCH" compose test-feature FEAT-1 backend 2>&1)"; then
+  echo "FAIL: MAX_ACTIVE_IMPLEMENTERS under sequential should be refused"; FAILURES=$((FAILURES+1))
+elif printf '%s' "$out" | grep -q "MAX_ACTIVE_IMPLEMENTERS"; then
+  echo "ok: knob refused under sequential"
+else
+  echo "FAIL: knob refusal has wrong message: $out"; FAILURES=$((FAILURES+1))
+fi
+printf 'EXECUTION=parallel\n' >> "$CFG"
+check "knob accepted under parallel" "$LAUNCH" compose test-feature FEAT-1 backend
+sed -i '' '/^MAX_ACTIVE_IMPLEMENTERS=1$/d;/^EXECUTION=parallel$/d' "$CFG"
+printf 'EXECUTION=parallel\nMAX_ACTIVE_IMPLEMENTERS=zero\n' >> "$CFG"
+if "$LAUNCH" compose test-feature FEAT-1 backend >/dev/null 2>&1; then
+  echo "FAIL: non-integer MAX_ACTIVE_IMPLEMENTERS should be refused"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-integer knob refused"
+fi
+sed -i '' '/^EXECUTION=parallel$/d;/^MAX_ACTIVE_IMPLEMENTERS=zero$/d' "$CFG"
+```
+
+Note: the fixture config has no `EXECUTION` line, so the first case exercises the "absent = sequential" default. The `sed -i ''` form is macOS bash — this suite already runs on darwin.
+
+- [ ] **Step 2: Run the suite to verify the new checks fail**
+
+Run: `bash tests/launcher-test.sh 2>&1 | tail -8`
+Expected: `FAIL: MAX_ACTIVE_IMPLEMENTERS under sequential should be refused` (the guard doesn't exist yet, so compose succeeds), and the suite exits with `FAILURE(S)`.
+
+- [ ] **Step 3: Implement the guard**
+
+In `bin/launch-team.sh`, add after the `key_is_null()` function definition:
+
+```bash
+validate_config() { # MAX_ACTIVE_IMPLEMENTERS is a parallel-only knob (spec: throughput levers)
+  local exec_mode max_active
+  exec_mode="$(read_key EXECUTION)"
+  max_active="$(read_key MAX_ACTIVE_IMPLEMENTERS)"
+  [ -z "$max_active" ] && return 0
+  [ "$exec_mode" = "parallel" ] || die "MAX_ACTIVE_IMPLEMENTERS is set but EXECUTION is '${exec_mode:-sequential}' — the knob only applies under EXECUTION=parallel"
+  case "$max_active" in
+    ''|*[!0-9]*) die "MAX_ACTIVE_IMPLEMENTERS must be a positive integer, got '$max_active'" ;;
+  esac
+  [ "$max_active" -ge 1 ] || die "MAX_ACTIVE_IMPLEMENTERS must be >= 1"
+}
+```
+
+Then, immediately before the main `case "${1:-}" in` dispatch, add:
+
+```bash
+case "${1:-}" in validate-board|'') ;; *) validate_config ;; esac
+```
+
+(`validate-board` checks a board config file and must not depend on team-config sanity; `''` falls through to the usage error.)
+
+- [ ] **Step 4: Run the suite to verify it passes**
+
+Run: `bash tests/launcher-test.sh 2>&1 | tail -8`
+Expected: `ok: knob refused under sequential`, `ok: knob accepted under parallel`, `ok: non-integer knob refused`, ending `ALL PASS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/launch-team.sh tests/launcher-test.sh
+git commit -m "feat: launcher guard — MAX_ACTIVE_IMPLEMENTERS requires EXECUTION=parallel"
+```
+
+---
+
+### Task 2: `config/team.config.md` — declare the knob
+
+**Files:**
+- Modify: `config/team.config.md` (Coordination fenced block, after the `EXECUTION=` comment lines ending `# merge; REQUIRED the moment >=2 implementers should work` / `# concurrently (reference/orchestration.md → "Execution modes")`)
+
+**Interfaces:**
+- Produces: the key `MAX_ACTIVE_IMPLEMENTERS=null` with semantics comment; every later doc task refers to this exact key name.
+
+- [ ] **Step 1: Add the key**
+
+Append inside the Coordination fenced block, directly after the `EXECUTION=sequential` entry's last comment line:
+
+```
+MAX_ACTIVE_IMPLEMENTERS=null     # Only under EXECUTION=parallel. 1 = pipelined dispatch:
+                                 # full worktree isolation, but the team-lead dispatches
+                                 # the next [task] when the current one enters [Review]
+                                 # instead of after integration (reference/orchestration.md
+                                 # → "Execution modes"). >=2 = bounded full parallelism;
+                                 # null = unbounded parallel. Setting it under sequential
+                                 # is a config error — the launcher refuses to run.
+```
+
+- [ ] **Step 2: Verify the launcher still accepts the default config**
+
+Run: `bash tests/launcher-test.sh 2>&1 | tail -3`
+Expected: `ALL PASS` (the fixture writes its own config; this catches accidental fence breakage via the repo copy used by `compose` in other tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/team.config.md
+git commit -m "feat: MAX_ACTIVE_IMPLEMENTERS key in team config"
+```
+
+---
+
+### Task 3: `reference/orchestration.md` — knob semantics, sweep timing, checklist, marker content
+
+**Files:**
+- Modify: `reference/orchestration.md` — four edits: (a) Execution modes section, (b) pre-parallel validation checklist, (c) `[design-approved]` marker row, (d) Claiming step 2.
+
+**Interfaces:**
+- Consumes: `MAX_ACTIVE_IMPLEMENTERS` key name (Task 2).
+- Produces: the canonical rules every brief cites — "Execution modes" gains the *pipelined dispatch* rules (dispatch-on-Review, independence test, freeze protocol, sweep timing); the validation checklist becomes "before setting `EXECUTION=parallel` at any cap"; `[design-approved]` requires a numbered checklist.
+
+- [ ] **Step 1: Edit (a) — insert the knob bullet in "Execution modes"**
+
+Insert AFTER the `**`parallel`.**` bullet (ends `…handed back to the implementer for rebase.`) and BEFORE the paragraph starting `Deliberately **not** mode-dependent:`:
+
+```markdown
+- **Concurrency cap — `MAX_ACTIVE_IMPLEMENTERS` (parallel only).** Bounds how
+  many [tasks] may be in implementer hands at once; `null` leaves parallelism
+  unbounded. With the cap set (any value), claims are **lead-dispatched**
+  exactly as in sequential mode — the cap lives in the lead's single dispatch
+  point, never in self-claiming agents racing the tracker. Setting the key
+  under `EXECUTION=sequential` is a config error (the launcher refuses it).
+
+  `MAX_ACTIVE_IMPLEMENTERS=1` is **pipelined dispatch**: full parallel
+  isolation (worktree + task branch per [task], serial integrator merges), but
+  the lead sends assignment N+1 when [task] N **enters `[Review]`** rather
+  than after integration — N's review, rework, and integration overlap N+1's
+  implementation. Its rules:
+
+  - **Independence.** N+1 must consume no `CONTRACTS.md` export of any
+    un-integrated [task] and must not be expected to touch the same files.
+    No independent [task] ready → the lead waits; never stack a task branch
+    on un-integrated work.
+  - **Sweep gate.** N+1 is dispatched only after the principal-architect
+    confirms its divergence sweep of N (see *Sweep timing* below).
+  - **Freeze protocol — rework preempts.** If N gets `[review-findings]`
+    while N+1 is being implemented: the lead sends a supersession assignment
+    (park N+1 at a clean point — its WIP is safe in its own worktree — switch
+    to N's worktree, deliver the rework and a fresh `[review-request]` before
+    idling), moves N+1 `Active → Blocked` with the comment
+    `Parked (pipelined): preempted by rework on <N>. Resume on <N> re-entering [Review].`,
+    and when N re-enters `[Review]`, moves N+1 `Blocked → Active` with a
+    fresh resume assignment. Oldest [task] first, always; one implementer
+    never holds two [tasks] hot at once. A parked [task] reads as **Parked**
+    in the supervision loop, not Stuck.
+  - **Sweep timing.** Under `parallel` (any cap), the principal-architect's
+    divergence sweep for a [task] runs at **`[Review]` entry** instead of
+    post-integration — every `[divergence]` comment exists by then. Rework
+    that adds new `[divergence]` comments gets an incremental re-sweep at
+    `[Review]` re-entry. A sweep finding that invalidates an
+    already-dispatched [task] is a binding mailbox ruling to its implementer
+    (revised `[design-note]` if needed). Sequential mode keeps the
+    post-integration trigger.
+  - **When to enable.** Only after the pre-parallel validation checklist
+    below passes — including its pipelined rework-rate item.
+```
+
+- [ ] **Step 2: Edit (b) — widen the pre-parallel validation checklist**
+
+Replace the line:
+
+```markdown
+**Before switching to `parallel`, validate the machinery once** — docs are not
+evidence, and a sequential run proves nothing about it:
+```
+
+with:
+
+```markdown
+**Before setting `EXECUTION=parallel` — at any `MAX_ACTIVE_IMPLEMENTERS`,
+pipelined `1` included — validate the machinery once** — docs are not
+evidence, and a sequential run proves nothing about it. Record what ran and
+where (in `BASELINE.md` or on the [feature]):
+```
+
+Then append a fourth item after item 3 (`…the plan-time contract forks that parallel planning actually produces.`):
+
+```markdown
+4. **Pipelined (`MAX_ACTIVE_IMPLEMENTERS=1`) additionally requires:** the
+   team's most recent comparable run shows a first-pass rework rate below
+   ~25%. Pipelined saves ≈ (review + integrate time) × (first-pass-approved
+   [task] count); rework cycles gain nothing from it — at a high rework rate,
+   fix review predictability first (mandatory design checklists,
+   `REVIEW_MODE` — see `teams/_PLAYBOOK.md` → *Review modes*).
+```
+
+- [ ] **Step 3: Edit (c) — `[design-approved]` marker row**
+
+In the *Structured comments* table, replace the `[design-approved]` row:
+
+```markdown
+| `[design-approved]` | principal-architect | Gate open. May carry conditions the implementation must honour. |
+```
+
+with:
+
+```markdown
+| `[design-approved]` | principal-architect | Gate open. Carries a **numbered architecture checklist** — the items the architecture review will verify — plus any binding conditions. The lead delivers the checklist in the assignment; reviewer/QA Phase-1 checklists start from it (add items, never subtract). |
+```
+
+- [ ] **Step 4: Edit (d) — Claiming step 2**
+
+In *Claiming a [task]* step 2, replace the sentence:
+
+```markdown
+Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox.
+```
+
+with:
+
+```markdown
+Also verify the sweep is not pending on your track: under `EXECUTION=sequential`, the previously integrated [task] has no `[divergence]` comments still awaiting the principal-architect's sweep; under `parallel`, the most recent [task] that entered `[Review]` on your track has the PA's sweep confirmation. If pending, wait or ask the PA by mailbox.
+```
+
+And in the same step, replace:
+
+```markdown
+Under `EXECUTION=sequential`, you claim only on the team-lead's assignment (never self-serve — see *Execution modes*)
+```
+
+with:
+
+```markdown
+Under `EXECUTION=sequential` — and under `parallel` whenever `MAX_ACTIVE_IMPLEMENTERS` is set — you claim only on the team-lead's assignment (never self-serve — see *Execution modes*)
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `grep -c "MAX_ACTIVE_IMPLEMENTERS" reference/orchestration.md`
+Expected: `4` or more (knob bullet ×2+, checklist item, claiming step).
+
+Run: `grep -n "Parked (pipelined)" reference/orchestration.md`
+Expected: exactly 1 match, spelled per Global Constraints.
+
+```bash
+git add reference/orchestration.md
+git commit -m "feat: pipelined dispatch rules, sweep-at-Review-entry, design checklists in protocol"
+```
+
+---
+
+### Task 4: `roles/principal-architect.md` — mandatory checklist + sweep trigger
+
+**Files:**
+- Modify: `roles/principal-architect.md` — checkpoint 2 and the "Your exclusive right: task descriptions" section.
+
+**Interfaces:**
+- Consumes: `[design-approved]` checklist rule (Task 3c), sweep timing (Task 3a).
+
+- [ ] **Step 1: Checkpoint 2 — checklist in every mode**
+
+Replace (checkpoint 2, currently):
+
+```markdown
+2. **Design gate — every [task], before any code.** Answer every `[design-note]`
+   with `[design-approved]` (optionally with binding conditions) or
+   `[design-pushback]` (numbered required changes). Backend [tasks] always get a
+   full design review. Frontend [tasks] declare `Architectural impact: yes/no`;
+   for a credible "no", reply `[design-approved]` fast — keep the gate cheap where
+   it should be cheap. When the team runs `REVIEW_MODE=tiered`
+   (`teams/_PLAYBOOK.md` → *Review modes*) and the [task] qualifies for a
+   combined review, attach a **numbered architecture checklist** to your
+   `[design-approved]` — it is what QA executes in your stead at review time.
+```
+
+with:
+
+```markdown
+2. **Design gate — every [task], before any code.** Answer every `[design-note]`
+   with `[design-approved]` or `[design-pushback]` (numbered required changes).
+   Every `[design-approved]` carries a **numbered architecture checklist** — the
+   items you will verify at architecture-review time — plus any binding
+   conditions. The checklist is the implementer's target (the lead delivers it
+   in the assignment message) and the seed of the reviewer's Phase-1 checklist
+   (reviewers add items, never subtract). In `REVIEW_MODE=tiered` combined
+   reviews (`teams/_PLAYBOOK.md` → *Review modes*), QA executes your checklist
+   in your stead at review time — write it to be executable without you.
+   Backend [tasks] always get a full design review. Frontend [tasks] declare
+   `Architectural impact: yes/no`; for a credible "no", reply
+   `[design-approved]` fast — the checklist may be short, never absent.
+```
+
+- [ ] **Step 2: Sweep trigger amendment**
+
+In "Your exclusive right: task descriptions", after the sentence ending `This sweep blocks the next [task] from being claimed on your track — do it promptly.`, append:
+
+```markdown
+Under `EXECUTION=parallel` your sweep for a [task] runs when it **enters
+`[Review]`** (every `[divergence]` comment exists by then) and gates the
+lead's dispatch of the next [task] — confirm completion by mailbox and
+tracker comment. Rework that adds new `[divergence]` comments gets an
+incremental re-sweep at `[Review]` re-entry. A finding that invalidates an
+already-dispatched [task] is a binding mailbox ruling to its implementer —
+revised `[design-note]` if needed. Sequential mode keeps the
+post-integration trigger.
+```
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `grep -n "numbered architecture checklist" roles/principal-architect.md`
+Expected: 1 match in checkpoint 2.
+
+```bash
+git add roles/principal-architect.md
+git commit -m "feat: PA brief — mandatory design checklist, sweep at [Review] entry under parallel"
+```
+
+---
+
+### Task 5: `roles/team-lead.md` — pipelined dispatch + design-gate look-ahead
+
+**Files:**
+- Modify: `roles/team-lead.md` — Phase 1, after step 8.
+
+**Interfaces:**
+- Consumes: dispatch rules and freeze protocol exactly as defined in Task 3a; look-ahead pattern (spec Lever 3).
+
+- [ ] **Step 1: Add steps 9 and 10**
+
+Append after step 8 (`…cannot race a claim you never issued.`):
+
+```markdown
+9. **Pipelined execution (`EXECUTION=parallel` + `MAX_ACTIVE_IMPLEMENTERS=1`):
+   dispatch on `[Review]` entry.** You still dispatch every claim (the cap
+   lives in your single dispatch point), but you send assignment N+1 the
+   moment [task] N enters `[Review]` — provided N+1 consumes no `CONTRACTS.md`
+   export of any un-integrated [task], is not expected to touch its files, and
+   the principal-architect has confirmed its sweep of N. No independent [task]
+   ready → wait. Rework preempts (protocol: *Execution modes* → freeze
+   protocol): if N bounces while N+1 is in flight, send a supersession
+   assignment (park N+1, fix N, fresh `[review-request]` first), move N+1
+   `Active → Blocked` with the parked comment, and resume it
+   (`Blocked → Active`, fresh assignment) when N re-enters `[Review]`.
+   Oldest [task] first, always.
+10. **Keep the design gate ahead of the dispatch (any mode).** Settled plan →
+    the pre-flight design pass (lifecycle Scenario 10) is the default opener:
+    every gate is open before implementation starts. Emergent plan → rolling
+    look-ahead: when dispatching [task] N, trigger N+1's `[design-note]` so
+    the principal-architect reviews it while N is in flight; skip the
+    look-ahead when N+1 depends on N's implementation detail.
+```
+
+- [ ] **Step 2: Verify and commit**
+
+Run: `grep -n "supersession" roles/team-lead.md reference/orchestration.md`
+Expected: 1 match in each file.
+
+```bash
+git add roles/team-lead.md
+git commit -m "feat: team-lead brief — pipelined dispatch, freeze protocol, design-gate look-ahead"
+```
+
+---
+
+### Task 6: `teams/_PLAYBOOK.md` — pre-flight default, review-mode guidance, ASSIGN checklist line
+
+**Files:**
+- Modify: `teams/_PLAYBOOK.md` — stage 3, *Review modes*, ASSIGN template.
+
+**Interfaces:**
+- Consumes: checklist marker content (Task 3c), tiered eligibility conditions (spec Lever 1).
+
+- [ ] **Step 1: Stage 3 — pre-flight becomes the default opener**
+
+Replace the stage-3 pre-flight paragraph:
+
+```markdown
+   *Pre-flight variant (lifecycle Scenario 10):* when the plan should be settled
+   before any code, run all design gates as one batch — notes for every [task]
+```
+
+with:
+
+```markdown
+   *Pre-flight pass (lifecycle Scenario 10) — the **default opener**:* unless
+   the plan is genuinely emergent, run all design gates as one batch — notes
+   for every [task]
+```
+
+(the rest of the paragraph is unchanged), and append at the end of the same paragraph, after `At claim time each gate is already open.`:
+
+```markdown
+   For genuinely emergent plans, keep the gate ahead of the dispatch with a
+   rolling look-ahead instead: when [task] N is dispatched, N+1's
+   `[design-note]` is written and reviewed while N is in flight (skip when
+   N+1 depends on N's implementation detail).
+```
+
+- [ ] **Step 2: Review modes — recommendation + tiered eligibility test**
+
+Append after the `tiered` bullet (ends `…independent evidence rather than extra findings.`), before the `Whatever the mode` paragraph:
+
+```markdown
+**Recommendation:** `sequential` for a team's first feature; `tiered` once the
+team has run history. Tiered eligibility is a mechanical test the lead applies
+at dispatch — combined review only if (a) the `[design-note]` declared
+`Architectural impact: no` **and** (b) the [task] touches no contract
+registered in `CONTRACTS.md`; anything else gets full dual review.
+```
+
+- [ ] **Step 3: ASSIGN template — deliver the checklist**
+
+In the ASSIGN template, after the `Inputs:` lines and before `Baseline:`, add:
+
+```
+Checklist: numbered architecture checklist from [design-approved] — implement
+        to satisfy every item
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `grep -n "default opener" teams/_PLAYBOOK.md`
+Expected: 1 match in stage 3.
+
+```bash
+git add teams/_PLAYBOOK.md
+git commit -m "feat: playbook — pre-flight default opener, review-mode guidance, ASSIGN checklist line"
+```
+
+---
+
+### Task 7: `reference/lifecycle.md` — Scenario 10 default note + sweep cross-reference
+
+**Files:**
+- Modify: `reference/lifecycle.md` — Scenario 10 intro and step 6.
+
+**Interfaces:**
+- Consumes: sweep timing (Task 3a), default-opener rule (Task 6).
+
+- [ ] **Step 1: Scenario 10 intro**
+
+After the intro sentence ending `— run the gates as one batch instead:`, the paragraph break, add before the numbered list:
+
+```markdown
+For preset teams this batch is the **default opener** (`teams/_PLAYBOOK.md`
+stage 3); per-[task] gates at claim time are the opt-out for genuinely
+emergent plans.
+```
+
+- [ ] **Step 2: Step 6 sweep cross-reference**
+
+Replace Scenario 10 step 6's ending:
+
+```markdown
+   approval needed unless a `[divergence]` or re-plan invalidated the note.
+```
+
+with:
+
+```markdown
+   approval needed unless a `[divergence]` or re-plan invalidated the note
+   (under `EXECUTION=parallel` the sweep that flags this runs at `[Review]`
+   entry — see `reference/orchestration.md` → *Execution modes*).
+```
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `grep -n "default opener" reference/lifecycle.md`
+Expected: 1 match.
+
+```bash
+git add reference/lifecycle.md
+git commit -m "feat: lifecycle — Scenario 10 default opener, sweep-timing cross-reference"
+```
+
+---
+
+### Task 7b: Role briefs — claim dispatch under the cap, checklist seeding
+
+**Files:**
+- Modify: `roles/backend.md` (Loop step 1), `roles/reviewer.md` (Phase 1), `reference/orchestration.md` (Dual review, reviewer phase 1 sentence)
+
+**Interfaces:**
+- Consumes: lead-dispatched-claims rule (Task 3d), `[design-approved]` checklist (Task 3c).
+
+- [ ] **Step 1: backend.md — claims are lead-dispatched under the cap too**
+
+Replace in Loop step 1:
+
+```markdown
+   `EXECUTION=sequential`: claim only the [task] the team-lead's assignment
+   message names — never self-claim — and only with the shared checkout free.
+```
+
+with:
+
+```markdown
+   `EXECUTION=sequential` — and `parallel` whenever `MAX_ACTIVE_IMPLEMENTERS`
+   is set — claim only the [task] the team-lead's assignment message names,
+   never self-claim; in sequential additionally only with the shared checkout
+   free.
+```
+
+(`roles/frontend.md` needs no edit — it defers to "the protocol and the backend
+brief"; `roles/qa.md` and `roles/integrator.md` are already EXECUTION-conditional.)
+
+- [ ] **Step 2: reviewer.md — Phase-1 checklist seeded by the design checklist**
+
+Replace in Phase 1:
+
+```markdown
+Extract every business rule, validation, edge case,
+and permission check into your own numbered checklist.
+```
+
+with:
+
+```markdown
+Extract every business rule, validation, edge case,
+and permission check into your own numbered checklist — seeded by the numbered
+architecture checklist in the `[design-approved]` (you add items, never
+subtract).
+```
+
+- [ ] **Step 3: orchestration.md — Dual review phase-1 sentence**
+
+In *Dual review*, replace:
+
+```markdown
+(1) *Plan*: before reading any code, read the
+  [feature] and [task], extract every business rule / validation / edge case into an
+  independent checklist with an expected file list.
+```
+
+with:
+
+```markdown
+(1) *Plan*: before reading any code, read the
+  [feature] and [task], extract every business rule / validation / edge case into an
+  independent checklist — seeded by the `[design-approved]` architecture
+  checklist (add items, never subtract) — with an expected file list.
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `grep -rn "add items, never subtract\|never subtract" roles/reviewer.md reference/orchestration.md roles/principal-architect.md | wc -l`
+Expected: `4` (marker table, Dual review, reviewer brief, PA brief).
+
+```bash
+git add roles/backend.md roles/reviewer.md reference/orchestration.md
+git commit -m "feat: role briefs — lead-dispatched claims under the cap, checklist-seeded reviews"
+```
+
+---
+
+### Task 8: Consistency review + full validation
+
+**Files:** none new — verification and fixes only.
+
+- [ ] **Step 1: Run both suites**
+
+```bash
+bash tests/launcher-test.sh 2>&1 | tail -3
+bash tests/tracker-ops-test.sh 2>&1 | tail -3
+```
+
+Expected: both end `ALL PASS`.
+
+- [ ] **Step 2: Cross-doc consistency greps**
+
+```bash
+# Key spelled identically everywhere it appears:
+grep -rn "MAX_ACTIVE" --include="*.md" --include="*.sh" . | grep -v "MAX_ACTIVE_IMPLEMENTERS" ; echo "expect: no output"
+# No doc still claims the sweep is post-integration-only without the parallel carve-out:
+grep -n "After every integration" roles/principal-architect.md ; echo "expect: 1 hit, immediately followed by the parallel amendment added in Task 4"
+# Freeze comment spelled once per file that defines/uses it:
+grep -rn "Parked (pipelined)" --include="*.md" .
+# expect: reference/orchestration.md and roles/team-lead.md refer to it; identical spelling
+```
+
+Fix any inconsistency found, amend the relevant commit or add a `fix:` commit.
+
+- [ ] **Step 3: Read-through check**
+
+Re-read the changed sections of `reference/orchestration.md` and `teams/_PLAYBOOK.md` end-to-end once, checking: no section still asserts worktrees are unconditional; sequential-mode text is untouched; no new markers were introduced.
+
+- [ ] **Step 4: Final commit if fixes were made, then summarize**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: ~8 commits (Tasks 1–7b), all suites green.
+
+---
+
+## Out of scope (per spec)
+
+- `MAX_ACTIVE_IMPLEMENTERS >= 2` behavior changes.
+- Stacked task branches.
+- Async/write-behind tracker layer.
+- Running the enablement-gate machinery proof (that is a runtime exercise for a real team run, not CI).

--- a/docs/superpowers/specs/2026-07-09-throughput-levers-design.md
+++ b/docs/superpowers/specs/2026-07-09-throughput-levers-design.md
@@ -1,0 +1,249 @@
+# Throughput Levers — Layered Execution Speedups — Design
+
+**Date:** 2026-07-09
+**Status:** Approved (pending user spec review)
+**Branch:** `main` (spec); implementation on a feature branch
+
+## Problem
+
+Per-feature wall-clock is dominated by a serial critical path per [task]:
+design-wait + implement + review + rework + integrate. Production evidence
+(`FEEDBACK-parallel-and-worktrees.md`, inscribed run: 15 [tasks], ~10 rework
+cycles, harness mode, `EXECUTION=sequential`):
+
+- The shared checkout is reserved from claim until integration — a [task] in
+  `[Review]` still owns it — so nothing overlaps anything.
+- Default `REVIEW_MODE=sequential` "roughly doubles per-[task] review wall
+  time" (`teams/_PLAYBOOK.md` → *Review modes*).
+- ~67% of [tasks] bounced at review at least once; review criteria were
+  discovered after code existed.
+- The design gate opens per-[task] at claim time, putting the
+  `[design-note] → [design-approved]` round-trip on every [task]'s critical path.
+
+Goal: cut wall-clock **without weakening the gates that caught real defects**
+(the cross-tenant IDOR, the INS-14/INS-20 contract fork).
+
+## Inputs
+
+- Two prior analysis rounds in-session (bottleneck: checkout reservation; flaw
+  found in naive "release checkout at review" — integration would commit onto a
+  tree holding the next task's uncommitted edits, contaminating validation).
+- An independent principal-architect review (run as an agent against this
+  repo's own `roles/principal-architect.md` brief), which returned
+  `[design-pushback]` on a pipelined-mode proposal with four required changes
+  (RC-1..RC-4, resolved below) and three alternatives (Alt A/B/C, adopted as
+  Levers 1–3).
+
+## Decisions (clarified with user)
+
+| Question | Decision |
+|---|---|
+| Shape of pipelining | **Concurrency knob**, not a third mode: `EXECUTION=parallel` + `MAX_ACTIVE_IMPLEMENTERS=1`. All parallel-mode isolation rules apply at any N. |
+| Rework contention | **Rework preempts** — oldest [task] first; the implementer parks the newer [task], clears findings on the older, resumes. |
+| Scope | **One layered spec**: all four levers, ordered by value-per-risk, PA ladder as adoption order. Pipelined fully designed but gated. |
+| Stacking dependent [tasks] on un-integrated branches | **Deferred** — out of scope. Dispatch only independent [tasks]; otherwise wait. |
+
+## Adoption order (the ladder)
+
+1. **Lever 1** — review-window compression (config guidance; immediate)
+2. **Lever 2** — mandatory design checklists (root-cause rework fix)
+3. **Lever 3** — design-wait elimination (pre-flight default + rolling look-ahead)
+4. **Lever 4** — `MAX_ACTIVE_IMPLEMENTERS=1` pipelined dispatch (gated: machinery
+   proof + rework-rate threshold)
+
+Each lever is independently adoptable; none depends on a later one. Lever 4's
+benefit is real only after Lever 2 lowers the rework rate (see *Enablement gates*).
+
+---
+
+## Lever 1 — Review-window compression (`REVIEW_MODE`)
+
+Guidance change only; all three modes already exist (`teams/_PLAYBOOK.md` →
+*Review modes*).
+
+- Preset team files gain an explicit recommendation: `REVIEW_MODE=tiered` for
+  teams past their first feature; `parallel` where dual review on everything is
+  wanted but not serially; `sequential` remains the conservative default for a
+  team's first run.
+- *Review modes* gains one explicit eligibility checklist the lead applies at
+  dispatch: a [task] qualifies for tiered combined review only if
+  (a) `Architectural impact: no` and (b) it touches no contract registered in
+  `CONTRACTS.md`. (Both conditions exist in the tiered prose today; this makes
+  them a single mechanical test.)
+
+## Lever 2 — Mandatory design checklist on every `[design-approved]`
+
+Extend the existing tiered-mode rule to **all modes**:
+
+- `roles/principal-architect.md` checkpoint 2: every `[design-approved]`
+  carries a **numbered architecture checklist** — what will be verified at
+  review time. (Today required only for tiered combined reviews.)
+- The team-lead's assignment message delivers the checklist as acceptance
+  input: "implement to satisfy items 1–N."
+- Reviewer/QA Phase-1 checklists **start from** the PA's items — reviewers add
+  items, never subtract.
+- `[design-approved]` marker definition in `reference/orchestration.md`
+  updated to name the checklist as required content.
+
+Rationale: criteria exist before code, so implementation targets them instead
+of guessing what review will check. Cost: ~5–10 min per design approval.
+
+## Lever 3 — Design-wait elimination
+
+Rule: **a [task]'s design gate should already be open when the [task] is
+dispatched.** Two variants of the same rule, chosen by plan stability:
+
+- **Settled plans → pre-flight pass is the default opener.** The pre-flight
+  variant (`teams/_PLAYBOOK.md` stage 3; `reference/lifecycle.md` Scenario 10)
+  flips from opt-in to default; the lead opts *out* (per-[task] gates) only
+  when the plan is genuinely emergent. The registry gate condition (no approval
+  while exports are unregistered or consumed names uncited) is unchanged.
+- **Emergent plans → rolling look-ahead.** When dispatching [task] N for
+  implementation, the lead simultaneously triggers N+1's `[design-note]`; the
+  PA reviews it while N is in flight. Skip the look-ahead when N+1 depends on
+  N's implementation detail (same dependency test as Lever 4's dispatch rule).
+  If N's later `[divergence]` invalidates an approved look-ahead design, the
+  PA's sweep flags it and N+1 opens with a revised `[design-note]`
+  (existing clause: `reference/lifecycle.md` Scenario 10 step 6, "unless a
+  `[divergence]` or re-plan invalidated the note").
+
+No new markers or protocol objects.
+
+## Lever 4 — Pipelined dispatch (`MAX_ACTIVE_IMPLEMENTERS`)
+
+### Config shape
+
+```
+EXECUTION=sequential            # unchanged; still the default and the proven path
+EXECUTION=parallel              # gains one sub-key:
+MAX_ACTIVE_IMPLEMENTERS=1       # 1 = pipelined dispatch (this spec)
+                                # >=2 = full parallel (existing rules)
+```
+
+Under `parallel`, all existing isolation rules apply at any N — worktree +
+task branch per [task] (`bin/launch-team.sh worktree`), integrator merges
+serially in dependency order, same-file collisions handed back for rebase.
+The knob only bounds how many [tasks] the lead may have in implementer hands
+at once. Setting `MAX_ACTIVE_IMPLEMENTERS` while `EXECUTION=sequential` is a
+config error (launcher validates; see *Files touched*).
+
+### Dispatch rule
+
+The lead sends assignment N+1 **when [task] N enters `[Review]`** — not after
+integration — provided:
+
+1. **Independence:** N+1 consumes no `CONTRACTS.md` export of any
+   un-integrated [task] and is not expected to touch the same files. Dependent
+   [task] → wait; never stack on an un-integrated branch (deferred).
+2. **Sweep confirmed:** the PA's divergence sweep of N is confirmed (see
+   *Sweep timing*).
+
+No eligible independent [task] → the lead waits; pipelining is opportunistic,
+never forced.
+
+### Freeze protocol (RC-1; implements rework-preempts)
+
+When N gets `[review-findings]` (→ `[Active]`) while N+1 is being implemented:
+
+1. The lead sends the implementer a **supersession assignment**: park N+1 at a
+   clean point, switch to N's worktree, deliver the rework and a fresh
+   `[review-request]` before idling. Worktrees make the park safe — N+1's WIP
+   sits untouched in its own tree.
+2. The lead moves N+1 `Active → Blocked` with the comment:
+   `Parked (pipelined): preempted by rework on <N>. Resume on <N> re-entering [Review].`
+   Stuck-detection stays honest: a parked [task] reads as **Parked** (existing
+   supervision category; `[Blocked]`'s owner is the team-lead — the parker and
+   resumer, per `config/statuses.config.json`).
+3. When N re-enters `[Review]`, the lead moves N+1 `Blocked → Active` and
+   sends a fresh resume assignment.
+4. **Oldest-first always:** rework on an older [task] outranks progress on a
+   newer one. One implementer never holds two [tasks] hot at once.
+
+Board support verified: `Active → Blocked` and `Blocked → Active` transitions
+already exist in `config/statuses.config.json` — no board change.
+
+### Sweep timing (RC-2)
+
+Under `EXECUTION=parallel` (any N), the PA divergence sweep triggers at
+**`[Review]` entry** instead of post-integration — all `[divergence]` comments
+exist by then. Consequences:
+
+- Dispatch of N+1 is gated on the PA's sweep confirmation for N (mailbox +
+  tracker comment).
+- Rework that adds new `[divergence]` comments gets an **incremental re-sweep**
+  when N re-enters `[Review]`.
+- If a sweep finding invalidates the already-dispatched N+1, the PA pings its
+  implementer with a binding ruling — revised `[design-note]` if needed.
+- `sequential` mode keeps the post-integration trigger unchanged.
+
+### Enablement gates (RC-3, RC-4)
+
+A **"Before you turn the knob"** checklist in `reference/orchestration.md`;
+both items mandatory, results recorded (in `BASELINE.md` or on the feature's
+tracker item):
+
+1. **Machinery proof** (the existing parallel pre-validation, which applies at
+   N=1 too): (a) `launch-team.sh worktree` creates a usable isolated tree in
+   *your* environment (harness subagents included) and an implementer can
+   build and test inside it; (b) a deliberate same-file collision across two
+   task branches ends with the integrator merging the first and handing the
+   second back for rebase; (c) `CONTRACTS.md` is populated during planning.
+2. **Rework-rate threshold** (new): first-pass approval rate from the team's
+   most recent comparable run must justify the overlap — guidance: enable at
+   rework rate **< ~25%**; above that, apply Levers 1–3 first. Documented
+   honestly: pipelined saves ≈ (review + integrate time) × (first-pass-approved
+   [task] count); rework cycles gain nothing from it.
+
+### Deliberately unchanged
+
+- `TRACKER_WRITERS=lead` stays the recommended write path.
+- QA's `[review-approval]` remains the serialized last-in-time gate.
+- Relaunch hygiene gets structurally simpler: kill+relaunch = quarantine is
+  just discarding the dead instance's worktree (satisfies feedback R2).
+
+---
+
+## Expected effect (per production-run numbers)
+
+| Lever | Estimated saving per feature run | Cost |
+|---|---|---|
+| 1 — tiered/parallel review | 3–5 h | 1 config line + guidance |
+| 2 — mandatory checklists | 3–5 h (rework rate ↓) | 3 file edits; +5–10 min/approval |
+| 3 — design-wait elimination | 3.5–7 h | 2 doc edits |
+| 4 — pipelined dispatch | ≈(review+integrate) × first-pass count — meaningful only after Lever 2 | doc edits + launcher validation + gates |
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `reference/orchestration.md` | Execution modes (knob, dispatch rule, freeze protocol), Claiming (sweep gate), `[design-approved]` marker content, sweep timing, "Before you turn the knob" checklist |
+| `config/team.config.md` | `MAX_ACTIVE_IMPLEMENTERS` key + comments; note that it is invalid under `sequential` |
+| `teams/_PLAYBOOK.md` | Pre-flight pass as default opener; review-mode recommendation + tiered eligibility checklist; rolling look-ahead pattern; ASSIGN template carries the PA checklist |
+| `reference/lifecycle.md` | Scenario 10 default-opener note; sweep-timing amendment cross-reference |
+| `roles/principal-architect.md` | Checklist mandatory in all modes (checkpoint 2); sweep trigger at `[Review]` entry under `parallel` |
+| `roles/team-lead.md` | Dispatch loop: pipelined dispatch rule, freeze protocol, look-ahead trigger |
+| `roles/backend.md`, `roles/frontend.md`, `roles/reviewer.md`, `roles/qa.md` | Wording that assumes per-task worktrees are parallel-only / checklist-driven review inputs — touch only where wording conflicts |
+| `bin/launch-team.sh` | Validate: `MAX_ACTIVE_IMPLEMENTERS` set while `EXECUTION=sequential` → die |
+| `tests/launcher-test.sh` | One test for the new validation |
+
+## Testing
+
+- **Launcher validation test** (`tests/launcher-test.sh`): `MAX_ACTIVE_IMPLEMENTERS=1`
+  with `EXECUTION=sequential` → non-zero exit with a clear message; with
+  `EXECUTION=parallel` → accepted.
+- **Doc consistency:** the repo's existing test suites (`launcher-test.sh`,
+  `tracker-ops-test.sh`) must stay green; a consistency review pass over the
+  changed docs (per the repo's established practice) checks that no section
+  still asserts worktrees are unconditional or that the sweep is
+  post-integration-only under `parallel`.
+- **Runtime validation** is deliberately deferred to the enablement gates: the
+  machinery proof (worktree-in-harness, rebase-handback, registry) runs as a
+  controlled exercise before the knob is first enabled — documented as the
+  checklist itself, not as CI.
+
+## Out of scope
+
+- `MAX_ACTIVE_IMPLEMENTERS >= 2` behavior changes (full parallel is already
+  specified; only the shared pre-validation checklist references it).
+- Stacked task branches (dependent [task] pipelining).
+- Async/write-behind tracker layer (separate concern, discussed and parked).

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -157,6 +157,10 @@ When the plan should be settled before any code — the user asks for all plans
 up front, or the [tasks] share contracts that must not fork — run the gates as
 one batch instead:
 
+For preset teams this batch is the **default opener** (`teams/_PLAYBOOK.md`
+stage 3); per-[task] gates at claim time are the opt-out for genuinely
+emergent plans.
+
 1. **One `[design-note]` per [task]**, written against the real codebase (not the
    [task] text alone). Registering exports in the contract registry
    (`reference/orchestration.md` → *Contract registry*, team mode) is part of
@@ -178,7 +182,9 @@ one batch instead:
 5. **Everything lands as comments** on the [tasks], like any gate.
 6. At claim time the gate is already open: the implementer re-reads the approved
    note, its conditions, and any cross-cutting rulings, and proceeds — no second
-   approval needed unless a `[divergence]` or re-plan invalidated the note.
+   approval needed unless a `[divergence]` or re-plan invalidated the note
+   (under `EXECUTION=parallel` the sweep that flags this runs at `[Review]`
+   entry — see `reference/orchestration.md` → *Execution modes*).
 
 The per-[task] gate is unchanged — this scenario only moves *when* it runs.
 [Tasks] added later (Scenario 6) go through the normal per-[task] gate.

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -357,7 +357,8 @@ must approve before integration:
 
 - **Reviewer — three phases.** (1) *Plan*: before reading any code, read the
   [feature] and [task], extract every business rule / validation / edge case into an
-  independent checklist with an expected file list. (2) *Review*: every changed file,
+  independent checklist — seeded by the `[design-approved]` architecture
+  checklist (add items, never subtract) — with an expected file list. (2) *Review*: every changed file,
   line by line; findings go out immediately as `[review-findings]`. (3) *Verify*:
   re-read fixes; every checklist item needs a `file:line` citation and a test
   citation; the approval file list must equal the actual diff.

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -301,13 +301,20 @@ one that performs its outbound transitions.
 ## Claiming a [task]
 
 1. Read the [task] in full via the adapter (description, [subtasks], all comments).
-2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the sweep is not pending on your track: under `EXECUTION=sequential`,
-the previously integrated [task] has no `[divergence]` comments still awaiting
-the principal-architect's sweep; under `parallel`, the most recent [task] that
-entered `[Review]` on your track has the PA's sweep confirmation. If pending,
-wait or ask the PA by mailbox. Under `EXECUTION=sequential` — and under `parallel` whenever
-`MAX_ACTIVE_IMPLEMENTERS` is set — you claim only on the team-lead's
-assignment (never self-serve — see *Execution modes*), and before touching anything verify **the shared checkout is free**: no [task] anywhere is in flight (`[Active]` **or** `[Review]` — a [task] in review still owns the checkout until integrated), and `git status --porcelain -uall` on the feature-branch checkout is clean. Dirty checkout or an in-flight [task] → don't claim; tell the lead.
+2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`.
+   Also verify the sweep is not pending on your track: under `EXECUTION=sequential`,
+   the previously integrated [task] has no `[divergence]` comments still awaiting
+   the principal-architect's sweep; under `parallel`, the most recent [task] that
+   entered `[Review]` on your track has the PA's sweep confirmation. If pending,
+   wait or ask the PA by mailbox. Under `EXECUTION=sequential` — and under
+   `parallel` whenever `MAX_ACTIVE_IMPLEMENTERS` is set — you claim only on the
+   team-lead's assignment (never self-serve — see *Execution modes*). Under
+   `sequential`, additionally verify before touching anything that
+   **the shared checkout is free**: no [task] anywhere is in flight
+   (`[Active]` **or** `[Review]` — a [task] in review still owns the checkout
+   until integrated), and `git status --porcelain -uall` on the feature-branch
+   checkout is clean. Dirty checkout or an in-flight [task] → don't claim;
+   tell the lead.
 3. Set assignee = your role name AND move `[Planned] → [Active]` (one adapter write
    where the tool allows, else assignee first).
 4. **Read back.** If the assignee is not you, another agent won — back off silently

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -143,13 +143,55 @@ nothing else: markers, gates, reviews, and statuses are identical in both modes.
   dependency order, and same-file collisions are handed back to the implementer
   for rebase.
 
+- **Concurrency cap — `MAX_ACTIVE_IMPLEMENTERS` (parallel only).** Bounds how
+  many [tasks] may be in implementer hands at once; `null` leaves parallelism
+  unbounded. With the cap set (any value), claims are **lead-dispatched**
+  exactly as in sequential mode — the cap lives in the lead's single dispatch
+  point, never in self-claiming agents racing the tracker. Setting the key
+  under `EXECUTION=sequential` is a config error (the launcher refuses it).
+
+  `MAX_ACTIVE_IMPLEMENTERS=1` is **pipelined dispatch**: full parallel
+  isolation (worktree + task branch per [task], serial integrator merges), but
+  the lead sends assignment N+1 when [task] N **enters `[Review]`** rather
+  than after integration — N's review, rework, and integration overlap N+1's
+  implementation. Its rules:
+
+  - **Independence.** N+1 must consume no `CONTRACTS.md` export of any
+    un-integrated [task] and must not be expected to touch the same files.
+    No independent [task] ready → the lead waits; never stack a task branch
+    on un-integrated work.
+  - **Sweep gate.** N+1 is dispatched only after the principal-architect
+    confirms its divergence sweep of N (see *Sweep timing* below).
+  - **Freeze protocol — rework preempts.** If N gets `[review-findings]`
+    while N+1 is being implemented: the lead sends a supersession assignment
+    (park N+1 at a clean point — its WIP is safe in its own worktree — switch
+    to N's worktree, deliver the rework and a fresh `[review-request]` before
+    idling), moves N+1 `Active → Blocked` with the comment
+    `Parked (pipelined): preempted by rework on <N>. Resume on <N> re-entering [Review].`,
+    and when N re-enters `[Review]`, moves N+1 `Blocked → Active` with a
+    fresh resume assignment. Oldest [task] first, always; one implementer
+    never holds two [tasks] hot at once. A parked [task] reads as **Parked**
+    in the supervision loop, not Stuck.
+  - **Sweep timing.** Under `parallel` (any cap), the principal-architect's
+    divergence sweep for a [task] runs at **`[Review]` entry** instead of
+    post-integration — every `[divergence]` comment exists by then. Rework
+    that adds new `[divergence]` comments gets an incremental re-sweep at
+    `[Review]` re-entry. A sweep finding that invalidates an
+    already-dispatched [task] is a binding mailbox ruling to its implementer
+    (revised `[design-note]` if needed). Sequential mode keeps the
+    post-integration trigger.
+  - **When to enable.** Only after the pre-parallel validation checklist
+    below passes — including its pipelined rework-rate item.
+
 Deliberately **not** mode-dependent: `TRACKER_WRITERS=lead` stays the
 recommended write path under parallelism (more concurrent writers means more
 races, not fewer), and QA's last-in-time `[review-approval]` remains a
 serialized final gate no matter how many implementers run.
 
-**Before switching to `parallel`, validate the machinery once** — docs are not
-evidence, and a sequential run proves nothing about it:
+**Before setting `EXECUTION=parallel` — at any `MAX_ACTIVE_IMPLEMENTERS`,
+pipelined `1` included — validate the machinery once** — docs are not
+evidence, and a sequential run proves nothing about it. Record what ran and
+where (in `BASELINE.md` or on the [feature]):
 
 1. `bin/launch-team.sh worktree` creates a usable isolated tree in *your*
    environment (harness subagents included) and an implementer can build and
@@ -160,6 +202,12 @@ evidence, and a sequential run proves nothing about it:
 3. The contract registry is populated **during** planning (see *Contract
    registry*): worktrees isolate code-in-progress; only the registry prevents
    the plan-time contract forks that parallel planning actually produces.
+4. **Pipelined (`MAX_ACTIVE_IMPLEMENTERS=1`) additionally requires:** the
+   team's most recent comparable run shows a first-pass rework rate below
+   ~25%. Pipelined saves ≈ (review + integrate time) × (first-pass-approved
+   [task] count); rework cycles gain nothing from it — at a high rework rate,
+   fix review predictability first (mandatory design checklists,
+   `REVIEW_MODE` — see `teams/_PLAYBOOK.md` → *Review modes*).
 
 ## Structured comments — the coordination markers
 
@@ -170,7 +218,7 @@ invent new ones, never misspell them.
 | Marker | Written by | Meaning / required content |
 |---|---|---|
 | `[design-note]` | implementer | Proposed approach before any code: approach, API/contract changes, data-model changes, affected components. Frontend must include `Architectural impact: yes/no — <why>`. Registers every name it exports in `CONTRACTS.md` and cites the registry line for every sibling export it consumes (see *Contract registry*). |
-| `[design-approved]` | principal-architect | Gate open. May carry conditions the implementation must honour. |
+| `[design-approved]` | principal-architect | Gate open. Carries a **numbered architecture checklist** — the items the architecture review will verify — plus any binding conditions. The lead delivers the checklist in the assignment; reviewer/QA Phase-1 checklists start from it (add items, never subtract). |
 | `[design-pushback]` | principal-architect | Gate closed. Lists required changes; implementer revises the `[design-note]` and re-pings. |
 | `[api-ready]` | backend | Contract available for frontend: endpoints, request/response shapes. Also sent by mailbox. |
 | `[divergence]` | implementer | What was done differently from the [task]/design note and why. Additive — **never edit the original [task] description.** |
@@ -253,7 +301,13 @@ one that performs its outbound transitions.
 ## Claiming a [task]
 
 1. Read the [task] in full via the adapter (description, [subtasks], all comments).
-2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the previously integrated [task] on your track has no `[divergence]` comments still awaiting the principal-architect's sweep — if it does, wait or ask the PA by mailbox. Under `EXECUTION=sequential`, you claim only on the team-lead's assignment (never self-serve — see *Execution modes*), and before touching anything verify **the shared checkout is free**: no [task] anywhere is in flight (`[Active]` **or** `[Review]` — a [task] in review still owns the checkout until integrated), and `git status --porcelain -uall` on the feature-branch checkout is clean. Dirty checkout or an in-flight [task] → don't claim; tell the lead.
+2. Verify status is `[Planned]` and it belongs to your track. If not → `[andon]`. Also verify the sweep is not pending on your track: under `EXECUTION=sequential`,
+the previously integrated [task] has no `[divergence]` comments still awaiting
+the principal-architect's sweep; under `parallel`, the most recent [task] that
+entered `[Review]` on your track has the PA's sweep confirmation. If pending,
+wait or ask the PA by mailbox. Under `EXECUTION=sequential` — and under `parallel` whenever
+`MAX_ACTIVE_IMPLEMENTERS` is set — you claim only on the team-lead's
+assignment (never self-serve — see *Execution modes*), and before touching anything verify **the shared checkout is free**: no [task] anywhere is in flight (`[Active]` **or** `[Review]` — a [task] in review still owns the checkout until integrated), and `git status --porcelain -uall` on the feature-branch checkout is clean. Dirty checkout or an in-flight [task] → don't claim; tell the lead.
 3. Set assignee = your role name AND move `[Planned] → [Active]` (one adapter write
    where the tool allows, else assignee first).
 4. **Read back.** If the assignee is not you, another agent won — back off silently

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -343,6 +343,7 @@ claim → [design-note] → wait for [design-approved]      (no code before the 
         merge to the feature branch (parallel execution only), commit,
         move to [Ready to deploy] (atomic pair)
       → principal-architect divergence sweep updates upcoming [tasks]
+        (sequential: runs here; parallel: already ran at [Review] entry)
 ```
 
 Gates live in comments; statuses move only along the `transitions` graph in

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -8,8 +8,10 @@ if it isn't, that's a `[design-pushback]`-worthy planning defect — say so.
 ## Loop
 
 1. **Claim** the next `[Planned]` backend [task] (protocol: *Claiming a [task]*).
-   `EXECUTION=sequential`: claim only the [task] the team-lead's assignment
-   message names — never self-claim — and only with the shared checkout free.
+   `EXECUTION=sequential` — and `parallel` whenever `MAX_ACTIVE_IMPLEMENTERS`
+   is set — claim only the [task] the team-lead's assignment message names,
+   never self-claim; in sequential additionally only with the shared checkout
+   free.
    Set up your working copy per `EXECUTION` (protocol: *Execution modes*) —
    `parallel`: create your worktree with
    `bin/launch-team.sh worktree <team> backend <taskId>`; `sequential`: work in

--- a/roles/principal-architect.md
+++ b/roles/principal-architect.md
@@ -32,7 +32,8 @@ human). **You never write code. Git is read-only for you.** The protocol in
 
 ## Your exclusive right: task descriptions
 
-After every integration, read the [task]'s `[divergence]` comments and update the
+After every integration (sequential — in parallel, at each [task]'s [Review] entry;
+see below), read the [task]'s `[divergence]` comments and update the
 descriptions of **upcoming** `[Planned]` [tasks] so no one starts from a stale
 plan. You are the only role allowed to edit a [task] description — and even you
 never rewrite the original ask of a claimed or completed [task]; you edit only
@@ -52,7 +53,7 @@ post-integration trigger.
 
 Every `POLL_INTERVAL_SECONDS`: mailbox, then tracker — pending `[design-note]`s
 without your verdict, [tasks] in `[Review]` without your `[architecture-approval]`,
-completed integrations without your divergence sweep. You are the hot path of the
+completed integrations (sequential) or [tasks] at [Review] entry (parallel) without your divergence sweep. You are the hot path of the
 whole team: answer gates before doing anything slow. Update your heartbeat between
 steps.
 

--- a/roles/principal-architect.md
+++ b/roles/principal-architect.md
@@ -13,14 +13,17 @@ human). **You never write code. Git is read-only for you.** The protocol in
    contracts, data model, sequencing. Approve or return it with required changes.
    Nothing is created until you approve.
 2. **Design gate — every [task], before any code.** Answer every `[design-note]`
-   with `[design-approved]` (optionally with binding conditions) or
-   `[design-pushback]` (numbered required changes). Backend [tasks] always get a
-   full design review. Frontend [tasks] declare `Architectural impact: yes/no`;
-   for a credible "no", reply `[design-approved]` fast — keep the gate cheap where
-   it should be cheap. When the team runs `REVIEW_MODE=tiered`
-   (`teams/_PLAYBOOK.md` → *Review modes*) and the [task] qualifies for a
-   combined review, attach a **numbered architecture checklist** to your
-   `[design-approved]` — it is what QA executes in your stead at review time.
+   with `[design-approved]` or `[design-pushback]` (numbered required changes).
+   Every `[design-approved]` carries a **numbered architecture checklist** — the
+   items you will verify at architecture-review time — plus any binding
+   conditions. The checklist is the implementer's target (the lead delivers it
+   in the assignment message) and the seed of the reviewer's Phase-1 checklist
+   (reviewers add items, never subtract). In `REVIEW_MODE=tiered` combined
+   reviews (`teams/_PLAYBOOK.md` → *Review modes*), QA executes your checklist
+   in your stead at review time — write it to be executable without you.
+   Backend [tasks] always get a full design review. Frontend [tasks] declare
+   `Architectural impact: yes/no`; for a credible "no", reply
+   `[design-approved]` fast — the checklist may be short, never absent.
 3. **Architecture review — every [task] in `[Review]`.** In parallel with the
    reviewer: check conformance to the approved `[design-note]` and its conditions,
    boundary violations, coupling, contract drift. Problems →
@@ -35,6 +38,15 @@ plan. You are the only role allowed to edit a [task] description — and even yo
 never rewrite the original ask of a claimed or completed [task]; you edit only
 not-yet-started ones. This sweep blocks the next [task] from being claimed on your
 track — do it promptly.
+
+Under `EXECUTION=parallel` your sweep for a [task] runs when it **enters
+`[Review]`** (every `[divergence]` comment exists by then) and gates the
+lead's dispatch of the next [task] — confirm completion by mailbox and
+tracker comment. Rework that adds new `[divergence]` comments gets an
+incremental re-sweep at `[Review]` re-entry. A finding that invalidates an
+already-dispatched [task] is a binding mailbox ruling to its implementer —
+revised `[design-note]` if needed. Sequential mode keeps the
+post-integration trigger.
 
 ## Your loop
 

--- a/roles/principal-architect.md
+++ b/roles/principal-architect.md
@@ -53,7 +53,8 @@ post-integration trigger.
 
 Every `POLL_INTERVAL_SECONDS`: mailbox, then tracker — pending `[design-note]`s
 without your verdict, [tasks] in `[Review]` without your `[architecture-approval]`,
-completed integrations (sequential) or [tasks] at [Review] entry (parallel) without your divergence sweep. You are the hot path of the
+completed integrations (sequential) or [tasks] at [Review] entry (parallel)
+without your divergence sweep. You are the hot path of the
 whole team: answer gates before doing anything slow. Update your heartbeat between
 steps.
 

--- a/roles/reviewer.md
+++ b/roles/reviewer.md
@@ -16,7 +16,8 @@ Do not wait for each other; do not coordinate verdicts.
 **Phase 1 — Plan (before reading ANY code).** Read the [feature] and the [task] —
 description, [subtasks], every comment (`[design-note]`, `[design-approved]`
 conditions, `[divergence]`). Extract every business rule, validation, edge case,
-and permission check into your own numbered checklist. Write down the files you
+and permission check into your own numbered checklist — seeded by the numbered
+architecture checklist in the `[design-approved]` (you add items, never subtract). Write down the files you
 *expect* to have changed. This independence is the point: derived from
 requirements, not from the diff.
 

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -54,6 +54,24 @@ governs everything below; this brief only says what is *yours*.
    checkout is clean (`git status --porcelain -uall`). This single dispatch
    point is what makes one-at-a-time atomic across agents — two implementers
    reading the tracker "simultaneously" cannot race a claim you never issued.
+9. **Pipelined execution (`EXECUTION=parallel` + `MAX_ACTIVE_IMPLEMENTERS=1`):
+   dispatch on `[Review]` entry.** You still dispatch every claim (the cap
+   lives in your single dispatch point), but you send assignment N+1 the
+   moment [task] N enters `[Review]` — provided N+1 consumes no `CONTRACTS.md`
+   export of any un-integrated [task], is not expected to touch its files, and
+   the principal-architect has confirmed its sweep of N. No independent [task]
+   ready → wait. Rework preempts (protocol: *Execution modes* → freeze
+   protocol): if N bounces while N+1 is in flight, send a supersession
+   assignment (park N+1, fix N, fresh `[review-request]` first), move N+1
+   `Active → Blocked` with the parked comment, and resume it
+   (`Blocked → Active`, fresh assignment) when N re-enters `[Review]`.
+   Oldest [task] first, always.
+10. **Keep the design gate ahead of the dispatch (any mode).** Settled plan →
+    the pre-flight design pass (lifecycle Scenario 10) is the default opener:
+    every gate is open before implementation starts. Emergent plan → rolling
+    look-ahead: when dispatching [task] N, trigger N+1's `[design-note]` so
+    the principal-architect reviews it while N is in flight; skip the
+    look-ahead when N+1 depends on N's implementation detail.
 
 ## Phase 2 — Supervise
 

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -102,9 +102,10 @@ default is `sequential` (the order in stage 5):
   second reviewer's value is independent evidence rather than extra findings.
 
 **Recommendation:** `sequential` for a team's first feature; `tiered` once the
-team has run history. Tiered eligibility is a mechanical test the lead applies
-at dispatch — combined review only if (a) the `[design-note]` declared
-`Architectural impact: no` **and** (b) the [task] touches no contract
+team has run history; `parallel` where dual review on every [task] is wanted
+concurrently rather than serially. Tiered eligibility is a mechanical test the
+lead applies at dispatch — combined review only if (a) the `[design-note]`
+declared `Architectural impact: no` **and** (b) the [task] touches no contract
 registered in `CONTRACTS.md`; anything else gets full dual review.
 
 Whatever the mode, the invariants hold: every required approval exists before

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -65,8 +65,9 @@ is context, not a trigger.
    2. **Team-specific specialist reviews** (listed in the team file, if any).
       Problems → `[review-findings]`; a clean pass → a plain comment stating the
       review ran and passed (specialists never invent new markers).
-   3. **QA — the final gate.** Runs the reviewer's three phases with the TPM's
-      acceptance criteria as the Phase-1 checklist; every criterion needs a
+   3. **QA — the final gate.** Runs the reviewer's three phases with a Phase-1
+      checklist seeded by the [design-approved] architecture checklist plus the
+      TPM's acceptance criteria (add items, never subtract); every criterion needs a
       `file:line` citation and a test citation; runs the applicable suites.
       Approval → `[review-approval]`, always the **last** approval.
 
@@ -148,7 +149,8 @@ Re: <taskId>  (mode: <sequential|parallel|tiered>)
 Diff: <files changed, one-line summary> (working copy: <worktree path, or
         "feature-branch checkout" in sequential execution>)
 Rule on: <open [divergence]s awaiting a ruling, or "none">
-Check: approved [design-note] conditions <pointer>; review-ledger.md lines that
+Check: [design-approved] numbered architecture checklist (your Phase-1 seed —
+        add items, never subtract) + its conditions; review-ledger.md lines that
         apply; CONTRACTS.md exports this [task] registered or consumes
 Evidence: run the applicable suites yourself; judge against BASELINE.md
 Report back: [architecture-approval] / [review-approval] with the explicit file

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -43,13 +43,18 @@ is context, not a trigger.
    `[design-approved]` (possibly with conditions) or `[design-pushback]`. No code
    before approval.
 
-   *Pre-flight variant (lifecycle Scenario 10):* when the plan should be settled
-   before any code, run all design gates as one batch — notes for every [task]
+   *Pre-flight pass (lifecycle Scenario 10) — the **default opener**:* unless
+   the plan is genuinely emergent, run all design gates as one batch — notes
+   for every [task]
    (each registering its exports in the contract registry **as it is written**),
    the architect's cross-[task] consistency review first (diffing the set against
    the registry; unregistered exports or uncited imports block approval), then
    per-[task] verdicts and TPM scope sign-offs. At claim time each gate is
    already open.
+   For genuinely emergent plans, keep the gate ahead of the dispatch with a
+   rolling look-ahead instead: when [task] N is dispatched, N+1's
+   `[design-note]` is written and reviewed while N is in flight (skip when
+   N+1 depends on N's implementation detail).
 4. **Implementation.** Own working copy per implementer (a per-[task] worktree
    under `EXECUTION=parallel`; the feature-branch checkout under `sequential`),
    the [task]'s [subtasks] as checklist, `[divergence]` comments for every
@@ -95,6 +100,12 @@ default is `sequential` (the order in stage 5):
   [task] touching a contract registered in `CONTRACTS.md`. Cheaper where the
   second reviewer's value is independent evidence rather than extra findings.
 
+**Recommendation:** `sequential` for a team's first feature; `tiered` once the
+team has run history. Tiered eligibility is a mechanical test the lead applies
+at dispatch — combined review only if (a) the `[design-note]` declared
+`Architectural impact: no` **and** (b) the [task] touches no contract
+registered in `CONTRACTS.md`; anything else gets full dual review.
+
 Whatever the mode, the invariants hold: every required approval exists before
 integration, QA's approval is last, file lists must equal the diff.
 
@@ -122,6 +133,8 @@ Assignment: <one line — what this [task] delivers>
 Inputs: [task] description + all comments; approved [design-note] + conditions
         <link/pointer>; cross-cutting rulings <pointer, if any>; CONTRACTS.md
         lines you consume: <lines or "none">
+Checklist: numbered architecture checklist from [design-approved] — implement
+        to satisfy every item
 Baseline: BASELINE.md — bar is no new failures
 Validate: <VALIDATE_* / VALIDATE_SCRIPT expectations for this change>
 Report back: [review-request] with changed-file list, validation results, and

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -149,6 +149,27 @@ bad "requiresCommit on initial refused" "not allowed on the initial" "{$MINF,\"t
 bad "no terminal refused"             "at least one terminal" "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"initial\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"A\"]}]}}"
 bad "zero initials refused"           "exactly one initial"   "{$MINF,\"tasks\":{\"statuses\":[{\"name\":\"A\",\"owner\":{\"role\":\"team-lead\"},\"transitions\":[\"Z\"]},{\"name\":\"Z\",\"terminal\":true,\"owner\":{\"role\":\"team-lead\"},\"transitions\":[]}]}}"
 
+# -- config guard: MAX_ACTIVE_IMPLEMENTERS requires EXECUTION=parallel ---------
+CFG=.claude/skills/pm/config/team.config.md
+printf 'MAX_ACTIVE_IMPLEMENTERS=1\n' >> "$CFG"
+if out="$("$LAUNCH" compose test-feature FEAT-1 backend 2>&1)"; then
+  echo "FAIL: MAX_ACTIVE_IMPLEMENTERS under sequential should be refused"; FAILURES=$((FAILURES+1))
+elif printf '%s' "$out" | grep -q "MAX_ACTIVE_IMPLEMENTERS"; then
+  echo "ok: knob refused under sequential"
+else
+  echo "FAIL: knob refusal has wrong message: $out"; FAILURES=$((FAILURES+1))
+fi
+printf 'EXECUTION=parallel\n' >> "$CFG"
+check "knob accepted under parallel" "$LAUNCH" compose test-feature FEAT-1 backend
+sed -i '' '/^MAX_ACTIVE_IMPLEMENTERS=1$/d;/^EXECUTION=parallel$/d' "$CFG"
+printf 'EXECUTION=parallel\nMAX_ACTIVE_IMPLEMENTERS=zero\n' >> "$CFG"
+if "$LAUNCH" compose test-feature FEAT-1 backend >/dev/null 2>&1; then
+  echo "FAIL: non-integer MAX_ACTIVE_IMPLEMENTERS should be refused"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-integer knob refused"
+fi
+sed -i '' '/^EXECUTION=parallel$/d;/^MAX_ACTIVE_IMPLEMENTERS=zero$/d' "$CFG"
+
 # -- status + stop --------------------------------------------------------------
 # Capture first (grep -q closes the pipe early → SIGPIPE on the writer under pipefail).
 status_out="$("$LAUNCH" status test-feature)"


### PR DESCRIPTION
## Summary

Implements the four-lever throughput design (`docs/superpowers/specs/2026-07-09-throughput-levers-design.md`), motivated by the inscribed production run (15 tasks, ~10 rework cycles, fully serial critical path):

- **Lever 1 — review-window compression:** explicit `REVIEW_MODE` recommendation (`sequential` first feature → `tiered`/`parallel` after) + a mechanical tiered-eligibility test (`Architectural impact: no` AND no `CONTRACTS.md` contract touched).
- **Lever 2 — mandatory design checklists:** every `[design-approved]` now carries a numbered architecture checklist; the lead delivers it in the ASSIGN message; reviewer/QA Phase-1 checklists are seeded from it (add items, never subtract). Attacks the root cause of the rework rate.
- **Lever 3 — design-wait elimination:** the pre-flight design pass (lifecycle Scenario 10) becomes the default opener; rolling look-ahead (`N+1`'s design reviewed while `N` is in flight) for emergent plans.
- **Lever 4 — pipelined dispatch (gated):** `MAX_ACTIVE_IMPLEMENTERS` cap under `EXECUTION=parallel`. Cap=1 = pipelined: dispatch on `[Review]` entry, independence + PA-sweep gates, rework-preempts freeze protocol (`Active → Blocked` parking with a canonical comment), divergence sweep moved to `[Review]` entry under parallel. Enablement gated on the machinery-proof checklist + <~25% rework rate. Launcher refuses the key under `sequential` (TDD'd).

Design inputs included an independent principal-architect review (run against this repo's own PA brief) whose pushback (RC-1..RC-4) and alternatives (Alt A/B/C) shaped the lever ordering.

## Changes

10 files: `reference/orchestration.md`, `reference/lifecycle.md`, `teams/_PLAYBOOK.md`, `roles/{principal-architect,team-lead,backend,reviewer}.md`, `config/team.config.md`, `bin/launch-team.sh`, `tests/launcher-test.sh` (+ spec/plan docs committed on main earlier).

## Test plan

- [x] `tests/launcher-test.sh` — ALL PASS (3 new guard checks: knob refused under sequential, accepted under parallel, non-integer refused)
- [x] `tests/tracker-ops-test.sh` — ALL PASS
- [x] Per-task spec+quality reviews (2 fix waves: checkout-check scoping, cross-doc consistency)
- [x] Whole-branch final review — 0 Critical; both Important findings fixed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)