### PR TITLE
Add skill self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ anywhere and point the agent at `SKILL.md`.
 | **Cursor / Windsurf / Cline** | the tool's rules dir | reference `SKILL.md` in chat |
 | **Anything else** | anywhere | point the agent at `SKILL.md` |
 
+### Update an installed copy
+
+From any repository where the skill is installed in Claude Code's default
+location, run:
+
+```bash
+bash .claude/skills/agent_squad_pm/bin/update-installed-skill.sh
+```
+
+Or ask Claude:
+
+```
+Fetch latest Agent Squad PM skill.
+```
+
+The updater fetches `main` from
+`https://github.com/alexrolls/agent_squad_pm.git`, syncs the bundle into
+`.claude/skills/agent_squad_pm`, and preserves existing project config files by
+default:
+
+- `config/project-management.config.md`
+- `config/team.config.md`
+- `config/statuses.config.json`
+
+To replace those config files with upstream defaults too:
+
+```bash
+bash .claude/skills/agent_squad_pm/bin/update-installed-skill.sh --overwrite-config
+```
+
+To install or update a non-default location:
+
+```bash
+bash /path/to/agent_squad_pm/bin/update-installed-skill.sh --install-dir .codex/pm
+```
+
 Multi-agent teams work on a git branch and use a task branch plus **git
 worktree** for every implementation attempt, so the bundle must live inside a
 git repository. `.teamwork/` and `.workspace/` are already git-ignored.
@@ -418,6 +454,7 @@ when `TRACKER_WRITERS=lead`; polling remains the distributed fallback.
 │   └── roles/                        14 specialized role briefs
 ├── bin/
 │   ├── launch-team.sh                role and task-instance launcher
+│   ├── update-installed-skill.sh     refresh this skill from upstream
 │   ├── dispatch.sh · dispatch-plan.py deterministic bounded scheduler
 │   ├── runtime-state.py · task_metadata.py
 │   │                                  event journal, metadata/routing, task packets

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-squad-pm
-description: Create, track, and update [features] and [tasks] in any project-management tool — Linear, Jira, GitHub Issues, or a Markdown fallback — through one tool-agnostic workflow. Use when the user wants to plan a feature, break work into tasks, start/review/complete a task, change a [task]'s status, or connect/switch the project-management tool, or run a multi-agent team on a feature (orchestration with a team lead, principal architect, and cross-functional implementers). Language- and framework-agnostic.
+description: Create, track, and update [features] and [tasks] in any project-management tool — Linear, Jira, GitHub Issues, or a Markdown fallback — through one tool-agnostic workflow. Use when the user wants to plan a feature, break work into tasks, start/review/complete a task, change a [task]'s status, connect/switch the project-management tool, run a multi-agent team on a feature (orchestration with a team lead, principal architect, and cross-functional implementers), or fetch/update the latest Agent Squad PM skill itself. Language- and framework-agnostic.
 ---
 
 # Project Management Workflow
@@ -18,6 +18,7 @@ skill's directory):
 - `reference/dispatch.md` — who converts tracker/mailbox events into role launches (the loop lives outside the agent)
 - `roles/<role>.md` + `config/team.config.md` + `bin/launch-team.sh` — the agent team
 - `bin/tracker-ops.sh` — ergonomic CLI for recurring tracker operations (scriptable mechanisms)
+- `bin/update-installed-skill.sh` — fetch the latest upstream skill bundle into the current repository
 - `bin/runtime-state.py` + `bin/task-packet.sh` — durable events, PM projections,
   and minimal task-local context
 - `bin/submit-artifact.sh` + `bin/process-outbox.sh` — idempotent agent handoffs
@@ -28,6 +29,26 @@ skill's directory):
 > **Golden rule:** in everything you write — comments, commit messages, messages to the
 > user — use only the generic vocabulary — terms `[feature]`, `[task]`, `[subtask]` and the statuses defined in `config/statuses.config.json` (default board: `[Planned]`/`[Active]`/`[Review]`/`[Blocked]`/`[Ready to deploy]`). Never write "issue", "epic",
 > "story", or "ticket" outside the adapter. See the banned-terms list in `vocabulary.md`.
+
+## Self-update request
+
+If the user asks to "fetch latest Agent Squad PM", "update agent_squad_pm skill",
+"sync this skill from upstream", or equivalent, do this before the normal mandatory
+preparation:
+
+1. From the target repository, run:
+
+   ```bash
+   bash .claude/skills/agent_squad_pm/bin/update-installed-skill.sh
+   ```
+
+   If this skill is installed somewhere else, run the same script from this skill's
+   `bin/` directory with `--install-dir <path-to-installed-skill>`.
+2. Keep the default config-preserving behavior unless the user explicitly asks to
+   replace project config. Existing `config/project-management.config.md`,
+   `config/team.config.md`, and `config/statuses.config.json` are preserved.
+3. Report the script's target path and git status/diff summary. Do not commit unless
+   the user asks.
 
 ## Mandatory Preparation (every invocation)
 

--- a/bin/update-installed-skill.sh
+++ b/bin/update-installed-skill.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# update-installed-skill.sh — refresh an installed Agent Squad PM skill from GitHub.
+set -euo pipefail
+
+REMOTE_URL="${AGENT_SQUAD_PM_REMOTE_URL:-https://github.com/alexrolls/agent_squad_pm.git}"
+REMOTE_REF="${AGENT_SQUAD_PM_REF:-main}"
+SKILL_NAME="${AGENT_SQUAD_PM_SKILL_NAME:-agent_squad_pm}"
+
+install_dir=""
+overwrite_config=false
+dry_run=false
+
+die() {
+  echo "update-installed-skill: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: update-installed-skill.sh [options]
+
+Fetch the latest Agent Squad PM bundle and sync it into the current repository's
+.claude/skills/agent_squad_pm directory.
+
+Options:
+  --install-dir PATH     Update this skill directory instead of auto-detecting.
+  --remote-url URL       Git remote to fetch from.
+                         Default: $REMOTE_URL
+  --ref REF              Branch or tag to fetch.
+                         Default: $REMOTE_REF
+  --overwrite-config     Replace local config files with the upstream defaults.
+  --dry-run              Show rsync changes without writing them.
+  -h, --help             Show this help.
+
+Environment overrides:
+  AGENT_SQUAD_PM_REMOTE_URL
+  AGENT_SQUAD_PM_REF
+  AGENT_SQUAD_PM_SKILL_NAME
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      [ "$#" -ge 2 ] || die "--install-dir requires a path"
+      install_dir="$2"
+      shift 2
+      ;;
+    --remote-url)
+      [ "$#" -ge 2 ] || die "--remote-url requires a URL"
+      REMOTE_URL="$2"
+      shift 2
+      ;;
+    --ref)
+      [ "$#" -ge 2 ] || die "--ref requires a branch or tag"
+      REMOTE_REF="$2"
+      shift 2
+      ;;
+    --overwrite-config)
+      overwrite_config=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+command -v git >/dev/null 2>&1 || die "git is required"
+command -v rsync >/dev/null 2>&1 || die "rsync is required"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+script_skill_dir="$(cd "$script_dir/.." && pwd -P)"
+
+if [ -z "$install_dir" ]; then
+  case "$script_skill_dir" in
+    */.claude/skills/"$SKILL_NAME")
+      install_dir="$script_skill_dir"
+      ;;
+    *)
+      repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+      [ -n "$repo_root" ] || die "not inside a git repository; pass --install-dir"
+      install_dir="$repo_root/.claude/skills/$SKILL_NAME"
+      ;;
+  esac
+fi
+
+case "$install_dir" in
+  /*) ;;
+  *) install_dir="$(pwd -P)/$install_dir" ;;
+esac
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+checkout="$tmp/source"
+preserve="$tmp/preserve"
+
+echo "Fetching $REMOTE_URL ($REMOTE_REF)"
+git clone --depth 1 --branch "$REMOTE_REF" "$REMOTE_URL" "$checkout" >/dev/null
+
+if ! $overwrite_config && [ -d "$install_dir" ]; then
+  for file in \
+    config/project-management.config.md \
+    config/team.config.md \
+    config/statuses.config.json
+  do
+    if [ -f "$install_dir/$file" ]; then
+      mkdir -p "$preserve/$(dirname "$file")"
+      cp "$install_dir/$file" "$preserve/$file"
+    fi
+  done
+fi
+
+mkdir -p "$install_dir"
+
+rsync_args=(-a --delete --exclude .git)
+if $dry_run; then
+  rsync_args+=(--dry-run --itemize-changes)
+fi
+
+rsync "${rsync_args[@]}" "$checkout"/ "$install_dir"/
+
+if ! $overwrite_config && ! $dry_run && [ -d "$preserve" ]; then
+  rsync -a "$preserve"/ "$install_dir"/
+fi
+
+echo "Updated Agent Squad PM skill at: $install_dir"
+if ! $overwrite_config; then
+  echo "Preserved existing local config files when present."
+fi
+
+target_repo="$(git -C "$install_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$target_repo" ]; then
+  case "$install_dir" in
+    "$target_repo") rel_path="." ;;
+    "$target_repo"/*) rel_path="${install_dir#"$target_repo"/}" ;;
+    *) rel_path="$install_dir" ;;
+  esac
+
+  echo
+  echo "Git status for $rel_path:"
+  git -C "$target_repo" status --short -- "$rel_path" || true
+
+  if ! $dry_run; then
+    echo
+    echo "Diff stat for $rel_path:"
+    git -C "$target_repo" diff --stat -- "$rel_path" || true
+  fi
+fi


### PR DESCRIPTION
## Summary

Adds a repo-owned updater script for refreshing an installed Agent Squad PM skill from upstream.

## Details

- Adds bin/update-installed-skill.sh to fetch the upstream bundle and sync it into .claude/skills/agent_squad_pm.
- Preserves existing local project config files by default, with --overwrite-config for replacing them.
- Documents the terminal command and the natural-language Claude trigger.
- Updates SKILL.md so requests like Fetch latest Agent Squad PM skill route to the updater before the normal workflow.

## Validation

- bash -n bin/update-installed-skill.sh
- bash bin/update-installed-skill.sh --help