### PR TITLE
Add portfolio automation foundations: scan, guardrails, policy gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,46 @@ state remain visible where your team already manages the project.
 [feature] -> design gate -> safe parallel [tasks] -> review -> QA -> validated integration -> [Ready to deploy]
 ```
 
+## The security gateway for AI builders
+
+Autonomous agents are only as useful as the boundaries around them. If you are
+building with AI teams, Startup Factory's strongest argument is not the speed —
+it is the **fail-closed security gateway** that stands between every agent and
+anything destructive:
+
+- **A code-owned policy gate.** `bin/policy-check.py` screens every privileged
+  structured command and release plan before a subprocess starts. Its deny
+  baseline — shell composition, privilege escalation, filesystem/database/
+  infrastructure destruction, secret dumping, metadata-credential access,
+  encoded-command bypasses — is owned by the code: project configuration can
+  **add** denials, never remove one.
+- **A three-tier authority model.** Every action resolves to **DENY**,
+  **REQUIRE HUMAN APPROVAL**, or **ALLOW** (`reference/guardrails.md`).
+  Approvals bind exact digests, environments, targets, expirations, and one-use
+  nonces. Silence never approves; unknown anything is denied.
+- **A ticket-level audit trail for blocked actions.** When an agentic team or a
+  dedicated agent attempts a denied action, the enforcing component documents
+  it on the ticket as an idempotent `[DENIED ACTION]` comment
+  (`bin/tracker-ops.sh record-denial`): which agent acted, a full sanitized
+  description of what it tried to do, why the policy gate refused, and the
+  explicit statement that the action was prevented and never executed. Your
+  tracker shows not only what agents did — but what they were stopped from doing.
+- **Least-privilege agent sandboxes.** LLM processes start under `env -i` with a
+  positive environment allowlist; secrets, cloud credentials, deploy tokens, and
+  metadata endpoints are refused. In broker mode no LLM — including the team
+  lead — ever holds tracker credentials.
+- **Contained workspaces.** Every implementer is isolated in its own git
+  worktree; tracker file paths are symlink-safe and confined to their configured
+  root; integration and terminal transitions are serialized, verified by
+  read-back, and reserved to dedicated components.
+- **Automation that is off by default.** The portfolio supervisor is
+  deterministic (not an LLM), disabled until explicitly enabled, and stops the
+  pass rather than fabricating state when anything is malformed.
+
+The result: you can hand real delivery work to AI agents and still answer, from
+your own tracker, the questions an auditor would ask — who did what, who
+approved what, and what was denied.
+
 ## Why Startup Factory
 
 | Advantage | What it gives you |
@@ -43,6 +83,7 @@ projected back into the configured tool.
 | Live progress | A mechanically updated `[progress]` record on every task and a compact `[digest]` across the feature |
 | Validation and review | Evidence records, changed-file lists, review findings, exact artifact paths, and explicit `NOT validated` declarations |
 | Blockers and human decisions | Proven `blocked-by` relationships plus escalations with a question, options, and a default if you are unavailable |
+| Denied actions | Idempotent `[DENIED ACTION]` audit comments: which agent attempted a forbidden action, what it tried to do, why the policy gate refused, and that it was never executed |
 | Delivery | The integrated commit, completed validation gates, and the final move to `[Ready to deploy]` |
 
 Use as much of the system as your project needs:
@@ -63,6 +104,7 @@ delivery contract around the code rather than assuming anything about the stack.
 
 ## Table of contents
 
+- [The security gateway for AI builders](#the-security-gateway-for-ai-builders)
 - [Why Startup Factory](#why-startup-factory)
 - [Full transparency in your tracker](#full-transparency-in-your-tracker)
 - [Requirements](#requirements)
@@ -392,7 +434,8 @@ Just talk to your agent in the generic vocabulary:
 
 There is also `bin/tracker-ops.sh` — an ergonomic wrapper for the recurring
 tracker operations (`claim`, `state`, `comment` with the body from a file/stdin,
-`update-comment <id> <file>`, `upsert-progress`, `upsert-digest`, `integrate
+`update-comment <id> <file>`, `upsert-progress`, `upsert-digest`,
+`record-denial` (idempotent `[DENIED ACTION]` audit records), `integrate
 <hash>`, `export`) over the scriptable access mechanisms (Linear/Jira REST,
 `gh`, Markdown files). The adapter docs remain the spec; MCP sessions use their
 native tools instead.

--- a/bin/policy-check.py
+++ b/bin/policy-check.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Fail-closed policy gate for privileged structured commands and release plans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ALLOW = "ALLOW"
+APPROVAL = "REQUIRE_HUMAN_APPROVAL"
+DENY = "DENY"
+
+# This baseline is code-owned. Project configuration may add denials, never remove one.
+DENY_COMMAND_PATTERNS = (
+    (r"[\n\r;&|><`$]", "shell composition/redirection is forbidden"),
+    (r"(^|\s)(?:sudo|doas)(?:\s|$)", "privilege escalation is forbidden"),
+    (r"(^|\s)(?:ba|z|c|k|fi)?sh\s+-c(?:\s|$)", "opaque shell execution is forbidden"),
+    (r"(^|\s)(?:eval|exec|xargs)(?:\s|$)", "opaque command execution is forbidden"),
+    (r"(^|\s)(?:rm|rmdir)(?:\s|$)", "filesystem deletion is forbidden in the privileged executor"),
+    (r"(^|\s)find(?:\s+\S+)*\s+-delete(?:\s|$)", "bulk filesystem deletion is forbidden"),
+    (r"(^|\s)(?:dd|mkfs(?:\.\w+)?|fdisk|parted|shred)(?:\s|$)", "device/filesystem destruction is forbidden"),
+    (r"\bgit\s+reset\s+--hard\b", "destructive git reset is forbidden"),
+    (r"\bgit\s+clean\s+[^\n]*-[^\s]*f", "destructive git clean is forbidden"),
+    (r"\bgit\s+push\s+[^\n]*(?:--force(?:-with-lease)?|-f)(?:\s|$)", "force push is forbidden"),
+    (r"\bgit\s+(?:branch\s+-D|tag\s+-d)(?:\s|$)", "protected ref deletion is forbidden"),
+    (r"\bDROP\s+(?:DATABASE|SCHEMA)\b", "database/schema drop is forbidden"),
+    (r"\bTRUNCATE(?:\s+TABLE)?\b", "database truncation is forbidden"),
+    (r"\bDELETE\s+FROM\b(?![^;]*\bWHERE\b)", "unbounded database deletion is forbidden"),
+    (r"\bterraform\s+destroy\b", "infrastructure destroy is forbidden"),
+    (r"\bterraform\s+apply\b[^\n]*\s-destroy\b", "infrastructure destroy is forbidden"),
+    (r"\bpulumi\s+destroy\b", "infrastructure destroy is forbidden"),
+    (r"\bkubectl\s+delete\b", "cluster resource deletion is forbidden"),
+    (r"\bhelm\s+uninstall\b", "release deletion is forbidden"),
+    (r"\b(?:delete|destroy|terminate|purge|deprovision)[-_ ](?:instance|cluster|database|db|volume|disk|network|subnet|vpc|key|secret|backup|log|bucket|dns|certificate)s?\b", "resource deletion is forbidden"),
+    (r"(^|\s)(?:env|printenv)(?:\s|$)", "environment/secret dumping is forbidden"),
+    (r"169\.254\.169\.254|metadata\.google\.internal", "metadata credential access is forbidden"),
+    (r"\b(?:disable|delete)[-_ ](?:audit|logging|backup|monitoring|alarm|waf|mfa|policy)\b", "control-plane safeguard removal is forbidden"),
+    (r"\b(?:base64|openssl)\b[^\n]*(?:-d|--decode)\b", "encoded command bypass is forbidden"),
+)
+
+ALLOWED_ACTIONS = {"deploy.plan", "deploy.status", "deploy.verify", "approval.verify"}
+PREAUTH_ACTIONS = {"deploy.apply", "deploy.rollback"}
+PLAN_ACTIONS = {"CREATE", "READ", "UPDATE", "REPLACE", "DELETE"}
+SENSITIVE_RESOURCE_WORDS = {
+    "database", "schema", "table", "data", "migration", "iam", "identity", "role",
+    "policy", "network", "subnet", "firewall", "dns", "certificate", "secret", "kms",
+    "key", "backup", "billing", "quota", "capacity", "traffic", "region",
+}
+
+
+def load_config(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"cannot load guardrail config {path}: {exc}") from exc
+    if value.get("schemaVersion") != 1:
+        raise ValueError("guardrail config schemaVersion must be 1")
+    return value
+
+
+def result(decision: str, reason: str, **extra: object) -> dict:
+    return {"decision": decision, "reason": reason, **extra}
+
+
+def emit(value: dict) -> int:
+    print(json.dumps(value, sort_keys=True))
+    return {ALLOW: 0, APPROVAL: 2, DENY: 3}[value["decision"]]
+
+
+def evaluate_command(action: str, environment: str, argv: list[str], preauthorized: bool, config: dict) -> dict:
+    if not argv or not all(isinstance(token, str) and token and "\x00" not in token for token in argv):
+        return result(DENY, "command must be a non-empty structured argv array")
+    normalized = " ".join(argv)
+    for pattern, reason in DENY_COMMAND_PATTERNS:
+        if re.search(pattern, normalized, re.IGNORECASE):
+            return result(DENY, reason, pattern=pattern)
+    for pattern in config.get("additionalDenyPatterns") or []:
+        try:
+            matched = re.search(pattern, normalized, re.IGNORECASE)
+        except re.error as exc:
+            return result(DENY, f"invalid additional deny pattern: {exc}")
+        if matched:
+            return result(DENY, "project guardrail denied the command", pattern=pattern)
+    if action in ALLOWED_ACTIONS:
+        return result(ALLOW, f"{action} is read-only or independently verifying")
+    if action in PREAUTH_ACTIONS:
+        if environment != "production":
+            return result(DENY, "privileged release hooks are production-only in this executor")
+        if preauthorized:
+            return result(ALLOW, f"{action} is bound to a verified/pre-authorized release manifest")
+        return result(APPROVAL, f"{action} requires an exact release authorization")
+    if action in set(config.get("additionalApprovalRequiredActions") or []):
+        return result(APPROVAL, f"project policy requires approval for {action}")
+    return result(DENY, f"unknown privileged action: {action}")
+
+
+def evaluate_plan(plan: dict, mode: str, approved: bool, config: dict) -> dict:
+    if plan.get("schemaVersion") != 1:
+        return result(DENY, "release plan schemaVersion must be 1")
+    if plan.get("environment") != "production":
+        return result(DENY, "release plan environment must be production")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", str(plan.get("commit") or "")):
+        return result(DENY, "release plan must bind a full immutable commit hash")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", str(plan.get("artifactDigest") or "")):
+        return result(DENY, "release plan must bind a sha256 artifact digest")
+    changes = plan.get("changes")
+    if not isinstance(changes, list):
+        return result(DENY, "release plan changes must be a list")
+    maximum = int(config.get("maximumAutomaticPlanChanges", 100))
+    if len(changes) > maximum:
+        return result(APPROVAL, f"plan has {len(changes)} changes; maximum automatic count is {maximum}")
+    approval_reasons: list[str] = []
+    for index, change in enumerate(changes):
+        if not isinstance(change, dict):
+            return result(DENY, f"plan change {index} is not an object")
+        operation = str(change.get("action") or "").upper()
+        if operation not in PLAN_ACTIONS:
+            return result(DENY, f"unknown plan action at change {index}: {operation or '<empty>'}")
+        if operation in {"DELETE", "REPLACE"}:
+            return result(DENY, f"autonomous {operation} is forbidden at change {index}")
+        resource = " ".join(str(change.get(key) or "") for key in ("resourceType", "resourceId")).lower()
+        if operation in {"CREATE", "UPDATE"} and any(word in resource for word in SENSITIVE_RESOURCE_WORDS):
+            approval_reasons.append(f"sensitive {operation} at change {index} ({resource.strip()})")
+        if bool(change.get("publicExposure")):
+            approval_reasons.append(f"public exposure at change {index}")
+        try:
+            cost_delta = float(change.get("estimatedCostDelta") or 0)
+        except (TypeError, ValueError):
+            return result(DENY, f"invalid estimatedCostDelta at change {index}")
+        if cost_delta > float(config.get("maximumAutomaticCostDelta", 0)):
+            approval_reasons.append(f"cost delta {cost_delta} at change {index}")
+    if approval_reasons and not approved:
+        return result(APPROVAL, "; ".join(approval_reasons))
+    if approval_reasons and mode == "automatic":
+        return result(DENY, "automatic mode cannot authorize policy-sensitive plan changes")
+    if mode == "approval-required" and not approved:
+        return result(APPROVAL, "production apply requires an external exact-manifest authorization")
+    if mode not in {"automatic", "approval-required"}:
+        return result(DENY, f"unknown deployment mode: {mode}")
+    return result(ALLOW, "plan is non-destructive and bound to the reviewed artifact")
+
+
+def main() -> int:
+    default_config = Path(__file__).resolve().parent.parent / "config" / "guardrails.config.json"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=default_config)
+    sub = parser.add_subparsers(dest="operation", required=True)
+
+    command = sub.add_parser("command")
+    command.add_argument("--action", required=True)
+    command.add_argument("--environment", required=True)
+    command.add_argument("--preauthorized", action="store_true")
+    command.add_argument("argv", nargs=argparse.REMAINDER)
+
+    plan = sub.add_parser("plan")
+    plan.add_argument("--mode", required=True)
+    plan.add_argument("--approved", action="store_true")
+    plan.add_argument("plan_file", type=Path)
+
+    args = parser.parse_args()
+    try:
+        config = load_config(args.config)
+        if args.operation == "command":
+            argv = args.argv[1:] if args.argv[:1] == ["--"] else args.argv
+            value = evaluate_command(args.action, args.environment, argv, args.preauthorized, config)
+        else:
+            try:
+                payload = json.loads(args.plan_file.read_text())
+            except (OSError, ValueError) as exc:
+                value = result(DENY, f"cannot load release plan: {exc}")
+            else:
+                value = evaluate_plan(payload, args.mode, args.approved, config)
+    except ValueError as exc:
+        value = result(DENY, str(exc))
+    return emit(value)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -15,6 +15,8 @@
 #   tracker-ops.sh upsert-progress <taskId> [bodyfile]                       # create/update the task's single [progress] artifact
 #   tracker-ops.sh upsert-digest   <featureId> [bodyfile]                    # create/update the feature's single [digest] artifact
 #   tracker-ops.sh claim          <taskId> <role> [--to <Status>]           # claim: initial→working status + claim comment
+#   tracker-ops.sh record-denial  <taskId> --actor <agent> --reason <text> [--denial-id <id>] [bodyfile]
+#                                                                            # idempotent [DENIED ACTION] audit comment
 #   tracker-ops.sh integrate      <taskId> <hash> [bodyfile]                # terminal move + completion comment citing <hash>
 #   tracker-ops.sh export         <featureId> <outfile>                     # read-side: dump the [feature]'s [tasks] as JSON
 #   tracker-ops.sh scan           <outfile> --status <Status>...            # board-wide normalized discovery
@@ -130,6 +132,13 @@ def read_body(path):
     if not body:
         die("empty comment body")
     return body
+
+def sanitize_untrusted(text, limit):
+    """Bound untrusted agent-supplied text before it becomes tracker evidence."""
+    text = ''.join(ch if ch in '\n\t' or ord(ch) >= 32 else ' ' for ch in text).strip()
+    if len(text) > limit:
+        text = text[:limit].rstrip() + '\n… [truncated for the tracker; the full record stays in protected local logs]'
+    return text
 
 def replace_managed_block(text, key, body):
     """Replace one generated block while preserving all user-authored text."""
@@ -806,9 +815,15 @@ class Markdown:
         marker = marker_m.group(1) if marker_m else 'note'
         content = body[len(marker):].lstrip(' :') if marker_m else body
         lines = content.split('\n')
-        quoted = '> %s (%s): %s' % (marker, date.today().isoformat(), lines[0])
-        for extra in lines[1:]:
-            quoted += '\n> %s' % extra
+        if body.startswith('[DENIED ACTION]'):
+            # A denied-action audit record keeps its marker literal. Preserve the
+            # envelope byte-for-byte (apart from Markdown quote prefixes) instead
+            # of folding its first field into the legacy dated first line.
+            quoted = '\n'.join('> %s' % line for line in body.split('\n'))
+        else:
+            quoted = '> %s (%s): %s' % (marker, date.today().isoformat(), lines[0])
+            for extra in lines[1:]:
+                quoted += '\n> %s' % extra
         rest = text[m.end():]
         nxt = re.search(r'^## ', rest, re.M)
         insert_at = m.end() + (nxt.start() if nxt else len(rest))
@@ -1080,6 +1095,47 @@ def op_claim(args):
         die("claim write did not read back as [%s] (observed: %s) — no launch" % (to, observed))
     print("%s claimed by %s → [%s] (claim-id: %s)" % (task_id, role, to, claim_id))
 
+def op_record_denial(args):
+    # A guardrail DENY encountered while an agentic team or dedicated agent acts
+    # on a [task] must become ticket-level evidence: what was attempted, by whom,
+    # and that the action was prevented. Documentation only — never authorization.
+    actor = reason = denial_id = None
+    for flag in ('--actor', '--reason', '--denial-id'):
+        if flag in args:
+            i = args.index(flag)
+            value = args[i + 1] if i + 1 < len(args) else die("%s needs a value" % flag)
+            args = args[:i] + args[i + 2:]
+            if flag == '--actor': actor = value
+            elif flag == '--reason': reason = value
+            else: denial_id = value
+    if len(args) not in (1, 2):
+        die("usage: record-denial <taskId> --actor <agent> --reason <text> [--denial-id <id>] [bodyfile]")
+    task_id = args[0]
+    if not actor or not reason:
+        die("record-denial requires --actor and --reason")
+    actor = sanitize_untrusted(actor.replace('\n', ' '), 128)
+    reason = sanitize_untrusted(reason.replace('\n', '; '), 500)
+    if not actor or not reason:
+        die("record-denial actor/reason must not be empty after sanitization")
+    attempted = sanitize_untrusted(read_body(args[1] if len(args) == 2 else None), 1800)
+    if not attempted:
+        die("record-denial requires a non-empty attempted-action description")
+    denial_id = denial_id or ('denial-' + hashlib.sha256(
+        ('%s\0%s\0%s\0%s' % (task_id, actor, reason, attempted)).encode()).hexdigest()[:24])
+    if not re.fullmatch(r'[A-Za-z0-9._:-]{8,128}', denial_id):
+        die("invalid denial id '%s'" % denial_id)
+    token = "denial-id: %s" % denial_id
+    if backend.comment_exists(task_id, token):
+        print("%s denial %s already recorded" % (task_id, denial_id))
+        return
+    body = ("[DENIED ACTION]\n%s\nactor: %s\ndecision: DENY\n\n"
+            "Attempted action:\n%s\n\n"
+            "Denial reason: %s\n\n"
+            "This action was blocked by the fail-closed policy gate and was not executed.\n\n"
+            "— policy gate" % (token, actor, attempted, reason))
+    backend.comment(task_id, body)
+    print("%s denial recorded (denial-id: %s)" % (task_id, denial_id))
+
 def op_integrate(args):
     if len(args) not in (2, 3):
         die("usage: integrate <taskId> <commit-hash> [bodyfile]")
@@ -1159,8 +1215,9 @@ def op_scan(args):
 OPS = {'state': op_state, 'comment': op_comment, 'comment-once': op_comment_once, 'update-comment': op_update_comment,
        'upsert-progress': op_upsert_progress, 'upsert-digest': op_upsert_digest,
        'upsert-deployment': op_upsert_deployment, 'feature-state': op_feature_state,
-       'claim': op_claim, 'integrate': op_integrate, 'export': op_export, 'scan': op_scan}
+       'claim': op_claim, 'record-denial': op_record_denial, 'integrate': op_integrate,
+       'export': op_export, 'scan': op_scan}
 if not ARGS or ARGS[0] not in OPS:
-    die("usage: tracker-ops.sh {state|feature-state|comment|comment-once|update-comment|upsert-progress|upsert-digest|upsert-deployment|claim|integrate|export|scan} ...")
+    die("usage: tracker-ops.sh {state|feature-state|comment|comment-once|update-comment|upsert-progress|upsert-digest|upsert-deployment|claim|record-denial|integrate|export|scan} ...")
 OPS[ARGS[0]](ARGS[1:])
 PYEOF

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -17,6 +17,9 @@
 #   tracker-ops.sh claim          <taskId> <role> [--to <Status>]           # claim: initial→working status + claim comment
 #   tracker-ops.sh integrate      <taskId> <hash> [bodyfile]                # terminal move + completion comment citing <hash>
 #   tracker-ops.sh export         <featureId> <outfile>                     # read-side: dump the [feature]'s [tasks] as JSON
+#   tracker-ops.sh scan           <outfile> --status <Status>...            # board-wide normalized discovery
+#   tracker-ops.sh feature-state  <featureId> <Status>                      # set [feature] status (generic name)
+#   tracker-ops.sh upsert-deployment <featureId> [bodyfile]                 # one managed [deployment] projection
 #
 # Adapter comes from PRODUCT_MANAGEMENT_TOOL in config/project-management.config.md
 # (override with TRACKER_ADAPTER=<Name>). Credentials come from the environment,
@@ -27,7 +30,7 @@ set -euo pipefail
 # The script rides on fd 3 so stdin stays free for comment bodies.
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 exec python3 /dev/fd/3 "$SKILL_DIR" "$@" 3<<'PYEOF'
-import json, os, re, subprocess, sys, urllib.request, urllib.error
+import hashlib, json, os, re, subprocess, sys, urllib.request, urllib.error
 from datetime import date, datetime, timezone
 
 def die(msg):
@@ -64,6 +67,7 @@ except (OSError, ValueError) as e:
     die("cannot load board config %s: %s" % (board_path, e))
 
 TASK_STATUSES = BOARD['tasks']['statuses']
+FEATURE_STATUSES = BOARD['features']['statuses']
 
 def status_by_name(name):
     for s in TASK_STATUSES:
@@ -71,10 +75,22 @@ def status_by_name(name):
             return s
     die("unknown [task] status '%s' (board: %s)" % (name, ', '.join(x['name'] for x in TASK_STATUSES)))
 
+def feature_status_by_name(name):
+    for s in FEATURE_STATUSES:
+        if s['name'] == name:
+            return s
+    die("unknown [feature] status '%s' (board: %s)" % (name, ', '.join(x['name'] for x in FEATURE_STATUSES)))
+
 def tool_value(status):
     v = status.get('tool', {}).get(ADAPTER)
     if v is None:
         die("status '%s' has no '%s' mapping in the board config — andon" % (status['name'], ADAPTER))
+    return v
+
+def feature_tool_value(status):
+    v = status.get('tool', {}).get(ADAPTER)
+    if v is None:
+        die("[feature] status '%s' has no '%s' mapping in the board config — andon" % (status['name'], ADAPTER))
     return v
 
 def initial_status():
@@ -91,6 +107,12 @@ def terminal_status():
 
 def generic_of(raw):  # reverse-map a tool-side status value to the generic name
     for s in TASK_STATUSES:
+        if s.get('tool', {}).get(ADAPTER) == raw:
+            return s['name']
+    return None
+
+def feature_generic_of(raw):
+    for s in FEATURE_STATUSES:
         if s.get('tool', {}).get(ADAPTER) == raw:
             return s['name']
     return None
@@ -222,6 +244,28 @@ class Linear:
         self.gql('mutation($id: String!, $description: String!) { projectUpdate(id: $id, input: {description: $description}) { success } }',
                  {'id': pid, 'description': description})
 
+    def upsert_deployment(self, feature_id, body):
+        pid = self.project_id(feature_id)
+        d = self.gql('query($id: String!) { project(id: $id) { description } }', {'id': pid})
+        description = replace_managed_block((d.get('project') or {}).get('description') or '', 'deployment', body)
+        self.gql('mutation($id: String!, $description: String!) { projectUpdate(id: $id, input: {description: $description}) { success } }',
+                 {'id': pid, 'description': description})
+
+    def current_feature_status(self, feature_id):
+        d = self.gql('query($id: String!) { project(id: $id) { status { name } } }',
+                     {'id': self.project_id(feature_id)})
+        raw = ((d.get('project') or {}).get('status') or {}).get('name')
+        return feature_generic_of(raw)
+
+    def set_feature_state(self, feature_id, status):
+        want = feature_tool_value(status)
+        d = self.gql('{ projectStatuses { nodes { id name } } }')
+        sid = next((s['id'] for s in d.get('projectStatuses', {}).get('nodes', []) if s.get('name') == want), None)
+        if not sid:
+            die("Linear workspace has no project status '%s' — andon" % want)
+        self.gql('mutation($id: String!, $sid: String!) { projectUpdate(id: $id, input: {statusId: $sid}) { success } }',
+                 {'id': self.project_id(feature_id), 'sid': sid})
+
     def project_id(self, feature_id):
         # The adapter's ID mapping allows a project UUID or a project name.
         if re.fullmatch(r'[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}', feature_id.lower()):
@@ -236,7 +280,7 @@ class Linear:
         return nodes[0]['id']
 
     def export(self, feature_id):
-        d = self.gql('query($id: String!) { project(id: $id) { name issues { nodes { identifier title description state { name } assignee { name } comments { nodes { id body createdAt } } inverseRelations { nodes { type issue { identifier } } } } } } }',
+        d = self.gql('query($id: String!) { project(id: $id) { name issues { nodes { identifier title description updatedAt state { name } assignee { name } labels { nodes { name } } comments { nodes { id body createdAt user { name email } } } inverseRelations { nodes { type issue { identifier } } } } } } }',
                      {'id': self.project_id(feature_id)})
         if not d.get('project'):
             die("no Linear project '%s'" % feature_id)
@@ -250,10 +294,64 @@ class Linear:
                           'status': generic_of(raw), 'statusRaw': raw,
                           'assignee': (i.get('assignee') or {}).get('name'),
                           'description': i.get('description'),
-                          'comments': [{'id': c.get('id'), 'body': c['body'], 'createdAt': c['createdAt']}
+                          'comments': [{'id': c.get('id'), 'body': c['body'], 'createdAt': c['createdAt'],
+                                        'author': (c.get('user') or {}).get('email') or (c.get('user') or {}).get('name')}
                                        for c in i['comments']['nodes']],
-                          'blockedBy': blocked_by})
+                          'blockedBy': blocked_by,
+                          'labels': [x['name'] for x in (i.get('labels') or {}).get('nodes', [])],
+                          'updatedAt': i.get('updatedAt'), 'revision': i.get('updatedAt')})
         return tasks
+
+    def scan(self, statuses):
+        wanted = {tool_value(status_by_name(name)) for name in statuses}
+        team_scope = PM_CONFIG.get('LINEAR_DEFAULT_TEAM')
+        items, after = [], None
+        query = '''query($after: String) {
+          issues(first: 100, after: $after) {
+            nodes {
+              identifier title description updatedAt
+              state { name } assignee { name }
+              team { key name }
+              project { id name }
+              labels { nodes { name } }
+              comments { nodes { id body createdAt user { name email } } }
+              inverseRelations { nodes { type issue { identifier } } }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }'''
+        while True:
+            d = self.gql(query, {'after': after})['issues']
+            for i in d.get('nodes', []):
+                raw = (i.get('state') or {}).get('name')
+                team = i.get('team') or {}
+                if raw not in wanted:
+                    continue
+                if team_scope and team_scope not in {team.get('key'), team.get('name')}:
+                    continue
+                project = i.get('project') or {}
+                blocked_by = [r['issue']['identifier']
+                              for r in (i.get('inverseRelations') or {}).get('nodes', [])
+                              if r.get('type') == 'blocks' and r.get('issue')]
+                items.append({
+                    'featureId': project.get('id'), 'featureTitle': project.get('name'),
+                    'taskId': i['identifier'], 'title': i['title'],
+                    'status': generic_of(raw), 'statusRaw': raw,
+                    'assignee': (i.get('assignee') or {}).get('name'),
+                    'description': i.get('description'), 'blockedBy': blocked_by,
+                    'comments': [{'id': c.get('id'), 'body': c.get('body'), 'createdAt': c.get('createdAt'),
+                                  'author': (c.get('user') or {}).get('email') or (c.get('user') or {}).get('name')}
+                                 for c in (i.get('comments') or {}).get('nodes', [])],
+                    'labels': [x['name'] for x in (i.get('labels') or {}).get('nodes', [])],
+                    'updatedAt': i.get('updatedAt'), 'revision': i.get('updatedAt'),
+                })
+            page = d.get('pageInfo') or {}
+            if not page.get('hasNextPage'):
+                break
+            after = page.get('endCursor')
+            if not after:
+                die("Linear pagination said hasNextPage without an endCursor")
+        return items
 
 class Jira:
     def __init__(self):
@@ -320,8 +418,31 @@ class Jira:
         else:
             self.comment(feature_id, body)
 
+    def upsert_deployment(self, feature_id, body):
+        issue = self.api('/rest/api/3/issue/%s?fields=comment' % feature_id)
+        comments = (issue.get('fields', {}).get('comment') or {}).get('comments', [])
+        current = next((c for c in comments
+                        if adf_text(c.get('body')).lstrip().startswith('[deployment]')), None)
+        if current:
+            self.update_comment(feature_id, current['id'], body)
+        else:
+            self.comment(feature_id, body)
+
+    def current_feature_status(self, feature_id):
+        issue = self.api('/rest/api/3/issue/%s?fields=status' % feature_id)
+        return feature_generic_of(issue['fields']['status']['name'])
+
+    def set_feature_state(self, feature_id, status):
+        want = feature_tool_value(status)
+        trans = self.api('/rest/api/3/issue/%s/transitions' % feature_id).get('transitions', [])
+        tid = next((t['id'] for t in trans if t.get('to', {}).get('name') == want), None)
+        if not tid:
+            avail = ', '.join(t.get('to', {}).get('name', '?') for t in trans)
+            die("no Jira [feature] transition to '%s' (available: %s) — andon" % (want, avail))
+        self.api('/rest/api/3/issue/%s/transitions' % feature_id, {'transition': {'id': tid}})
+
     def export(self, feature_id):
-        out = self.api('/rest/api/3/search?jql=%s&fields=summary,description,status,assignee,comment,issuelinks&maxResults=100'
+        out = self.api('/rest/api/3/search?jql=%s&fields=summary,description,status,assignee,comment,issuelinks,labels,updated&maxResults=100'
                        % urllib.request.quote('parent=%s' % feature_id))
         tasks = []
         for i in out.get('issues', []):
@@ -332,11 +453,50 @@ class Jira:
             tasks.append({'taskId': i['key'], 'title': f['summary'],
                           'status': generic_of(raw), 'statusRaw': raw,
                           'assignee': (f.get('assignee') or {}).get('displayName'),
-                          'description': f.get('description'),
-                          'comments': [{'id': c.get('id'), 'body': adf_text(c.get('body')), 'createdAt': c.get('created')}
+                          'description': adf_text(f.get('description')),
+                          'comments': [{'id': c.get('id'), 'body': adf_text(c.get('body')), 'createdAt': c.get('created'),
+                                        'author': (c.get('author') or {}).get('accountId') or (c.get('author') or {}).get('displayName')}
                                        for c in (f.get('comment') or {}).get('comments', [])],
-                          'blockedBy': blocked_by})
+                          'blockedBy': blocked_by, 'labels': f.get('labels') or [],
+                          'updatedAt': f.get('updated'), 'revision': f.get('updated')})
         return tasks
+
+    def scan(self, statuses):
+        raw_statuses = [tool_value(status_by_name(name)) for name in statuses]
+        quoted = ','.join('"%s"' % value.replace('"', '\\"') for value in raw_statuses)
+        clauses = ['status in (%s)' % quoted]
+        if PM_CONFIG.get('JIRA_PROJECT_KEY'):
+            clauses.append('project = "%s"' % PM_CONFIG['JIRA_PROJECT_KEY'].replace('"', '\\"'))
+        jql = ' AND '.join(clauses)
+        items, start = [], 0
+        while True:
+            path = ('/rest/api/3/search?jql=%s&fields=summary,description,status,assignee,comment,issuelinks,parent,labels,updated'
+                    '&startAt=%d&maxResults=100') % (urllib.request.quote(jql), start)
+            out = self.api(path)
+            rows = out.get('issues', [])
+            for i in rows:
+                f = i['fields']
+                raw = f['status']['name']
+                parent = f.get('parent') or {}
+                blocked_by = [l['inwardIssue']['key'] for l in f.get('issuelinks', [])
+                              if l.get('type', {}).get('name') == 'Blocks' and l.get('inwardIssue')]
+                items.append({
+                    'featureId': parent.get('key'),
+                    'featureTitle': ((parent.get('fields') or {}).get('summary') if isinstance(parent.get('fields'), dict) else None),
+                    'taskId': i['key'], 'title': f['summary'],
+                    'status': generic_of(raw), 'statusRaw': raw,
+                    'assignee': (f.get('assignee') or {}).get('displayName'),
+                    'description': adf_text(f.get('description')), 'blockedBy': blocked_by,
+                    'comments': [{'id': c.get('id'), 'body': adf_text(c.get('body')), 'createdAt': c.get('created'),
+                                  'author': (c.get('author') or {}).get('accountId') or (c.get('author') or {}).get('displayName')}
+                                 for c in (f.get('comment') or {}).get('comments', [])],
+                    'labels': f.get('labels') or [], 'updatedAt': f.get('updated'), 'revision': f.get('updated'),
+                })
+            start += len(rows)
+            total = int(out.get('total', start))
+            if not rows or start >= total:
+                break
+        return items
 
 class GitHubIssues:
     def __init__(self):
@@ -456,6 +616,47 @@ class GitHubIssues:
         if r.returncode != 0:
             die("gh failed: %s\n%s" % (' '.join(cmd), r.stderr.strip()))
 
+    def upsert_deployment(self, feature_id, body):
+        repo = self.repo_name()
+        milestones = json.loads(self.raw_gh('api', 'repos/%s/milestones?state=all&per_page=100' % repo))
+        current = next((m for m in milestones
+                        if str(m.get('number')) == str(feature_id) or m.get('title') == str(feature_id)), None)
+        if not current:
+            die("no GitHub milestone '%s' — andon" % feature_id)
+        description = replace_managed_block(current.get('description') or '', 'deployment', body)
+        cmd = ['gh', 'api', '-X', 'PATCH', 'repos/%s/milestones/%s' % (repo, current['number']),
+               '-f', 'description=%s' % description]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            die("gh failed: %s\n%s" % (' '.join(cmd), r.stderr.strip()))
+
+    def milestone(self, feature_id):
+        repo = self.repo_name()
+        milestones = json.loads(self.raw_gh('api', 'repos/%s/milestones?state=all&per_page=100' % repo))
+        current = next((m for m in milestones
+                        if str(m.get('number')) == str(feature_id) or m.get('title') == str(feature_id)), None)
+        if not current:
+            die("no GitHub milestone '%s' — andon" % feature_id)
+        return repo, current
+
+    def current_feature_status(self, feature_id):
+        _repo, milestone = self.milestone(feature_id)
+        if milestone.get('state') == 'closed':
+            return next((s['name'] for s in FEATURE_STATUSES if 'closed' in feature_tool_value(s)), None)
+        tasks = self.export(feature_id)
+        initial = next(s['name'] for s in TASK_STATUSES if s.get('initial'))
+        if any(task.get('status') != initial for task in tasks):
+            return next((s['name'] for s in FEATURE_STATUSES if s.get('kind') == 'working'), None)
+        return next((s['name'] for s in FEATURE_STATUSES if s.get('initial')), None)
+
+    def set_feature_state(self, feature_id, status):
+        repo, milestone = self.milestone(feature_id)
+        target = 'closed' if 'closed' in feature_tool_value(status) else 'open'
+        if milestone.get('state') == target:
+            return
+        self.raw_gh('api', '-X', 'PATCH', 'repos/%s/milestones/%s' % (repo, milestone['number']),
+                    '-f', 'state=%s' % target)
+
     def export(self, feature_id):
         raw = self.gh('issue', 'list', '--milestone', str(feature_id), '--state', 'all',
                       '--json', 'number,title,body,state,labels,assignees')
@@ -473,23 +674,71 @@ class GitHubIssues:
                           'status': generic, 'statusRaw': raw_status,
                           'assignee': (i['assignees'][0]['login'] if i['assignees'] else None),
                           'description': i.get('body'),
-                          'comments': [{'id': c.get('id'), 'body': c['body'], 'createdAt': c.get('createdAt')} for c in comments],
-                          'blockedBy': []})
+                          'comments': [{'id': c.get('id'), 'body': c['body'], 'createdAt': c.get('createdAt'),
+                                        'author': ((c.get('author') or {}).get('login') if isinstance(c.get('author'), dict) else c.get('author'))}
+                                       for c in comments],
+                          'blockedBy': [], 'labels': [l['name'] for l in i['labels']],
+                          'updatedAt': i.get('updatedAt'), 'revision': i.get('updatedAt')})
         return tasks
+
+    def scan(self, statuses):
+        wanted = set(statuses)
+        raw = self.gh('issue', 'list', '--state', 'all', '--limit', '1000',
+                      '--json', 'number,title,body,state,labels,assignees,milestone,updatedAt')
+        items = []
+        for i in json.loads(raw):
+            label = next((l['name'] for l in i['labels'] if l['name'].startswith('status:')), None)
+            raw_status = 'closed' if i['state'] == 'CLOSED' else 'open + label %s' % (label or '?')
+            generic = None
+            for status in TASK_STATUSES:
+                closed, wanted_label = self.parse_tool_value(tool_value(status))
+                if (closed and i['state'] == 'CLOSED') or (not closed and wanted_label and wanted_label == label):
+                    generic = status['name']; break
+            if generic not in wanted:
+                continue
+            milestone = i.get('milestone') or {}
+            comments = self.issue_comments(i['number'])
+            items.append({
+                'featureId': milestone.get('number'), 'featureTitle': milestone.get('title'),
+                'taskId': i['number'], 'title': i['title'], 'status': generic, 'statusRaw': raw_status,
+                'assignee': (i['assignees'][0]['login'] if i['assignees'] else None),
+                'description': i.get('body'), 'blockedBy': [],
+                'comments': [{'id': c.get('id'), 'body': c.get('body'), 'createdAt': c.get('created_at'),
+                              'author': (c.get('user') or {}).get('login')} for c in comments],
+                'labels': [l['name'] for l in i['labels']], 'updatedAt': i.get('updatedAt'),
+                'revision': i.get('updatedAt'),
+            })
+        return items
 
 class Markdown:
     def __init__(self):
-        self.root = PM_CONFIG.get('MARKDOWN_ROOT') or '.workspace/task-manager'
+        configured = PM_CONFIG.get('MARKDOWN_ROOT') or '.workspace/task-manager'
+        project_root = os.environ.get('TRACKER_PROJECT_ROOT') or os.getcwd()
+        self.root = configured if os.path.isabs(configured) else os.path.join(project_root, configured)
+
+    def contained_path(self, feature_id):
+        root = os.path.realpath(self.root)
+        path = os.path.realpath(feature_id)
+        try:
+            inside = os.path.commonpath([root, path]) == root
+        except ValueError:
+            inside = False
+        if not inside:
+            die("Markdown feature path escapes MARKDOWN_ROOT: %s" % feature_id)
+        return path
 
     def load(self, feature_id):
         try:
-            with open(feature_id) as f:
+            with open(self.contained_path(feature_id)) as f:
                 return f.read()
         except OSError as e:
             die("cannot read feature file '%s': %s — andon" % (feature_id, e))
 
     def save(self, feature_id, text):
-        with open(feature_id, 'w') as f:
+        path = self.contained_path(feature_id)
+        if os.path.islink(path):
+            die("refusing to write a symlinked Markdown feature: %s" % feature_id)
+        with open(path, 'w') as f:
             f.write(text)
 
     @staticmethod
@@ -591,6 +840,28 @@ class Markdown:
         quoted = '\n'.join('> ' + line for line in body.splitlines())
         self.save(feature_id, replace_managed_block(head, 'digest', quoted).rstrip() + '\n\n' + tail.lstrip())
 
+    def upsert_deployment(self, feature_id, body):
+        text = self.load(feature_id)
+        first_task = re.search(r'^## ', text, re.M)
+        head = text[:first_task.start()] if first_task else text
+        tail = text[first_task.start():] if first_task else ''
+        quoted = '\n'.join('> ' + line for line in body.splitlines())
+        self.save(feature_id, replace_managed_block(head, 'deployment', quoted).rstrip() + '\n\n' + tail.lstrip())
+
+    def current_feature_status(self, feature_id):
+        match = re.search(r'^# .*?\[([^\]]+)\][ \t]*$', self.load(feature_id), re.M)
+        if not match:
+            die("Markdown feature has no bracketed status: %s" % feature_id)
+        return feature_generic_of('[%s]' % match.group(1))
+
+    def set_feature_state(self, feature_id, status):
+        text = self.load(feature_id)
+        pattern = re.compile(r'^(# .*?)\[([^\]]+)\][ \t]*$', re.M)
+        if not pattern.search(text):
+            die("Markdown feature has no bracketed status: %s" % feature_id)
+        raw = feature_tool_value(status).strip('[]')
+        self.save(feature_id, pattern.sub(lambda m: '%s[%s]' % (m.group(1), raw), text, count=1))
+
     def export(self, feature_id):
         text = self.load(feature_id)
         tasks = []
@@ -629,13 +900,37 @@ class Markdown:
                 description_lines.append(_l)
             description = re.sub(r'\n{3,}', '\n\n', '\n'.join(description_lines)).strip()
             comments = [{'id': ('managed-progress-%s' % num if _b.startswith('[progress]') else None),
-                         'body': _b, 'createdAt': None} for _b in _blocks]
+                         'body': _b, 'createdAt': None, 'author': None} for _b in _blocks]
             tasks.append({'taskId': '%s#%s' % (feature_id, num), 'title': title,
                           'status': generic_of(raw), 'statusRaw': raw,
                           'assignee': (am.group(1).strip() if am and am.group(1).strip() not in ('-', '—') else None),
                           'description': description, 'comments': comments,
-                          'blockedBy': blocked_by})
+                          'blockedBy': blocked_by, 'labels': [],
+                          'updatedAt': datetime.fromtimestamp(os.path.getmtime(self.contained_path(feature_id)), timezone.utc).isoformat(),
+                          'revision': str(os.stat(self.contained_path(feature_id)).st_mtime_ns)})
         return tasks
+
+    def scan(self, statuses):
+        wanted = set(statuses)
+        root = self.contained_path(self.root)
+        if not os.path.isdir(root):
+            die("Markdown root does not exist: %s" % self.root)
+        items = []
+        for current, dirs, files in os.walk(root, followlinks=False):
+            dirs[:] = [name for name in dirs if not os.path.islink(os.path.join(current, name))]
+            if 'feature.md' not in files:
+                continue
+            path = os.path.join(current, 'feature.md')
+            text = self.load(path)
+            title_match = re.search(r'^# (.*?)\s*\[[^\]]+\][ \t]*$', text, re.M)
+            feature_title = title_match.group(1).strip() if title_match else os.path.basename(current)
+            for task in self.export(path):
+                if task.get('status') not in wanted:
+                    continue
+                item = dict(task)
+                item.update({'featureId': path, 'featureTitle': feature_title})
+                items.append(item)
+        return items
 
 BACKENDS = {'Linear': Linear, 'Jira': Jira, 'GitHubIssues': GitHubIssues, 'Markdown': Markdown}
 if ADAPTER not in BACKENDS:
@@ -647,9 +942,36 @@ def op_state(args):
     if len(args) != 2:
         die("usage: state <taskId> <Status>")
     target = status_by_name(args[1])
-    if backend.current_status(args[0]) != target['name']:
+    current_name = backend.current_status(args[0])
+    if current_name is None:
+        die("cannot reverse-map the current status of %s — andon" % args[0])
+    if current_name != target['name']:
+        current = status_by_name(current_name)
+        if target['name'] not in current.get('transitions', []):
+            die("illegal [task] transition [%s] → [%s] — andon" % (current_name, target['name']))
         backend.set_state(args[0], target)
+        observed = backend.current_status(args[0])
+        if observed != target['name']:
+            die("status write did not read back as [%s] (observed: %s) — andon" % (target['name'], observed))
     print("%s → [%s]" % (args[0], args[1]))
+
+def op_feature_state(args):
+    if len(args) != 2:
+        die("usage: feature-state <featureId> <Status>")
+    feature_id, target_name = args
+    target = feature_status_by_name(target_name)
+    current_name = backend.current_feature_status(feature_id)
+    if current_name is None:
+        die("cannot reverse-map the current [feature] status of %s — andon" % feature_id)
+    if current_name != target_name:
+        current = feature_status_by_name(current_name)
+        if target_name not in current.get('transitions', []):
+            die("illegal [feature] transition [%s] → [%s] — andon" % (current_name, target_name))
+        backend.set_feature_state(feature_id, target)
+        observed = backend.current_feature_status(feature_id)
+        if observed != target_name:
+            die("[feature] status write did not read back as [%s] (observed: %s) — andon" % (target_name, observed))
+    print("%s → [%s]" % (feature_id, target_name))
 
 def op_comment(args):
     if len(args) not in (1, 2):
@@ -702,16 +1024,34 @@ def op_upsert_digest(args):
     backend.upsert_digest(args[0], body)
     print("digest updated on %s" % args[0])
 
+def op_upsert_deployment(args):
+    if len(args) not in (1, 2):
+        die("usage: upsert-deployment <featureId> [bodyfile]  (no file / '-' = stdin)")
+    body = read_body(args[1] if len(args) == 2 else None)
+    if not body.lstrip().startswith('[deployment]'):
+        die("upsert-deployment body must begin with [deployment]")
+    backend.upsert_deployment(args[0], body)
+    print("deployment updated on %s" % args[0])
+
 def op_claim(args):
     to = None
-    if '--to' in args:
-        i = args.index('--to')
-        to = args[i + 1] if i + 1 < len(args) else die("--to needs a status name")
-        args = args[:i] + args[i + 2:]
+    expected = None
+    claim_id = None
+    for flag in ('--to', '--expected', '--claim-id'):
+        if flag in args:
+            i = args.index(flag)
+            value = args[i + 1] if i + 1 < len(args) else die("%s needs a value" % flag)
+            args = args[:i] + args[i + 2:]
+            if flag == '--to': to = value
+            elif flag == '--expected': expected = value
+            else: claim_id = value
     if len(args) != 2:
         die("usage: claim <taskId> <role> [--to <Status>]")
     task_id, role = args
     init = initial_status()
+    expected = expected or init['name']
+    if expected != init['name']:
+        die("claim expected status must be the board's initial status [%s]" % init['name'])
     if to is None:
         if len(init['transitions']) != 1:
             die("initial status '%s' has %d outbound transitions — pass --to <Status>"
@@ -720,11 +1060,25 @@ def op_claim(args):
     target = status_by_name(to)
     if to not in init['transitions']:
         die("claim must follow the board: '%s' is not in %s.transitions — andon" % (to, init['name']))
+    claim_id = claim_id or ('claim-' + hashlib.sha256(('%s\0%s\0%s' % (task_id, role, to)).encode()).hexdigest()[:24])
+    if not re.fullmatch(r'[A-Za-z0-9._:-]{8,128}', claim_id):
+        die("invalid claim id '%s'" % claim_id)
+    token = "claim-id: %s" % claim_id
+    current = backend.current_status(task_id)
+    if current == to and backend.comment_exists(task_id, token):
+        print("%s claim %s already recorded → [%s]" % (task_id, claim_id, to))
+        return
+    if current != expected:
+        die("claim conflict: expected [%s], observed [%s] for %s — no launch" % (expected, current, task_id))
+    if not backend.comment_exists(task_id, token):
+        backend.comment(task_id, "[claim]\n%s\nrole: %s\ntarget-status: %s\n\n— dispatcher" % (token, role, to))
     if hasattr(backend, 'set_assignee'):
         backend.set_assignee(task_id, role)
     backend.set_state(task_id, target)
-    backend.comment(task_id, "Claimed — moving to [%s].\n\n— %s" % (to, role))
-    print("%s claimed by %s → [%s]" % (task_id, role, to))
+    observed = backend.current_status(task_id)
+    if observed != to:
+        die("claim write did not read back as [%s] (observed: %s) — no launch" % (to, observed))
+    print("%s claimed by %s → [%s] (claim-id: %s)" % (task_id, role, to, claim_id))
 
 def op_integrate(args):
     if len(args) not in (2, 3):
@@ -757,10 +1111,56 @@ def op_export(args):
         f.write('\n')
     print("exported %d [tasks] of %s to %s" % (len(tasks), feature_id, outfile))
 
+def op_scan(args):
+    if not args:
+        die("usage: scan <outfile> --status <Status>...")
+    outfile, rest = args[0], args[1:]
+    statuses = []
+    while rest:
+        if len(rest) < 2 or rest[0] != '--status':
+            die("usage: scan <outfile> --status <Status>...")
+        status_by_name(rest[1])
+        statuses.append(rest[1])
+        rest = rest[2:]
+    if not statuses:
+        statuses = [s['name'] for s in TASK_STATUSES if s.get('kind') in ('queued', 'blocked')]
+    if not statuses:
+        die("scan has no statuses (pass --status or configure queued/blocked kinds)")
+    items = backend.scan(statuses)
+    normalized, orphans = [], []
+    for item in items:
+        if not isinstance(item, dict) or item.get('taskId') is None:
+            die("adapter returned a malformed scan record — andon")
+        if item.get('status') not in statuses:
+            die("adapter returned an out-of-scope status '%s' for %s" % (item.get('status'), item.get('taskId')))
+        value = dict(item)
+        value['taskId'] = str(value['taskId'])
+        if value.get('featureId') is not None:
+            value['featureId'] = str(value['featureId'])
+        value['routingHints'] = {'labels': list(value.get('labels') or []), 'teamPreset': None}
+        (normalized if value.get('featureId') else orphans).append(value)
+    payload = {
+        'schemaVersion': 1, 'adapter': ADAPTER,
+        'scannedAt': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+        'statuses': statuses, 'items': normalized, 'orphans': orphans,
+    }
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + '\n'
+    if outfile == '-':
+        sys.stdout.write(text)
+    else:
+        parent = os.path.dirname(os.path.abspath(outfile))
+        os.makedirs(parent, exist_ok=True)
+        temp = outfile + '.tmp.%d' % os.getpid()
+        with open(temp, 'w') as f:
+            f.write(text)
+        os.replace(temp, outfile)
+        print("scanned %d [tasks] (%d orphaned) to %s" % (len(normalized), len(orphans), outfile))
+
 OPS = {'state': op_state, 'comment': op_comment, 'comment-once': op_comment_once, 'update-comment': op_update_comment,
        'upsert-progress': op_upsert_progress, 'upsert-digest': op_upsert_digest,
-       'claim': op_claim, 'integrate': op_integrate, 'export': op_export}
+       'upsert-deployment': op_upsert_deployment, 'feature-state': op_feature_state,
+       'claim': op_claim, 'integrate': op_integrate, 'export': op_export, 'scan': op_scan}
 if not ARGS or ARGS[0] not in OPS:
-    die("usage: tracker-ops.sh {state|comment|comment-once|update-comment|upsert-progress|upsert-digest|claim|integrate|export} ...")
+    die("usage: tracker-ops.sh {state|feature-state|comment|comment-once|update-comment|upsert-progress|upsert-digest|upsert-deployment|claim|integrate|export|scan} ...")
 OPS[ARGS[0]](ARGS[1:])
 PYEOF

--- a/config/automation.config.json
+++ b/config/automation.config.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "enabled": false,
+  "pollSeconds": 120,
+  "leaseSeconds": 900,
+  "maxFeaturesPerPass": 2,
+  "scanStatusKinds": ["queued", "blocked"],
+  "reconcileRegisteredRuns": true,
+  "baseRef": "main",
+  "branchPrefix": "factory-",
+  "workspaceRoot": ".teamwork/pm-agent",
+  "defaultTeamPreset": "full-stack",
+  "allowedTeamPresets": [
+    "full-stack",
+    "deep-backend",
+    "deep-frontend",
+    "deep-infra",
+    "deep-security"
+  ],
+  "requireMetadataOptIn": false,
+  "metadata": {
+    "optInKey": "automation",
+    "teamPresetKey": "team-preset"
+  }
+}

--- a/config/deployment.config.json
+++ b/config/deployment.config.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "enabled": false,
+  "mode": "approval-required",
+  "environment": "production",
+  "credentialEnvFile": null,
+  "environmentAllowlist": ["PATH", "HOME", "TMPDIR", "LANG", "LC_ALL"],
+  "hooks": {
+    "plan": null,
+    "apply": null,
+    "status": null,
+    "verify": null,
+    "rollback": null,
+    "verifyApproval": null
+  },
+  "timeoutsSeconds": {
+    "plan": 300,
+    "apply": 1800,
+    "status": 120,
+    "verify": 600,
+    "rollback": 900,
+    "verifyApproval": 60
+  }
+}

--- a/config/guardrails.config.json
+++ b/config/guardrails.config.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "protectedBranches": ["main", "master", "production", "release"],
+  "additionalDenyPatterns": [],
+  "additionalApprovalRequiredActions": [],
+  "maximumAutomaticPlanChanges": 100,
+  "maximumAutomaticCostDelta": 0,
+  "allowAutomaticRollbackOnlyToPreviousArtifact": true
+}

--- a/config/statuses.config.json
+++ b/config/statuses.config.json
@@ -1,15 +1,15 @@
 {
   "features": {
     "statuses": [
-      { "name": "Planned", "initial": true,
+      { "name": "Planned", "kind": "queued", "initial": true,
         "owner": { "role": "team-lead" },
         "transitions": ["Active"],
         "tool": { "Linear": "Planned", "Jira": "To Do", "GitHubIssues": "milestone open, no task started", "Markdown": "[Planned]" } },
-      { "name": "Active",
+      { "name": "Active", "kind": "working",
         "owner": { "role": "team-lead" },
         "transitions": ["Resolved"],
         "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "milestone open, >=1 task active (derived)", "Markdown": "[Active]" } },
-      { "name": "Resolved", "terminal": true,
+      { "name": "Resolved", "kind": "completed", "terminal": true,
         "owner": { "role": "team-lead" },
         "transitions": [],
         "tool": { "Linear": "Completed", "Jira": "Done", "GitHubIssues": "milestone closed", "Markdown": "[Resolved]" } }
@@ -17,23 +17,23 @@
   },
   "tasks": {
     "statuses": [
-      { "name": "Planned", "initial": true,
+      { "name": "Planned", "kind": "queued", "initial": true,
         "owner": { "role": "team-lead" },
         "transitions": ["Active"],
         "tool": { "Linear": "Todo", "Jira": "To Do", "GitHubIssues": "open + label status:planned", "Markdown": "[Planned]" } },
-      { "name": "Active",
+      { "name": "Active", "kind": "working",
         "owner": { "role": "implementer" },
         "transitions": ["Review", "Blocked"],
         "tool": { "Linear": "In Progress", "Jira": "In Progress", "GitHubIssues": "open + label status:active", "Markdown": "[Active]" } },
-      { "name": "Review",
+      { "name": "Review", "kind": "review",
         "owner": { "role": "reviewer" },
         "transitions": ["Active", "Ready to deploy", "Blocked"],
         "tool": { "Linear": "In Review", "Jira": "In Review", "GitHubIssues": "open + label status:review", "Markdown": "[Review]" } },
-      { "name": "Blocked",
+      { "name": "Blocked", "kind": "blocked",
         "owner": { "role": "team-lead" },
         "transitions": ["Planned", "Active", "Review"],
         "tool": { "Linear": "Blocked", "Jira": "Blocked", "GitHubIssues": "open + label status:blocked", "Markdown": "[Blocked]" } },
-      { "name": "Ready to deploy", "terminal": true, "requiresCommit": true,
+      { "name": "Ready to deploy", "kind": "integrated", "terminal": true, "requiresCommit": true,
         "owner": { "role": "integrator" },
         "transitions": [],
         "tool": { "Linear": "Done", "Jira": "Done", "GitHubIssues": "closed", "Markdown": "[Ready to deploy]" } }

--- a/reference/automation.md
+++ b/reference/automation.md
@@ -1,0 +1,86 @@
+# Portfolio automation
+
+Use `bin/pm-agent.py` as the deterministic portfolio supervisor above the
+per-[feature] dispatcher. It owns time; no LLM agent sleeps, polls, or promises to
+return later.
+
+## Runtime shape
+
+```text
+cron / service timer
+  -> pm-agent.py --once
+  -> tracker-ops.sh scan (adapter-normalized discovery)
+  -> one isolated integration worktree per [feature]
+  -> launch-team.sh + dispatch.sh --once
+  -> release-feature.py after every [task] is integrated
+```
+
+`--once` is the scheduler primitive. `--watch` is a convenience for a dedicated
+host. Both reconcile registered, unfinished runs even after their [tasks] have
+left the scanned statuses. The scan resolves semantic status kinds through
+`config/statuses.config.json`; the shipped board maps `queued` to Linear `Todo`
+and `blocked` to Linear `Blocked`.
+
+The supervisor is deliberately not an LLM. It discovers, routes, deduplicates,
+bootstraps, and invokes deterministic state machines. A team-lead is launched
+when a blocker, comment, routing exception, or delivery decision needs judgment.
+
+## Enable and schedule
+
+Automation is fail-closed by default. Configure the scriptable adapter, set
+`enabled` in `config/automation.config.json`, and verify a dry run:
+
+```bash
+bin/pm-agent.py --once --dry-run
+bin/pm-agent.py --print-cron
+```
+
+Install the printed line in one scheduler only. For hosted schedulers, configure
+the equivalent of `concurrencyPolicy: Forbid`. The filesystem lease prevents
+overlap on one host; multi-host operation requires an external distributed lock
+or an adapter-native compare-and-set claim. Do not run two independent hosts and
+call that safe.
+
+Cron cannot call an MCP client. Linear and Jira automation therefore use their
+scriptable REST modes; GitHub uses its CLI; Markdown uses files. Keep credentials
+in the scheduler's secret facility, never in repository config or a crontab line.
+
+## Scope and routing
+
+Discovery returns only generic records: `featureId`, `taskId`, generic and raw
+status, description, comments, blockers, routing hints, and revision. A [task]
+without a `featureId` is quarantined and never launched.
+
+Add these adapter-neutral metadata lines to a [task] description or recent
+comment when needed:
+
+```text
+automation: enabled|disabled
+team-preset: full-stack|deep-backend|deep-frontend|deep-infra|deep-security
+```
+
+One explicit preset wins. Conflicting or unknown values fail closed and receive
+an idempotent `[escalation]`; they never fall through to a guessed specialist
+team. With no explicit value, `defaultTeamPreset` applies. The selected preset,
+branch, integration worktree, and run id are durable and never change because
+later prose changed.
+
+Every [feature] receives its own integration worktree. Task worktrees are nested
+under it, so two [features] never compete for the root checkout or feature branch.
+Externally sourced identifiers are hashed before becoming paths, branch names,
+or process identifiers.
+
+## Recovery and limits
+
+- A repository-global lease serializes scans and has bounded stale recovery.
+- The run registry is atomically replaced and reconstructs unfinished work.
+- `maxFeaturesPerPass` bounds cold starts; existing runs are reconciled first.
+- A failed adapter read, malformed record, preflight, claim, or launch stops the
+  pass without fabricating state.
+- Project-management text is untrusted data. It is never interpolated into a
+  shell command, filesystem path, role command, or deployment hook.
+- `[Blocked]` work always reaches a lead pass. Only dependency blocks with the
+  latest legal `resume-status` may use the existing deterministic auto-unblock.
+
+See `reference/guardrails.md` for authority boundaries and
+`reference/deployment.md` for the production transaction.

--- a/reference/automation.md
+++ b/reference/automation.md
@@ -77,6 +77,12 @@ or process identifiers.
 - `maxFeaturesPerPass` bounds cold starts; existing runs are reconciled first.
 - A failed adapter read, malformed record, preflight, claim, or launch stops the
   pass without fabricating state.
+- When the policy gate denies an action an agentic team or dedicated agent
+  attempted for a [task], the enforcing component documents it on that ticket
+  with an idempotent `[DENIED ACTION]` comment (`tracker-ops.sh record-denial`):
+  actor, sanitized attempted action, denial reason, and the statement that the
+  action was prevented. See `reference/guardrails.md` § Denied-action
+  documentation.
 - Project-management text is untrusted data. It is never interpolated into a
   shell command, filesystem path, role command, or deployment hook.
 - `[Blocked]` work always reaches a lead pass. Only dependency blocks with the

--- a/reference/deployment.md
+++ b/reference/deployment.md
@@ -1,0 +1,76 @@
+# Provider-neutral production delivery
+
+Keep production delivery separate from the project-management adapter. The
+tracker says what is ready; `bin/release-feature.py` executes an exact immutable
+release through structured project hooks.
+
+## Preconditions
+
+The executor refuses unless every [task] is in a terminal, commit-requiring
+status, the feature branch exists and is clean in its integration worktree, and
+no deployment transaction for another commit is active. `[Ready to deploy]`
+continues to mean reviewed, validated, and integrated—not already deployed.
+
+`config/deployment.config.json` is disabled by default. To opt in, configure
+JSON argv arrays for every required hook and select one mode:
+
+- `approval-required` — `verifyApproval` must validate an external authorization
+  bound to the generated manifest. Agents cannot create that authorization.
+- `automatic` — the trusted config pre-authorizes only a non-destructive release
+  plan for the exact reviewed commit. Policy-sensitive plan changes still fail.
+
+Do not put shell strings, credentials, or provider-specific logic in the skill.
+Each hook is an argv array and may use these placeholders:
+
+`{repository}`, `{feature_id}`, `{team}`, `{commit}`, `{environment}`,
+`{release_id}`, `{plan_file}`, `{manifest_file}`, `{transaction_file}`.
+
+## Hook contract
+
+1. `plan` writes `{plan_file}` as JSON:
+
+   ```json
+   {
+     "schemaVersion": 1,
+     "environment": "production",
+     "commit": "<full hash>",
+     "artifactDigest": "sha256:<digest>",
+     "changes": [
+       {"action": "UPDATE", "resourceType": "service", "resourceId": "api"}
+     ],
+     "rollback": {
+       "automaticSafe": true,
+       "previousArtifactDigest": "sha256:<digest>"
+     }
+   }
+   ```
+
+2. `status` prints one JSON object with `state` equal to `not-applied`,
+   `in-progress`, `applied`, or `failed`, plus the observed artifact digest when
+   available. This query makes crash recovery safe; an uncertain apply is never
+   blindly repeated.
+3. `apply` deploys only `{release_id}` and the digest in the immutable plan.
+4. `verify` independently checks production health and version.
+5. `rollback` is optional and is callable automatically only for the immediately
+   previous artifact declared by the plan.
+
+The plan may describe `CREATE`, `READ`, `UPDATE`, `REPLACE`, or `DELETE` changes.
+Unknown actions are denied. Autonomous `DELETE`/`REPLACE`, database/IAM/network/
+secret mutations, and above-threshold cost changes never reach `apply`.
+
+## Transaction and credentials
+
+The durable phases are `planned -> applying -> verifying -> succeeded`, with
+`failed`, `rolling-back`, and `rolled-back` outcomes. The transaction stores the
+commit, artifact digest, plan digest, release id, timestamps, hook results, and
+redacted log paths. Re-running the same release is idempotent.
+
+The executor builds a clean environment from `environmentAllowlist` and an
+optional mode-0600 `credentialEnvFile`. Ordinary agents and the PM supervisor
+must not inherit that credential file's values. Logs redact every loaded value
+before persistence or tracker projection.
+
+After independent verification succeeds, the executor upserts the [feature]'s
+`[deployment]` projection and moves the [feature] to its configured terminal
+status. A failed verification is never reported as success; safe rollback or an
+`[escalation]` is the only next action.

--- a/reference/guardrails.md
+++ b/reference/guardrails.md
@@ -17,6 +17,26 @@ Use three decisions, in this order:
 Silence never approves. An `[escalation]` involving a sensitive action must use
 `default-if-silent: do not execute; remain blocked`.
 
+## Denied-action documentation
+
+Every **DENY** hit while an agentic team or a dedicated agent acts on behalf of a
+[task] must be documented at the ticket level. The enforcing component (supervisor,
+dispatcher, or release executor — never the denied agent itself) posts one
+idempotent `[DENIED ACTION]` comment via `bin/tracker-ops.sh record-denial`,
+carrying:
+
+- `denial-id` — the idempotency token, so retries never duplicate the record;
+- `actor` — which agent or team role attempted the action;
+- a full, sanitized description of what the agent tried to do (bounded and
+  control-character-stripped; raw command output stays in protected local logs);
+- the denial reason from the policy gate;
+- the explicit statement that the action was blocked and **was not executed**.
+
+This record is audit evidence, not a workflow signal: it never changes the
+[task] status, never grants authority, and never softens the denial. Failing to
+post it is an andon for the enforcing component, but the denial stands whether
+or not the comment lands.
+
 ## Always denied to autonomous agents
 
 - **Filesystem:** recursive or bulk deletion outside an explicitly disposable

--- a/reference/guardrails.md
+++ b/reference/guardrails.md
@@ -1,0 +1,89 @@
+# Autonomous safety guardrails
+
+Apply this policy to every role, script, hook, and adapter. Unknown actions,
+targets, parsers, environments, or authorization state are denied.
+
+## Authority model
+
+Use three decisions, in this order:
+
+1. **DENY** — no autonomous agent may perform the action. Break-glass happens
+   outside this system with a human-operated tool.
+2. **REQUIRE HUMAN APPROVAL** — an exact, expiring authorization may release a
+   narrow deterministic executor. It never grants the LLM a shell or credential.
+3. **ALLOW** — only inside the role's assigned paths, targets, environment,
+   quotas, and lifecycle state.
+
+Silence never approves. An `[escalation]` involving a sensitive action must use
+`default-if-silent: do not execute; remain blocked`.
+
+## Always denied to autonomous agents
+
+- **Filesystem:** recursive or bulk deletion outside an explicitly disposable
+  task directory; writes outside the assigned worktree; path/symlink escape;
+  raw device, partition, or filesystem commands; mutation of `.git`, another
+  attempt, audit logs, policy, broker, approval store, or production credentials.
+- **Databases/data:** `DROP DATABASE`/`DROP SCHEMA`, `TRUNCATE`, uncontrolled
+  bulk mutation, destructive restore/down migration, disabling constraints,
+  backups, replication, or audit, and access to direct production credentials.
+- **Infrastructure:** destroy-all; deletion/termination of production instances,
+  clusters, databases, volumes, state, keys, backups, logging, networks, DNS, or
+  certificates; wildcard resource deletion; scaling a critical service to zero.
+- **Secrets:** reading, printing, exporting, logging, committing, or sending
+  secret values; metadata-service credential access; long-lived credential
+  creation; secret-store dumps.
+- **Identity/network:** privilege escalation, wildcard administrator grants,
+  runner-identity changes, MFA/audit/policy disablement, public database or
+  management ports, and unrestricted trust relationships.
+- **Git/release integrity:** force-pushing or deleting protected refs, history
+  rewrites, `reset --hard`, broad `clean`, bypassing hooks/gates, mutable release
+  tags, deploying a different commit/artifact than the reviewed transaction.
+- **External effects:** public/customer messages, status-page publication, or
+  transmission of private data without exact recipient/content authorization.
+- **Bypasses:** `sudo`, privileged containers, host sockets/mounts, encoded or
+  opaque shell execution, command substitution/chaining/redirection in the
+  privileged executor, editing this policy to weaken it, forging actors or
+  approvals, or disabling the supervisor/audit trail.
+
+## Human approval required
+
+- Any production infrastructure, IAM, network, DNS, certificate, billing,
+  region, capacity, schema, backfill, or data mutation.
+- Any plan containing a replacement or deletion, even when a provider calls it
+  an update.
+- An arbitrary rollback, failover, traffic shift, disaster-recovery action, or
+  destructive migration step.
+- Cost or scale changes above configured zero-default thresholds.
+- External communication beyond scoped project-management and repository
+  collaboration records.
+
+An approval binds the exact action digest, environment, target, [feature],
+commit, artifact, plan digest, approver, expiration, and one-use nonce. A normal
+project-management comment is not authorization.
+
+## Autonomously allowed
+
+- Read-only inventory, status, logs already redacted, plan/preview/diff, tests,
+  builds, linting, health checks, and disposable local fixtures.
+- Writes to declared task files inside the assigned task worktree; checkpoint
+  commits on task branches; controlled integration through the integrator.
+- Production release of the exact reviewed immutable artifact only when the
+  trusted deployment configuration explicitly selects `automatic`, the
+  normalized plan contains no denied/approval-only change, and independent
+  verification succeeds.
+- Automatic rollback only to the transaction's immediately previous immutable
+  artifact, when the trusted plan declares it safe and an objective health check
+  failed.
+
+## Enforcement boundaries
+
+`bin/policy-check.py` is a mandatory fail-closed gate for structured production
+hooks. Its built-in baseline cannot be weakened by project config. It rejects
+shell syntax and known destructive operations before a subprocess starts.
+
+This repository policy is defense in depth, not an operating-system security
+boundary. Run ordinary agents without production credentials; give the release
+executor a separate short-lived, target-scoped identity via
+`credentialEnvFile`; enforce no-delete/no-DDL/no-admin privileges in the cloud,
+database, secret store, and CI runner; sandbox agent write access to its worktree.
+No prompt or regular expression can compensate for an over-privileged identity.

--- a/reference/vocabulary.md
+++ b/reference/vocabulary.md
@@ -107,6 +107,7 @@ Markers are the machine-readable protocol prefixes that begin every coordination
 | `[digest]` | One per [feature], mechanically upserted from the tracker snapshot: one line per [task] for the human's whole view. |
 | `[andon]` | Stop-the-line report: what failed, exact error, what was not done. |
 | `[escalation]` | Needs the human: question, options, default-if-silent. |
+| `[DENIED ACTION]` | Policy gate blocked an agent's attempted action: actor, what was attempted, why it was denied, and that it was never executed. Audit evidence only — grants nothing. |
 
 ---
 

--- a/tests/dispatch-test.sh
+++ b/tests/dispatch-test.sh
@@ -16,6 +16,7 @@ cp "$SKILL_DIR/config/statuses.config.json" .claude/skills/pm/config/
 cat > .claude/skills/pm/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF
@@ -336,6 +337,7 @@ fi
 cat > .claude/skills/pm/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -208,6 +208,7 @@ sed -i '' '/^EXECUTION=parallel$/d;/^MAX_ACTIVE_IMPLEMENTERS=zero$/d' "$CFG"
 cat > .claude/skills/pm/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF
@@ -281,6 +282,7 @@ fi
 cat > .claude/skills/pm/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF

--- a/tests/parallel-integration-test.sh
+++ b/tests/parallel-integration-test.sh
@@ -26,6 +26,7 @@ git commit -q -m init
 cat > .agent-squad/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF

--- a/tests/task-runtime-test.sh
+++ b/tests/task-runtime-test.sh
@@ -18,6 +18,7 @@ cp "$SKILL_DIR/roles/backend.md" .agent-squad/roles/
 cat > .agent-squad/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF

--- a/tests/tracker-ops-test.sh
+++ b/tests/tracker-ops-test.sh
@@ -96,6 +96,26 @@ printf '[review-request]\nFiles: a.py\n' > delivery.txt
 "$OPS" comment-once "$T#1" delivery-123 delivery.txt
 check "comment-once retry keeps one delivery" test "$(grep -c 'delivery-id: delivery-123' "$T")" -eq 1
 
+# -- record-denial: guardrail DENY becomes idempotent ticket-level evidence -----
+printf 'deploy.apply argv: terraform destroy -auto-approve (production)\n' > denied.txt
+"$OPS" record-denial "$T#1" --actor deep-infra/devops --reason "infrastructure destroy is forbidden" denied.txt
+check "denial marker recorded literally"   grep -q '^> \[DENIED ACTION\]$' "$T"
+check "denial records the actor"           grep -q '^> actor: deep-infra/devops$' "$T"
+check "denial records the attempt"         grep -q 'terraform destroy -auto-approve' "$T"
+check "denial records the reason"          grep -q '^> Denial reason: infrastructure destroy is forbidden$' "$T"
+check "denial states prevention"           grep -q 'was blocked by the fail-closed policy gate and was not executed' "$T"
+check "denial carries an id"               grep -q '^> denial-id: denial-' "$T"
+check "denial retry is idempotent" bash -c \
+  "'$OPS' record-denial '$T#1' --actor deep-infra/devops --reason 'infrastructure destroy is forbidden' denied.txt \
+   && [ \"\$(grep -c 'denial-id: ' '$T')\" -eq 1 ]"
+printf 'curl 169.254.169.254 \x01\x02with control bytes\n' | "$OPS" record-denial "$T#1" \
+  --actor full-stack/backend --reason "metadata credential access is forbidden" --denial-id denial-ctrl-0001 -
+check "denial strips control bytes" bash -c "grep -q 'curl 169.254.169.254 *with control bytes' '$T' && ! grep -q \$'\x01' '$T'"
+refuse "denial without actor refused"   "requires --actor and --reason" bash -c "printf 'x\n' | '$OPS' record-denial '$T#1' --reason r -"
+refuse "denial without reason refused"  "requires --actor and --reason" bash -c "printf 'x\n' | '$OPS' record-denial '$T#1' --actor a -"
+refuse "denial with empty body refused" "empty comment body"            bash -c "printf '' | '$OPS' record-denial '$T#1' --actor a --reason r -"
+refuse "denial with bad id refused"     "invalid denial id"             bash -c "printf 'x\n' | '$OPS' record-denial '$T#1' --actor a --reason r --denial-id 'no spaces!' -"
+
 # -- state: legal generic status names only --------------------------------------
 "$OPS" state "$T#1" Review
 "$OPS" state "$T#1" Review

--- a/tests/tracker-ops-test.sh
+++ b/tests/tracker-ops-test.sh
@@ -30,7 +30,7 @@ cp "$SKILL_DIR/config/statuses.config.json" skill/config/
 cat > skill/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
-MARKDOWN_ROOT=.workspace/task-manager
+MARKDOWN_ROOT=.
 STATUS_CONFIG=config/statuses.config.json
 ```
 EOF
@@ -74,8 +74,10 @@ check "digest upsert replaces old content" grep -q '^> T#1 - active$' "$T"
 "$OPS" claim "$T#1" backend
 check "claim sets status"        grep -q '^## 1 Add form \[Active\]$' "$T"
 check "claim sets assignee"      grep -q '^\*\*Assignee:\*\* backend$' "$T"
-check "claim leaves a comment"   grep -q 'Claimed — moving to \[Active\]' "$T"
-check "claim comment signed"     grep -q -- '— backend' "$T"
+check "claim leaves a comment"   grep -q '\[claim\]' "$T"
+check "claim records the role"   grep -q 'role: backend' "$T"
+check "claim records a claim id" grep -q 'claim-id: ' "$T"
+check "claim retry is idempotent" bash -c "'$OPS' claim '$T#1' backend && [ \"\$(grep -c 'claim-id: ' '$T')\" -eq 1 ]"
 check "sibling task untouched"   grep -q '^## 2 Wire endpoint \[Planned\]$' "$T"
 
 # -- comment: body from stdin, marker extracted, quoting-proof ------------------
@@ -143,6 +145,7 @@ refuse "taskId without # refused"     "feature-file"            "$OPS" state "ju
 refuse "unknown op refused"           "usage:"                  "$OPS" frobnicate x y
 refuse "empty comment body refused"   "empty comment body"      bash -c "printf '' | '$OPS' comment '$T#2' -"
 refuse "missing feature file refused" "cannot read"             "$OPS" export nope/feature.md out.json
+refuse "path escaping MARKDOWN_ROOT refused" "escapes MARKDOWN_ROOT" "$OPS" export ../escape.md out.json
 refuse "unmapped adapter refused"     "no tracker-ops backend"  env TRACKER_ADAPTER=Nonesuch "$OPS" state "$T#2" Review
 refuse "Markdown update-comment refused"  "append-only"  bash -c "printf 'x\n' | '$OPS' update-comment '$T#2' some-id -"
 refuse "update-comment arg check"         "usage:"       "$OPS" update-comment onlyone


### PR DESCRIPTION
## Summary

Groundwork for a deterministic portfolio supervisor that sits above the per-feature dispatcher:

- **`bin/tracker-ops.sh`** — new board-wide normalized `scan` discovery command; `claim` redesigned to write an idempotent `[claim]` comment carrying a `claim-id`, role, and target status, with conflict detection and read-back verification before any launch; Markdown feature paths are now contained to `MARKDOWN_ROOT` (symlink-safe, fail-closed).
- **`[DENIED ACTION]` ticket-level audit trail** — when an agentic team or a dedicated agent attempts an action the policy gate denies, the enforcing component documents it on the ticket: new `tracker-ops.sh record-denial` posts one idempotent `[DENIED ACTION]` comment carrying the acting agent, a full sanitized (bounded, control-character-stripped) description of what it tried to do, the denial reason, and the explicit statement that the action was blocked and never executed. The Markdown adapter preserves the envelope byte-for-byte so the marker stays literal. The mandatory contract lives in `reference/guardrails.md` § Denied-action documentation (audit evidence, never authorization; a missing record is an andon but never unblocks), is wired into the supervisor recovery rules in `reference/automation.md`, and the marker is registered in `reference/vocabulary.md`.
- **`config/statuses.config.json`** — every status gains a semantic `kind` (`queued` / `working` / `review` / `blocked` / `integrated` / `completed`) so automation resolves board states by meaning rather than by name.
- **`bin/policy-check.py`** — fail-closed policy gate for privileged structured commands and release plans; project config may add denials but never remove the code-owned baseline.
- **`config/automation.config.json`**, **`config/deployment.config.json`**, **`config/guardrails.config.json`** — supervisor configuration, disabled by default (`"enabled": false`).
- **`reference/automation.md`**, **`reference/deployment.md`**, **`reference/guardrails.md`** — the operating contract: scheduling, scope/routing, recovery limits, authority boundaries, and the production transaction.
- **`README.md`** — now opens with "The security gateway for AI builders": the code-owned policy gate, the DENY / REQUIRE HUMAN APPROVAL / ALLOW authority model, the `[DENIED ACTION]` audit trail, least-privilege agent sandboxes, contained workspaces, and off-by-default automation.
- **Tests** — fixtures pin `MARKDOWN_ROOT` to the sandbox to satisfy the new containment check; claim assertions updated to the `[claim]` comment contract; new cases for root-escape refusal, claim retry idempotency, and the `record-denial` contract (literal marker, actor/reason/prevention fields, retry idempotency, control-byte sanitization, fail-loud argument checks).

## Not yet implemented

`reference/automation.md` references `bin/pm-agent.py` and `bin/release-feature.py`; those supervisor scripts are not in this PR. This change lands the contract, configuration, and tracker-ops plumbing they will build on, and automation stays disabled by default until they exist.

## Test plan

- [x] `bash tests/run-all.sh` → `ALL TESTS PASS` (offline, no LLM calls)
- [x] `bash -n bin/tracker-ops.sh`; `python3` parse of `bin/policy-check.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
