### PR TITLE
Add Claude Superpowers planning integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ release introduces a file at a project-owned extension path, the update fails
 before mutation instead of overwriting it:
 
 - `config/project-management.config.md`
+- `config/planning.config.md`
 - `config/team.config.md`
 - `config/statuses.config.json`
 - `config/automation.config.json`
@@ -418,7 +419,7 @@ installation into a partial one. Its main operator options are:
 | `--project PATH` | Resolve the agent directory relative to another project. |
 | `--install-dir PATH` | Override the mapped installation directory. |
 | `--bundle PATH` | For install/update, use an explicitly supplied local canonical archive. |
-| `--overwrite-config` | For install/update, replace all six preserved project configuration files. |
+| `--overwrite-config` | For install/update, replace all seven preserved project configuration files. |
 | `--dry-run` | For install/update, print the plan without writing the destination or lock. |
 | `--json` | Emit machine-readable output for operator automation. |
 
@@ -477,6 +478,23 @@ task-branch/worktree isolation: **`sequential`** runs one task worker at a time;
 `MAX_ACTIVE_IMPLEMENTERS` (default 2 when unset). Gate roles and integration
 remain serialized where required.
 
+### Optional Claude planning with obra/superpowers
+
+`config/planning.config.md` defaults `USE_SUPERPOWERS=true`. This means Claude
+Code is eligible to use Superpowers; it does not activate Superpowers for every
+model. When the current runtime is Claude Code, Startup Factory uses
+[`obra/superpowers`](https://github.com/obra/superpowers) for
+`brainstorming` and `writing-plans`, then binds the committed specification and
+plan into a digest-checked handoff. Startup Factory still owns its own planning
+review, team, task packets, worktrees, dispatch, implementation, four-party
+review, integration, and production release.
+
+Set `USE_SUPERPOWERS=false` for a complete opt-out. Non-Claude runtimes use the
+native workflow automatically and do not receive the Superpowers planning
+reference or Claude worker-method instructions. The integration deliberately
+does not call Superpowers' worktree, subagent execution, plan execution, or
+branch-finishing skills, avoiding two execution orchestrators on one [feature].
+
 ---
 
 ## Connect your LLM
@@ -518,6 +536,13 @@ Command templates for common CLIs:
 | Gemini CLI | `gemini --yolo "$(cat '{prompt_file}')"` |
 | Any file-reading CLI | `yourcli --prompt-file {prompt_file}` |
 
+Direct `claude` commands are detected automatically. If Claude is behind a
+wrapper, mark only that command template so mixed-model teams remain precise:
+
+```bash
+FRONTEND_CMD="STARTUP_FACTORY_LLM_RUNTIME=claude /path/to/claude-wrapper {prompt_file}"
+```
+
 **Mixing LLMs is the design intent** — e.g. Claude to lead and own the primary
 architecture position, Codex to challenge it independently and implement, and
 Gemini to review. Use different model families for the two architects when
@@ -537,6 +562,16 @@ tool), skip the command map entirely: compose each role's startup prompt with
 role natively with it. Harness messages replace mailboxes, harness idle
 notifications replace heartbeats, and the tracker stays the source of truth —
 see `reference/orchestration.md` → *Harness mode*.
+
+When the harness runtime is Claude Code, declare it while composing so the
+default-on Superpowers integration is included:
+
+```bash
+STARTUP_FACTORY_LLM_RUNTIME=claude \
+  bin/launch-team.sh compose <team> <featureId> <role> [preset]
+```
+
+Omit the variable for Codex, Gemini, and other runtimes.
 
 **Command resolution per role:** explicit `<ROLE>_CMD` value → used; `<ROLE>_CMD=null`
 → role disabled; **absent** → falls back to `TEAM_DEFAULT_CMD`. That fallback is
@@ -587,7 +622,7 @@ by name. A new tool also needs its adapter contract and deterministic
 
 ## Configure
 
-Core team operation uses two files. Autonomous operation adds three fail-closed
+Core operation uses three files. Autonomous operation adds three fail-closed
 JSON templates. Project policy stays versioned; an enabled deployment config is
 instead copied to operator-protected storage outside agent mounts.
 
@@ -601,6 +636,22 @@ instead copied to operator-protected storage outside agent mounts.
 | `STRICT_STATUS` | `true` = refuse an action if a `[task]` isn't in the expected status (the "andon cord") | `true` |
 
 > Set **`TEAM_MODE=true`** before running a team.
+
+### `config/planning.config.md` — optional Claude planning intake
+
+| Key | Meaning | Default |
+|---|---|---|
+| `USE_SUPERPOWERS` | Make Claude Code eligible for `obra/superpowers` brainstorming and plan-writing; non-Claude runtimes stay native | `true` |
+| `SUPERPOWERS_PLUGIN_ID` | Required Claude Code plugin id checked by the planning preflight | `superpowers@claude-plugins-official` |
+| `SUPERPOWERS_SPEC_ROOT` | Repository-relative root for approved specifications | `docs/superpowers/specs` |
+| `SUPERPOWERS_PLAN_ROOT` | Repository-relative root for approved implementation plans | `docs/superpowers/plans` |
+
+Run `python3 bin/superpowers-planning.py preflight --runtime claude` before the
+Claude planning stages, then
+`bin/launch-team.sh planning-handoff <team> <spec-path> <plan-path>` before
+launching the Startup Factory team. Set `USE_SUPERPOWERS=false` to remove all
+Superpowers-specific prompt wiring. With the default `true`, only commands
+classified as Claude receive that wiring.
 
 ### Configure your board
 
@@ -855,6 +906,7 @@ Just talk to your agent in the generic vocabulary:
 |---|---|
 | `team <preset> <team> <featureId>` | Launch a whole preset roster |
 | `gate-team <preset> <team> <featureId>` | Launch only persistent supervision/review/integration gates; automation uses this and starts implementers per task |
+| `planning-handoff <team> <spec-path> <plan-path>` | Bind committed Claude/Superpowers specification and plan inputs to this Startup Factory team |
 | `preflight <team> <featureId>` | Verify adapter access, workspace writability, and UTC pin — run once before any CLI team launch |
 | `start <team> <featureId> <role>…` | Launch specific roles (custom teams) |
 | `relaunch <team> <featureId> <role> [preset]` | Restart one crashed/wedged agent |
@@ -1293,6 +1345,7 @@ package metadata and CLI source, but not repository-only release automation.
 ├── .github/workflows/                release repository only: package/release CI
 ├── config/
 │   ├── project-management.config.md  ← EDIT: pick tracker, TEAM_MODE, STRICT_STATUS
+│   ├── planning.config.md            ← EDIT: Claude/Superpowers planning on/off
 │   ├── team.config.md                ← EDIT (teams): role→CLI, timings, VALIDATE_*
 │   └── statuses · automation · deployment · guardrails configs
 ├── reference/
@@ -1300,7 +1353,7 @@ package metadata and CLI source, but not repository-only release automation.
 │   ├── lifecycle.md                  the scenarios: plan → work → review → complete
 │   ├── team-roles.md                 status ownership across roles
 │   ├── orchestration.md              the multi-agent protocol
-│   └── automation · deployment · guardrails
+│   └── superpowers-planning · automation · deployment · guardrails
 ├── adapters/
 │   ├── Markdown.md · Linear.md · Jira.md · GitHubIssues.md
 │   └── _TEMPLATE.md                  scaffold for a new tracker
@@ -1313,6 +1366,7 @@ package metadata and CLI source, but not repository-only release automation.
 │   └── roles/                        14 specialized role briefs
 ├── bin/
 │   ├── launch-team.sh                role and task-instance launcher
+│   ├── superpowers-planning.py       Claude plugin preflight + planning handoff
 │   ├── process-lifecycle.py          authenticated external process/tmux authority
 │   ├── update-installed-skill.sh     legacy/source compatibility updater
 │   ├── dispatch.sh · dispatch-plan.py deterministic bounded scheduler

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,8 @@ the operational front door; the details live in sibling files (paths are relativ
 skill's directory):
 
 - `config/project-management.config.md` — selects the active tool + settings
+- `config/planning.config.md` + `reference/superpowers-planning.md` +
+  `bin/superpowers-planning.py` — optional Claude/Superpowers planning intake
 - `reference/vocabulary.md` — the generic contract (terms, statuses, IDs, banned words)
 - `reference/lifecycle.md` — the numbered scenarios you execute
 - `reference/team-roles.md` — status ownership (only if `TEAM_MODE=true`)
@@ -73,8 +75,8 @@ preparation:
    If this skill is installed somewhere else, run the same script with
    `--install-dir <path-to-installed-skill>`.
 3. Keep the default config-preserving behavior unless the user explicitly asks to
-   replace project config. Existing project-management, team, statuses, automation,
-   deployment, and guardrails config files under `config/` are preserved, as are
+   replace project config. Existing project-management, planning, team, statuses,
+   automation, deployment, and guardrails config files under `config/` are preserved, as are
    project-owned files under the documented `adapters/`, `extensions/`, and
    `teams/` extension points. An installed ownership manifest distinguishes
    custom files from retired upstream files. The updater validates the source
@@ -88,9 +90,10 @@ preparation:
 
 ## Mandatory Preparation (every invocation)
 
-1. **Read the config** (`config/project-management.config.md`). Note
+1. **Read the configs** (`config/project-management.config.md` and
+   `config/planning.config.md`). Note
    `PRODUCT_MANAGEMENT_TOOL`, the per-tool settings block, and the flags `TEAM_MODE` /
-   `STRICT_STATUS`.
+   `STRICT_STATUS` / `USE_SUPERPOWERS`.
 2. **Load the adapter** for that tool: `adapters/<PRODUCT_MANAGEMENT_TOOL>.md`. This is
    your only source for concrete operations, terminology, status, and ID mappings. If the
    file doesn't exist, stop and tell the user to create it from `adapters/_TEMPLATE.md`.
@@ -99,7 +102,15 @@ preparation:
    For autonomous monitoring or production delivery, also read
    `reference/automation.md`, `reference/guardrails.md`, and
    `reference/deployment.md` before enabling anything.
-4. **Initialize the tool** — steps depend on your execution mode:
+4. **Select the planning intake.** For Scenario 1 or 10, when
+   `USE_SUPERPOWERS=true` and the current runtime is Claude Code, read
+   `reference/superpowers-planning.md`, run its plugin preflight, and use
+   `superpowers:brainstorming` plus `superpowers:writing-plans` to produce the
+   approved specification and plan. Then create the digest-bound handoff and
+   continue with Startup Factory's own team. When disabled or running in another
+   runtime, use the native lifecycle. Never hand execution, worktrees, dispatch,
+   review, integration, or release to Superpowers.
+5. **Initialize the tool** — steps depend on your execution mode:
    - **Single-agent** (`TEAM_MODE` unset or false): run the adapter's *Initialization*
      section probe (a cheap read proving access works). If it fails, stop and tell the
      user to fix the *MCP / CLI Setup* — do not proceed.

--- a/bin/launch-team.sh
+++ b/bin/launch-team.sh
@@ -11,6 +11,7 @@
 #   launch-team.sh relaunch      <team> <featureId> <role> [preset]
 #   launch-team.sh compose       <team> <featureId> <role> [preset]  # write the composed startup prompt, print its path — no spawn (harness mode)
 #   launch-team.sh compose-task  <team> <featureId> <role> <taskId> [attempt] [preset]
+#   launch-team.sh planning-handoff <team> <spec-path> <plan-path>  # bind Claude/Superpowers planning inputs
 #   launch-team.sh worktree      <team> <role> <taskId> [attempt]
 #   launch-team.sh worktree-remove <team> <role> <taskId> [attempt]
 #   launch-team.sh validate-board [config-path]                  # validate board config JSON
@@ -23,6 +24,7 @@ umask 077
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONFIG="$SKILL_DIR/config/team.config.md"
 PM_CONFIG="$SKILL_DIR/config/project-management.config.md"
+PLANNING_CONFIG="$SKILL_DIR/config/planning.config.md"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # Populated immediately before each process launch.  These values are launcher
@@ -42,6 +44,7 @@ LAUNCH_BARRIER_DIR=""
 LAUNCH_BARRIER_FIFO=""
 LAUNCH_GROUP_FILE=""
 LAUNCH_TMUX_WRAPPER=""
+SUPERPOWERS_ENABLED=""
 
 die() { echo "launch-team: $*" >&2; exit 1; }
 
@@ -578,6 +581,100 @@ role_cmd_key() { # backend -> BACKEND_CMD ; principal-architect -> PRINCIPAL_ARC
   printf '%s_CMD' "$(printf '%s' "$1" | tr 'a-z-' 'A-Z_')"
 }
 
+classify_command_runtime() { # command template -> claude|other; never executes the template
+  python3 - "$1" <<'PY'
+import os
+import re
+import shlex
+import sys
+
+assignment = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*\Z")
+explicit_runtime = None
+
+
+def record_assignment(token):
+    global explicit_runtime
+    if not assignment.fullmatch(token):
+        return
+    key, value = token.split("=", 1)
+    if key == "STARTUP_FACTORY_LLM_RUNTIME" and value in {"claude", "other"}:
+        explicit_runtime = value
+
+
+try:
+    tokens = shlex.split(sys.argv[1], posix=True)
+except ValueError:
+    print("other")
+    raise SystemExit
+
+index = 0
+while index < len(tokens) and assignment.fullmatch(tokens[index]):
+    record_assignment(tokens[index])
+    index += 1
+
+if index < len(tokens) and os.path.basename(tokens[index]) == "env":
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}:
+            index += 2
+            continue
+        if assignment.fullmatch(token):
+            record_assignment(token)
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+
+while index < len(tokens) and assignment.fullmatch(tokens[index]):
+    record_assignment(tokens[index])
+    index += 1
+while index < len(tokens) and os.path.basename(tokens[index]) in {
+    "command",
+    "exec",
+    "nohup",
+}:
+    index += 1
+
+runtime = explicit_runtime or (
+    "claude"
+    if index < len(tokens) and os.path.basename(tokens[index]) == "claude"
+    else "other"
+)
+print(runtime)
+PY
+}
+
+role_command_template() { # role -> configured command or empty when disabled/unconfigured
+  local key command
+  key="$(role_cmd_key "$1")"
+  key_is_null "$key" && return 0
+  command="$(read_key "$key")"
+  [ -n "$command" ] || command="$(read_key TEAM_DEFAULT_CMD)"
+  printf '%s' "$command"
+}
+
+task_command_template() { # role profile -> selected task command or empty
+  local role="$1" profile="$2" task_cmd_key command
+  task_cmd_key="TASK_$(printf '%s' "$profile" | tr 'a-z-' 'A-Z_')_CMD"
+  command="$(read_key "$task_cmd_key")"
+  [ -n "$command" ] || command="$(role_command_template "$role")"
+  printf '%s' "$command"
+}
+
+harness_runtime() { # explicit harness runtime or fail-safe non-Claude default
+  case "${STARTUP_FACTORY_LLM_RUNTIME:-}" in
+    '') printf '%s' other ;;
+    claude|other) printf '%s' "$STARTUP_FACTORY_LLM_RUNTIME" ;;
+    *) die "STARTUP_FACTORY_LLM_RUNTIME must be exactly claude or other" ;;
+  esac
+}
+
 task_key() { python3 "$SKILL_DIR/bin/runtime-state.py" key "$1"; }
 
 task_branch() { # task_branch <team> <taskId>; generation/team namespace prevents reopened-ID reuse
@@ -592,11 +689,22 @@ key_is_null() { # key_is_null KEY -> 0 if the config sets KEY explicitly to null
   grep -qE "^$1=null[[:space:]]*(#.*)?$" "$CONFIG"
 }
 
+validate_planning_config() {
+  local planning_json
+  planning_json="$(python3 "$SKILL_DIR/bin/superpowers-planning.py" \
+    --config "$PLANNING_CONFIG" show-config)" \
+    || die "invalid config/planning.config.md"
+  SUPERPOWERS_ENABLED="$(printf '%s' "$planning_json" | python3 -c \
+    'import json,sys; print("true" if json.load(sys.stdin)["enabled"] else "false")')" \
+    || die "could not read config/planning.config.md"
+}
+
 validate_config() { # MAX_ACTIVE_IMPLEMENTERS is a parallel-only knob (spec: throughput levers)
   local exec_mode max_active
   validate_agent_env_allowlist
   validate_sandbox_runner_config
   configure_lifecycle_state
+  validate_planning_config
   exec_mode="$(read_key EXECUTION)"
   max_active="$(read_key MAX_ACTIVE_IMPLEMENTERS)"
   [ -z "$max_active" ] && return 0
@@ -845,17 +953,25 @@ PYEOF
 
 preflight() { # preflight <team> <featureId> — fail before five agents do
   local team="$1" fid="$2"
-  local dir preflight_dir write_test utc_file tool_prefix
+  local dir preflight_dir write_test utc_file tool_prefix planning_handoff
   dir="$(teamroot "$team")" || die "unsafe team workspace"
   preflight_dir="$(team_path "$dir" preflight)" || die "unsafe preflight path"
   write_test="$(team_path "$dir" preflight/.write-test)" || die "unsafe preflight path"
   utc_file="$(team_path "$dir" preflight/utc.txt)" || die "unsafe preflight path"
   tool_prefix="$(team_path "$dir" preflight/tool-prefix.txt)" || die "unsafe preflight path"
+  planning_handoff="$(team_path "$dir" planning/superpowers-handoff.json)" || die "unsafe planning handoff path"
   validate_board >/dev/null
   mkdir -p "$preflight_dir" 2>/dev/null || die "preflight: cannot create workspace $dir"
   ( : > "$write_test" && rm "$write_test" ) \
     || die "preflight: workspace not writable: $dir"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$utc_file"
+  if [ "$SUPERPOWERS_ENABLED" = true ] \
+      && { [ -e "$planning_handoff" ] || [ -L "$planning_handoff" ]; }; then
+    python3 "$SKILL_DIR/bin/superpowers-planning.py" \
+      --config "$PLANNING_CONFIG" validate-handoff \
+      --repo "$REPO_ROOT" --handoff "$planning_handoff" --team "$team" >/dev/null \
+      || die "preflight FAILED — the Claude/Superpowers planning handoff is stale or invalid"
+  fi
   local _a; _a="$(grep -m1 '^PRODUCT_MANAGEMENT_TOOL=' "$PM_CONFIG" | cut -d= -f2 | tr -d '"' || true)"
   local _adapter="${TRACKER_ADAPTER:-$_a}"
   if is_mcp_only "$_adapter"; then
@@ -895,15 +1011,17 @@ team_path() { # team_path <absolute-workspace> <relative-path>
     --repo "$REPO_ROOT" --workspace "$1" --relative "$2"
 }
 
-compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt file path
-  local team="$1" fid="$2" role="$3" preset="${4:-}"
+compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] [runtime] -> prompt file path
+  local team="$1" fid="$2" role="$3" preset="${4:-}" runtime="${5:-other}"
   validate_team_id "$team"; validate_role_id "$role"
+  case "$runtime" in claude|other) ;; *) die "internal launch error: invalid runtime '$runtime'" ;; esac
   if [ -n "$preset" ]; then
     validate_mandatory_sceptical_architect "$preset"
     validate_mandatory_security_reviewer "$preset"
     validate_review_board_independence "$preset"
   fi
-  local dir out prompts mailbox heartbeats pids utc_file tool_prefix
+  local dir out prompts mailbox heartbeats pids utc_file tool_prefix planning_handoff
+  local planning_json="" planning_spec="" planning_plan=""
   dir="$(teamroot "$team")" || die "unsafe team workspace"
   prompts="$(team_path "$dir" prompts)" || die "unsafe prompts path"
   mailbox="$(team_path "$dir" "mailbox/$role")" || die "unsafe mailbox path"
@@ -912,6 +1030,16 @@ compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt
   out="$(team_path "$dir" "prompts/$role.md")" || die "unsafe prompt path"
   utc_file="$(team_path "$dir" preflight/utc.txt)" || die "unsafe preflight path"
   tool_prefix="$(team_path "$dir" preflight/tool-prefix.txt)" || die "unsafe preflight path"
+  planning_handoff="$(team_path "$dir" planning/superpowers-handoff.json)" || die "unsafe planning handoff path"
+  if [ "$SUPERPOWERS_ENABLED" = true ] \
+      && { [ -e "$planning_handoff" ] || [ -L "$planning_handoff" ]; }; then
+    planning_json="$(python3 "$SKILL_DIR/bin/superpowers-planning.py" \
+      --config "$PLANNING_CONFIG" validate-handoff \
+      --repo "$REPO_ROOT" --handoff "$planning_handoff" --team "$team")" \
+      || die "the Claude/Superpowers planning handoff is stale or invalid"
+    planning_spec="$(printf '%s' "$planning_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["spec"]["path"])')"
+    planning_plan="$(printf '%s' "$planning_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["plan"]["path"])')"
+  fi
   local brief; brief="$(role_brief "$role")"
   [ -n "$brief" ] || die "unknown role: $role (no brief in roles/ or teams/roles/)"
   mkdir -p "$prompts" "$mailbox" "$heartbeats" "$pids"
@@ -925,11 +1053,16 @@ compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt
     echo "- Repository root: $REPO_ROOT"
     echo "- Skill directory: $SKILL_DIR (adapter + PM config live here)"
     echo "- Team workspace: $dir"
+    echo "- LLM runtime family: $runtime"
     if [ -s "$utc_file" ]; then
       echo "- Preflight UTC pin: $(cat "$utc_file") — generate every timestamp with: date -u +%Y-%m-%dT%H:%M:%SZ"
     fi
     if [ -s "$tool_prefix" ]; then
       echo "- Verified tracker tool prefix: $(cat "$tool_prefix") (preflight-verified — use it verbatim; do not re-derive from adapter docs)"
+    fi
+    if [ -n "$planning_json" ]; then
+      echo "- Planning handoff: $planning_handoff"
+      echo "- Approved planning inputs: $planning_spec and $planning_plan"
     fi
     echo
     echo "Begin by running the Mandatory Preparation in $SKILL_DIR/SKILL.md, then act"
@@ -955,6 +1088,11 @@ compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt
     echo
     echo "---"
     cat "$CONFIG"
+    if [ "$SUPERPOWERS_ENABLED" = true ] && [ "$runtime" = claude ]; then
+      echo
+      echo "---"
+      cat "$SKILL_DIR/reference/superpowers-planning.md"
+    fi
     if [ -f "$SKILL_DIR/config/statuses.config.json" ]; then
       echo
       echo "---"
@@ -965,8 +1103,8 @@ compose_prompt() { # compose_prompt <team> <featureId> <role> [preset] -> prompt
   printf '%s' "$out"
 }
 
-compose_task_prompt() { # compose_task_prompt <team> <featureId> <role> <taskId> <attempt> [preset]
-  local team="$1" fid="$2" role="$3" task="$4" attempt="$5" preset="${6:-}"
+compose_task_prompt() { # compose_task_prompt <team> <featureId> <role> <taskId> <attempt> [preset] [mode]
+  local team="$1" fid="$2" role="$3" task="$4" attempt="$5" preset="${6:-}" mode="${7:-launch}"
   validate_team_id "$team"; validate_role_id "$role"
   local dir; dir="$(teamroot "$team")" || die "unsafe team workspace"
   local instance; instance="$(task_instance "$role" "$task" "$attempt")"
@@ -976,10 +1114,18 @@ compose_task_prompt() { # compose_task_prompt <team> <featureId> <role> <taskId>
   local branch; branch="$(task_branch "$team" "$task")"
   [ -d "$wt" ] || die "task worktree does not exist: $wt"
   local execution; execution="$("$SKILL_DIR/bin/task-packet.sh" "$team" "$fid" "$task" "$role" "$attempt" "$wt" "$branch")"
-  local packet report profile
+  local packet report profile command runtime
   packet="$(printf '%s' "$execution" | python3 -c 'import json,sys; print(json.load(sys.stdin)["packetPath"])')"
   report="$(printf '%s' "$execution" | python3 -c 'import json,sys; print(json.load(sys.stdin)["reportPath"])')"
   profile="$(printf '%s' "$execution" | python3 -c 'import json,sys; print(json.load(sys.stdin)["modelProfile"])')"
+  case "$mode" in
+    launch)
+      command="$(task_command_template "$role" "$profile")"
+      runtime="$(classify_command_runtime "$command")"
+      ;;
+    harness) runtime="$(harness_runtime)" ;;
+    *) die "internal launch error: invalid prompt mode '$mode'" ;;
+  esac
   local out prompts_tasks pids_tasks heartbeats
   out="$(team_path "$dir" "prompts/tasks/$instance.md")" || die "unsafe task prompt path"
   prompts_tasks="$(team_path "$dir" prompts/tasks)" || die "unsafe task prompt path"
@@ -995,6 +1141,7 @@ compose_task_prompt() { # compose_task_prompt <team> <featureId> <role> <taskId>
     echo "- taskId: $task"
     echo "- Attempt: $attempt"
     echo "- Model profile: $profile"
+    echo "- LLM runtime family: $runtime"
     echo "- Working copy: $wt"
     echo "- Task branch: $branch"
     echo "- Task packet: $packet"
@@ -1019,6 +1166,16 @@ compose_task_prompt() { # compose_task_prompt <team> <featureId> <role> <taskId>
     echo
     echo "Start by emitting task.started / implementing. End by submitting a [review-request], [andon],"
     echo "or context request artifact before exiting. The artifact, not process exit, closes the assignment."
+    if [ "$SUPERPOWERS_ENABLED" = true ] && [ "$runtime" = claude ]; then
+      echo
+      echo "## Claude Superpowers task method"
+      echo
+      echo "If and only if this task is running in Claude Code, you may use the focused"
+      echo "Superpowers skills for test-driven development, systematic debugging,"
+      echo "receiving code review, and verification before completion."
+      echo "Never invoke Superpowers worktree, subagent execution, plan execution, or"
+      echo "branch-finishing skills. Startup Factory owns those execution boundaries."
+    fi
     echo
     echo "---"
     cat "$SKILL_DIR/reference/guardrails.md"
@@ -1046,7 +1203,8 @@ launch_one() { # launch_one <team> <featureId> <role> [preset]
   local cmd_tpl; cmd_tpl="$(read_key "$key")"
   [ -n "$cmd_tpl" ] || cmd_tpl="$(read_key TEAM_DEFAULT_CMD)"
   [ -n "$cmd_tpl" ] || die "no command for role '$role' ($key absent and TEAM_DEFAULT_CMD is null)"
-  local prompt; prompt="$(compose_prompt "$team" "$fid" "$role" "$preset")"
+  local runtime; runtime="$(classify_command_runtime "$cmd_tpl")"
+  local prompt; prompt="$(compose_prompt "$team" "$fid" "$role" "$preset" "$runtime")"
   local cmd="${cmd_tpl//\{prompt_file\}/$prompt}"
   local dir pidfile logfile env_cmd rc quoted_workdir quoted_marker
   dir="$(teamroot "$team")" || die "unsafe team workspace"
@@ -1142,7 +1300,7 @@ launch_task() { # launch_task <team> <featureId> <role> <taskId> <attempt> [pres
     fi
   fi
   local wt; wt="$("$0" worktree "$team" "$role" "$task" "$attempt")"
-  local prompt; prompt="$(compose_task_prompt "$team" "$fid" "$role" "$task" "$attempt" "$preset")"
+  local prompt; prompt="$(compose_task_prompt "$team" "$fid" "$role" "$task" "$attempt" "$preset" launch)"
   local execution profile task_cmd_key cmd_tpl
   execution="$(team_path "$dir" "executions/$(task_key "$task").json")" || die "unsafe execution path"
   profile="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["modelProfile"])' "$execution")"
@@ -1196,9 +1354,31 @@ launch_task() { # launch_task <team> <featureId> <role> <taskId> <attempt> [pres
   fi
 }
 
-case "${1:-}" in validate-board|'') ;; *) validate_config ;; esac
+case "${1:-}" in
+  validate-board|'') ;;
+  planning-handoff) validate_planning_config ;;
+  *) validate_config ;;
+esac
 
 case "${1:-}" in
+  planning-handoff)
+    [ $# -eq 4 ] || die "usage: planning-handoff <team> <spec-path> <plan-path>"
+    validate_team_id "$2"
+    [ "$SUPERPOWERS_ENABLED" = true ] \
+      || die "Superpowers planning is disabled by USE_SUPERPOWERS=false"
+    dir="$(teamroot "$2")" || die "unsafe team workspace"
+    handoff="$(team_path "$dir" planning/superpowers-handoff.json)" || die "unsafe planning handoff path"
+    mkdir -p "$(dirname "$handoff")"
+    python3 "$SKILL_DIR/bin/superpowers-planning.py" \
+      --config "$PLANNING_CONFIG" create-handoff \
+      --repo "$REPO_ROOT" --team "$2" --spec "$3" --plan "$4" --output "$handoff" >/dev/null \
+      || die "could not create the Claude/Superpowers planning handoff"
+    python3 "$SKILL_DIR/bin/superpowers-planning.py" \
+      --config "$PLANNING_CONFIG" validate-handoff \
+      --repo "$REPO_ROOT" --handoff "$handoff" --team "$2" --require-head >/dev/null \
+      || die "created planning handoff did not validate"
+    echo "$handoff"
+    ;;
   team)
     [ $# -eq 4 ] || die "usage: team <preset> <team> <featureId>"
     preset="$2"; team="$3"; fid="$4"
@@ -1262,13 +1442,14 @@ case "${1:-}" in
     # Harness mode: emit the exact same startup prompt `start` would use, without
     # spawning anything, so any harness can spawn the role natively with it.
     [ $# -eq 4 ] || [ $# -eq 5 ] || die "usage: compose <team> <featureId> <role> [preset]"
-    prompt="$(compose_prompt "$2" "$3" "$4" "${5:-}")"
+    runtime="$(harness_runtime)"
+    prompt="$(compose_prompt "$2" "$3" "$4" "${5:-}" "$runtime")"
     echo "$prompt"
     ;;
   compose-task)
     [ $# -ge 5 ] && [ $# -le 7 ] || die "usage: compose-task <team> <featureId> <role> <taskId> [attempt] [preset]"
     "$0" worktree "$2" "$4" "$5" "${6:-1}" >/dev/null
-    prompt="$(compose_task_prompt "$2" "$3" "$4" "$5" "${6:-1}" "${7:-}")"
+    prompt="$(compose_task_prompt "$2" "$3" "$4" "$5" "${6:-1}" "${7:-}" harness)"
     echo "$prompt"
     ;;
   worktree)
@@ -1508,6 +1689,6 @@ PY
     validate_board "${2:-}"
     ;;
   *)
-    die "usage: launch-team.sh {team|gate-team|preflight|start|start-task|relaunch|compose|compose-task|worktree|worktree-remove|validate-board|status|stop|stop-task} ..."
+    die "usage: launch-team.sh {planning-handoff|team|gate-team|preflight|start|start-task|relaunch|compose|compose-task|worktree|worktree-remove|validate-board|status|stop|stop-task} ..."
     ;;
 esac

--- a/bin/superpowers-planning.py
+++ b/bin/superpowers-planning.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Validate the optional Claude/Superpowers planning boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = SKILL_DIR / "config" / "planning.config.md"
+DEFAULTS = {
+    "USE_SUPERPOWERS": "true",
+    "SUPERPOWERS_PLUGIN_ID": "superpowers@claude-plugins-official",
+    "SUPERPOWERS_SPEC_ROOT": "docs/superpowers/specs",
+    "SUPERPOWERS_PLAN_ROOT": "docs/superpowers/plans",
+}
+ALLOWED_KEYS = frozenset(DEFAULTS)
+BLOCKED_EXECUTION_SKILLS = (
+    "superpowers:using-git-worktrees",
+    "superpowers:subagent-driven-development",
+    "superpowers:executing-plans",
+    "superpowers:finishing-a-development-branch",
+)
+TEAM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,62}\Z")
+PLUGIN_RE = re.compile(r"[A-Za-z0-9._-]+@[A-Za-z0-9._-]+\Z")
+HEX_RE = re.compile(r"[0-9a-f]{64}\Z")
+COMMIT_RE = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
+
+
+class PlanningError(RuntimeError):
+    """Safe user-facing planning configuration or handoff failure."""
+
+
+def strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PlanningError(f"JSON object contains duplicate key: {key}")
+        result[key] = value
+    return result
+
+
+def parse_config(path: Path) -> dict[str, str]:
+    values = dict(DEFAULTS)
+    if not path.exists():
+        return values
+    if path.is_symlink() or not path.is_file():
+        raise PlanningError(f"planning config is not a regular file: {path}")
+    seen: set[str] = set()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise PlanningError(f"cannot read planning config: {exc}") from exc
+    for raw_line in lines:
+        match = re.match(r"^([A-Z][A-Z0-9_]*)=(.*)$", raw_line)
+        if not match:
+            continue
+        key, raw_value = match.groups()
+        if key not in ALLOWED_KEYS:
+            raise PlanningError(f"unknown planning configuration key: {key}")
+        if key in seen:
+            raise PlanningError(f"duplicate planning configuration key: {key}")
+        seen.add(key)
+        value = raw_value.strip()
+        if value.startswith('"'):
+            closing = value.find('"', 1)
+            if closing < 0:
+                raise PlanningError(f"unterminated quoted value for {key}")
+            trailing = value[closing + 1 :].strip()
+            if trailing and not trailing.startswith("#"):
+                raise PlanningError(f"unexpected text after quoted value for {key}")
+            value = value[1:closing]
+        else:
+            value = value.split("#", 1)[0].strip()
+        values[key] = value
+    if values["USE_SUPERPOWERS"] not in {"true", "false"}:
+        raise PlanningError("USE_SUPERPOWERS must be exactly true or false")
+    if not PLUGIN_RE.fullmatch(values["SUPERPOWERS_PLUGIN_ID"]):
+        raise PlanningError("SUPERPOWERS_PLUGIN_ID must be a plugin@marketplace id")
+    for key in ("SUPERPOWERS_SPEC_ROOT", "SUPERPOWERS_PLAN_ROOT"):
+        values[key] = safe_relative_directory(values[key], key)
+    return values
+
+
+def safe_relative_directory(value: str, label: str) -> str:
+    if not value or "\\" in value or any(ord(char) < 32 for char in value):
+        raise PlanningError(
+            f"{label} must be a normalized repository-relative directory"
+        )
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or value.endswith("/")
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise PlanningError(
+            f"{label} must be a normalized repository-relative directory"
+        )
+    normalized = path.as_posix()
+    if normalized != value:
+        raise PlanningError(
+            f"{label} must be a normalized repository-relative directory"
+        )
+    return normalized
+
+
+def load_json(path: Path, label: str) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise PlanningError(f"{label} is not a regular file: {path}")
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=strict_object
+        )
+    except PlanningError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PlanningError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
+
+
+def canonical_json(value: Any) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def run(arguments: list[str], *, cwd: Path | None = None, timeout: int = 30) -> str:
+    try:
+        process = subprocess.run(
+            arguments,
+            cwd=os.fspath(cwd) if cwd else None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PlanningError(f"cannot run {' '.join(arguments)}: {exc}") from exc
+    if process.returncode:
+        detail = process.stderr.strip() or process.stdout.strip() or "unknown error"
+        raise PlanningError(f"{' '.join(arguments)} failed: {detail}")
+    return process.stdout
+
+
+def git(repo: Path, *arguments: str) -> str:
+    return run(["git", "-C", os.fspath(repo), *arguments], timeout=30).strip()
+
+
+def canonical_repo(raw: str) -> Path:
+    path = Path(raw).expanduser()
+    try:
+        repo = path.resolve(strict=True)
+    except OSError as exc:
+        raise PlanningError(f"cannot resolve repository: {exc}") from exc
+    if not repo.is_dir():
+        raise PlanningError(f"repository is not a directory: {repo}")
+    top = Path(git(repo, "rev-parse", "--show-toplevel")).resolve(strict=True)
+    if top != repo:
+        raise PlanningError(f"--repo must name the repository root: {top}")
+    return repo
+
+
+def repo_file(repo: Path, raw: str, root: str, label: str) -> tuple[Path, str]:
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        if ".." in candidate.parts:
+            raise PlanningError(f"{label} must not contain '..'")
+        candidate = repo / candidate
+    if candidate.is_symlink():
+        raise PlanningError(f"{label} must not be a symlink")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise PlanningError(f"cannot resolve {label}: {exc}") from exc
+    try:
+        relative = resolved.relative_to(repo).as_posix()
+    except ValueError as exc:
+        raise PlanningError(f"{label} must remain inside the repository") from exc
+    if not resolved.is_file():
+        raise PlanningError(f"{label} is not a regular file")
+    prefix = root + "/"
+    if relative == root or not relative.startswith(prefix):
+        raise PlanningError(f"{label} must be below {root}/")
+    return resolved, relative
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise PlanningError(f"cannot hash {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def require_committed(repo: Path, relative_paths: list[str]) -> None:
+    for relative in relative_paths:
+        git(repo, "ls-files", "--error-unmatch", "--", relative)
+    dirty = git(repo, "status", "--porcelain=v1", "--", *relative_paths)
+    if dirty:
+        raise PlanningError("specification and plan must be committed and unmodified")
+
+
+def plugin_list(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.plugin_list_json:
+        payload = load_json(Path(args.plugin_list_json), "Claude plugin list")
+    else:
+        command = args.claude_command
+        if not command or any(char.isspace() for char in command):
+            raise PlanningError("--claude-command must be one executable path or name")
+        try:
+            payload = json.loads(
+                run([command, "plugin", "list", "--json"], timeout=30),
+                object_pairs_hook=strict_object,
+            )
+        except json.JSONDecodeError as exc:
+            raise PlanningError(f"Claude plugin list is not valid JSON: {exc}") from exc
+    if not isinstance(payload, list) or any(
+        not isinstance(item, dict) for item in payload
+    ):
+        raise PlanningError("Claude plugin list must be an array of objects")
+    return payload
+
+
+def command_show_config(args: argparse.Namespace) -> dict[str, Any]:
+    config = parse_config(Path(args.config))
+    return {
+        "enabled": config["USE_SUPERPOWERS"] == "true",
+        "pluginId": config["SUPERPOWERS_PLUGIN_ID"],
+        "specRoot": config["SUPERPOWERS_SPEC_ROOT"],
+        "planRoot": config["SUPERPOWERS_PLAN_ROOT"],
+    }
+
+
+def command_preflight(args: argparse.Namespace) -> dict[str, Any]:
+    config = parse_config(Path(args.config))
+    if config["USE_SUPERPOWERS"] == "false":
+        return {"enabled": False, "runtime": args.runtime, "status": "disabled"}
+    if args.runtime != "claude":
+        return {"enabled": True, "runtime": args.runtime, "status": "not-applicable"}
+    expected = config["SUPERPOWERS_PLUGIN_ID"]
+    matches = [item for item in plugin_list(args) if item.get("id") == expected]
+    if len(matches) != 1:
+        raise PlanningError(
+            f"required Claude plugin is not installed exactly once: {expected}"
+        )
+    plugin = matches[0]
+    if plugin.get("enabled") is not True:
+        raise PlanningError(f"required Claude plugin is disabled: {expected}")
+    version = plugin.get("version")
+    if not isinstance(version, str) or not version:
+        raise PlanningError(f"required Claude plugin has no version: {expected}")
+    return {
+        "enabled": True,
+        "runtime": "claude",
+        "status": "ready",
+        "pluginId": expected,
+        "version": version,
+    }
+
+
+def command_create_handoff(args: argparse.Namespace) -> dict[str, Any]:
+    config = parse_config(Path(args.config))
+    if config["USE_SUPERPOWERS"] != "true":
+        raise PlanningError("Superpowers planning is disabled by USE_SUPERPOWERS=false")
+    if not TEAM_RE.fullmatch(args.team) or args.team in {".", ".."}:
+        raise PlanningError("team must use letters, digits, dot, underscore, or hyphen")
+    repo = canonical_repo(args.repo)
+    spec_path, spec_relative = repo_file(
+        repo, args.spec, config["SUPERPOWERS_SPEC_ROOT"], "specification"
+    )
+    plan_path, plan_relative = repo_file(
+        repo, args.plan, config["SUPERPOWERS_PLAN_ROOT"], "plan"
+    )
+    require_committed(repo, [spec_relative, plan_relative])
+    source_commit = git(repo, "rev-parse", "HEAD").lower()
+    if not COMMIT_RE.fullmatch(source_commit):
+        raise PlanningError("Git returned an invalid source commit")
+    manifest = {
+        "schemaVersion": 1,
+        "backend": "claude-superpowers",
+        "pluginId": config["SUPERPOWERS_PLUGIN_ID"],
+        "executionOwner": "startup-factory",
+        "blockedExecutionSkills": list(BLOCKED_EXECUTION_SKILLS),
+        "sourceCommit": source_commit,
+        "team": args.team,
+        "spec": {"path": spec_relative, "sha256": sha256(spec_path)},
+        "plan": {"path": plan_relative, "sha256": sha256(plan_path)},
+    }
+    output = Path(args.output).expanduser()
+    if not output.is_absolute():
+        if ".." in output.parts:
+            raise PlanningError("handoff output must not contain '..'")
+        output = repo / output
+    if output.is_symlink():
+        raise PlanningError("handoff output must not be a symlink")
+    output = output.resolve(strict=False)
+    try:
+        output.relative_to(repo)
+    except ValueError as exc:
+        raise PlanningError("handoff output must remain inside the repository") from exc
+    if output.exists() and (output.is_symlink() or not output.is_file()):
+        raise PlanningError("handoff output exists and is not a regular file")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.parent.is_symlink():
+        raise PlanningError("handoff output parent must not be a symlink")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".superpowers-handoff.", dir=os.fspath(output.parent)
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(canonical_json(manifest))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, output)
+    finally:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+    return {"handoff": os.fspath(output), "manifest": manifest}
+
+
+def require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        raise PlanningError(f"{label} has invalid fields")
+
+
+def validate_artifact(repo: Path, value: Any, root: str, label: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise PlanningError(f"{label} must be an object")
+    require_exact_keys(value, {"path", "sha256"}, label)
+    path_value = value["path"]
+    digest = value["sha256"]
+    if (
+        not isinstance(path_value, str)
+        or not isinstance(digest, str)
+        or not HEX_RE.fullmatch(digest)
+    ):
+        raise PlanningError(f"{label} has invalid path or digest")
+    path, relative = repo_file(repo, path_value, root, label)
+    if relative != path_value:
+        raise PlanningError(f"{label} path is not canonical")
+    if sha256(path) != digest:
+        raise PlanningError(f"{label} digest does not match the current file")
+    return {"path": relative, "sha256": digest}
+
+
+def command_validate_handoff(args: argparse.Namespace) -> dict[str, Any]:
+    config = parse_config(Path(args.config))
+    repo = canonical_repo(args.repo)
+    manifest = load_json(Path(args.handoff), "planning handoff")
+    if not isinstance(manifest, dict):
+        raise PlanningError("planning handoff must be an object")
+    require_exact_keys(
+        manifest,
+        {
+            "schemaVersion",
+            "backend",
+            "pluginId",
+            "executionOwner",
+            "blockedExecutionSkills",
+            "sourceCommit",
+            "team",
+            "spec",
+            "plan",
+        },
+        "planning handoff",
+    )
+    if manifest["schemaVersion"] != 1 or isinstance(manifest["schemaVersion"], bool):
+        raise PlanningError("unsupported planning handoff schema")
+    if manifest["backend"] != "claude-superpowers":
+        raise PlanningError("planning handoff has the wrong backend")
+    if manifest["pluginId"] != config["SUPERPOWERS_PLUGIN_ID"]:
+        raise PlanningError("planning handoff plugin id does not match configuration")
+    if manifest["executionOwner"] != "startup-factory":
+        raise PlanningError(
+            "planning handoff does not assign execution to Startup Factory"
+        )
+    if manifest["blockedExecutionSkills"] != list(BLOCKED_EXECUTION_SKILLS):
+        raise PlanningError("planning handoff has an invalid execution-skill boundary")
+    team = manifest["team"]
+    if not isinstance(team, str) or not TEAM_RE.fullmatch(team) or team in {".", ".."}:
+        raise PlanningError("planning handoff has an unsafe team id")
+    source_commit = manifest["sourceCommit"]
+    if not isinstance(source_commit, str) or not COMMIT_RE.fullmatch(source_commit):
+        raise PlanningError("planning handoff has an invalid source commit")
+    if args.team and args.team != team:
+        raise PlanningError("planning handoff belongs to a different team")
+    try:
+        run(
+            [
+                "git",
+                "-C",
+                os.fspath(repo),
+                "merge-base",
+                "--is-ancestor",
+                source_commit,
+                "HEAD",
+            ],
+            timeout=30,
+        )
+    except PlanningError as exc:
+        raise PlanningError(
+            "planning handoff source commit is not an ancestor of the current HEAD"
+        ) from exc
+    spec = validate_artifact(
+        repo, manifest["spec"], config["SUPERPOWERS_SPEC_ROOT"], "specification"
+    )
+    plan = validate_artifact(
+        repo, manifest["plan"], config["SUPERPOWERS_PLAN_ROOT"], "plan"
+    )
+    require_committed(repo, [spec["path"], plan["path"]])
+    if args.require_head and git(repo, "rev-parse", "HEAD").lower() != source_commit:
+        raise PlanningError("planning handoff source commit is not the current HEAD")
+    return {
+        "valid": True,
+        "team": team,
+        "sourceCommit": source_commit,
+        "spec": spec,
+        "plan": plan,
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument("--config", default=os.fspath(DEFAULT_CONFIG))
+    commands = root.add_subparsers(dest="command", required=True)
+
+    show = commands.add_parser("show-config")
+    show.set_defaults(handler=command_show_config)
+
+    preflight = commands.add_parser("preflight")
+    preflight.add_argument("--runtime", choices=("claude", "other"), required=True)
+    preflight.add_argument("--claude-command", default="claude")
+    preflight.add_argument("--plugin-list-json")
+    preflight.set_defaults(handler=command_preflight)
+
+    create = commands.add_parser("create-handoff")
+    create.add_argument("--repo", required=True)
+    create.add_argument("--team", required=True)
+    create.add_argument("--spec", required=True)
+    create.add_argument("--plan", required=True)
+    create.add_argument("--output", required=True)
+    create.set_defaults(handler=command_create_handoff)
+
+    validate = commands.add_parser("validate-handoff")
+    validate.add_argument("--repo", required=True)
+    validate.add_argument("--handoff", required=True)
+    validate.add_argument("--team")
+    validate.add_argument("--require-head", action="store_true")
+    validate.set_defaults(handler=command_validate_handoff)
+    return root
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        result = args.handler(args)
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return 0
+    except PlanningError as exc:
+        print(f"superpowers-planning: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/update-installed-skill.sh
+++ b/bin/update-installed-skill.sh
@@ -187,6 +187,7 @@ for required_file in \
   adapters/_TEMPLATE.md \
   bin/dispatch.sh \
   bin/launch-team.sh \
+  bin/superpowers-planning.py \
   bin/pm-agent.py \
   bin/policy-check.py \
   bin/release-feature.py \
@@ -194,6 +195,7 @@ for required_file in \
   bin/tracker-ops.sh \
   bin/update-installed-skill.sh \
   config/project-management.config.md \
+  config/planning.config.md \
   config/team.config.md \
   config/statuses.config.json \
   config/automation.config.json \
@@ -203,6 +205,7 @@ for required_file in \
   reference/automation.md \
   reference/deployment.md \
   reference/guardrails.md \
+  reference/superpowers-planning.md \
   roles/senior-security-engineer.md \
   roles/team-lead.md \
   teams/_PLAYBOOK.md
@@ -232,6 +235,7 @@ rsync_args=(-a --checksum --delete --exclude .git --exclude "/$OWNERSHIP_MANIFES
 if ! $overwrite_config; then
   for file in \
     config/project-management.config.md \
+    config/planning.config.md \
     config/team.config.md \
     config/statuses.config.json \
     config/automation.config.json \

--- a/config/planning.config.md
+++ b/config/planning.config.md
@@ -1,0 +1,42 @@
+# Planning Configuration
+
+This project-wide configuration selects whether Claude Code uses
+[`obra/superpowers`](https://github.com/obra/superpowers) to shape specification
+and implementation planning before Startup Factory launches its own team.
+
+```
+USE_SUPERPOWERS=true
+SUPERPOWERS_PLUGIN_ID=superpowers@claude-plugins-official
+SUPERPOWERS_SPEC_ROOT=docs/superpowers/specs
+SUPERPOWERS_PLAN_ROOT=docs/superpowers/plans
+```
+
+## Behavior
+
+- `USE_SUPERPOWERS=true` (default): make Claude Code runtimes eligible to invoke
+  `superpowers:brainstorming`, then `superpowers:writing-plans`. Bind the
+  resulting committed specification and plan into a Startup Factory planning
+  handoff before launching the team. This value does not enable Superpowers for
+  any non-Claude runtime.
+- `USE_SUPERPOWERS=false`: skip every Superpowers-specific planning and worker
+  instruction. Use the native Startup Factory planning, design, implementation,
+  review, integration, and release workflow.
+- Non-Claude runtimes always use the native workflow. They do not receive the
+  Superpowers planning reference or Claude worker-method instructions, and the
+  flag does not require another model or harness to install Superpowers.
+
+Superpowers never owns execution in this integration. Do not invoke its
+`using-git-worktrees`, `subagent-driven-development`, `executing-plans`, or
+`finishing-a-development-branch` skills for Startup Factory work. Startup
+Factory owns task packets, worktrees, dispatch, review, integration, and
+production release.
+
+## Rules
+
+- Keep exactly one `KEY=value` per line inside the fenced block.
+- `USE_SUPERPOWERS` must be exactly `true` or `false`.
+- `SUPERPOWERS_PLUGIN_ID` must be a Claude Code plugin id.
+- `SUPERPOWERS_SPEC_ROOT` and `SUPERPOWERS_PLAN_ROOT` must be normalized,
+  repository-relative directories.
+- This file is project configuration and is preserved during Startup Factory
+  updates unless `--overwrite-config` is explicitly requested.

--- a/packaging/build_bundle.py
+++ b/packaging/build_bundle.py
@@ -25,6 +25,7 @@ DEFAULT_SPEC_PATH = "packaging/bundle-spec.json"
 REGULAR_GIT_MODES = {"100644": 0o644, "100755": 0o755}
 EXPECTED_PRESERVED_CONFIGS = {
     "config/project-management.config.md",
+    "config/planning.config.md",
     "config/team.config.md",
     "config/statuses.config.json",
     "config/automation.config.json",
@@ -254,7 +255,7 @@ def _load_spec(repo: Path, entries: dict[str, GitEntry], spec_path: str) -> dict
         preservation["preservedConfigFiles"], label="preservedConfigFiles"
     )
     if set(preserved_configs) != EXPECTED_PRESERVED_CONFIGS:
-        raise BundleError("preservedConfigFiles must contain the six supported project configs")
+        raise BundleError("preservedConfigFiles must contain the seven supported project configs")
     extension_roots = _string_list(preservation["extensionRoots"], label="extensionRoots")
     if not extension_roots:
         raise BundleError("extensionRoots must not be empty")

--- a/packaging/bundle-spec.json
+++ b/packaging/bundle-spec.json
@@ -36,6 +36,7 @@
     "adapters/_TEMPLATE.md",
     "bin/dispatch.sh",
     "bin/launch-team.sh",
+    "bin/superpowers-planning.py",
     "bin/pm-agent.py",
     "bin/policy-check.py",
     "bin/release-feature.py",
@@ -43,6 +44,7 @@
     "bin/tracker-ops.sh",
     "bin/update-installed-skill.sh",
     "config/project-management.config.md",
+    "config/planning.config.md",
     "config/team.config.md",
     "config/statuses.config.json",
     "config/automation.config.json",
@@ -52,6 +54,7 @@
     "reference/automation.md",
     "reference/deployment.md",
     "reference/guardrails.md",
+    "reference/superpowers-planning.md",
     "roles/team-lead.md",
     "teams/_PLAYBOOK.md",
     "tests/run-all.sh"
@@ -60,6 +63,7 @@
     "version": 1,
     "preservedConfigFiles": [
       "config/project-management.config.md",
+      "config/planning.config.md",
       "config/team.config.md",
       "config/statuses.config.json",
       "config/automation.config.json",

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -16,6 +16,14 @@ the adapter doesn't define.
 
 Turn an idea into a tracked feature with a task breakdown.
 
+Before step 1, select the configured planning intake. If
+`USE_SUPERPOWERS=true` and the current runtime is Claude Code, follow
+`reference/superpowers-planning.md`: use Superpowers for brainstorming and
+writing the committed specification/plan, then create the Startup Factory
+planning handoff. Treat those documents as reviewed inputs to the steps below,
+not as authority to launch Superpowers execution. If the flag is false or the
+runtime is not Claude Code, begin directly with the native workflow.
+
 1. **Understand the goal.** Clarify scope with the user: what ships, what's explicitly out,
    and any dependencies. Research the codebase enough to size the work realistically.
 2. **Create the [feature]** via the adapter, status `[Planned]`. Record its `featureId`.
@@ -213,6 +221,10 @@ one batch instead:
 For preset teams this batch is the **default opener** (`teams/_PLAYBOOK.md`
 stage 3); per-[task] gates at claim time are the opt-out for genuinely
 emergent plans.
+
+An approved Claude/Superpowers planning handoff may seed these notes, but it
+does not replace the cross-[task] consistency pass, independent architectural
+challenge, per-[task] verdicts, product scope sign-off, or tracker comments.
 
 1. **One `[design-note]` per [task]**, written against the real codebase (not the
    [task] text alone). Registering exports in the contract registry

--- a/reference/orchestration.md
+++ b/reference/orchestration.md
@@ -28,6 +28,7 @@ Three principles rule everything:
 <TEAMWORK_ROOT>/<team>/
 ├── prompts/<role>.md            # full gate-role startup prompts
 ├── prompts/tasks/<instance>.md  # lean prompt for one task attempt
+├── planning/superpowers-handoff.json # optional digest-bound Claude planning intake
 ├── mailbox/<role>/NNN-<from>.md # incoming messages for <role>, numbered, append-only
 ├── heartbeats/<role>            # one line: <ISO-8601 UTC> | <taskId or -> | <state>
 ├── pids/<role>.pid              # non-authoritative `managed`/`unmanaged` UI marker + log location

--- a/reference/superpowers-planning.md
+++ b/reference/superpowers-planning.md
@@ -1,0 +1,96 @@
+# Claude + obra/superpowers planning
+
+Use this workflow only when all of the following are true:
+
+1. `USE_SUPERPOWERS=true` in `config/planning.config.md`.
+2. The current runtime is Claude Code.
+3. `bin/superpowers-planning.py preflight --runtime claude` succeeds.
+
+Non-Claude runtimes and projects with the flag disabled use the native Startup
+Factory lifecycle without emulating or copying Superpowers.
+
+The launcher recognizes a direct `claude` command automatically. If a configured
+command invokes Claude through a wrapper, mark that command template explicitly:
+
+```bash
+STARTUP_FACTORY_LLM_RUNTIME=claude /path/to/wrapper {prompt_file}
+```
+
+In harness mode, set `STARTUP_FACTORY_LLM_RUNTIME=claude` while composing the
+prompt. Any absent or non-Claude runtime marker is treated as `other`, so the
+default-on project flag remains Claude-only.
+
+## Ownership boundary
+
+Superpowers owns two inputs:
+
+1. `superpowers:brainstorming` — clarify intent, compare approaches, obtain human
+   design approval, and write the specification under the configured spec root.
+2. `superpowers:writing-plans` — turn the approved specification into a detailed
+   implementation plan under the configured plan root.
+
+Startup Factory owns everything after that:
+
+- cross-functional planning review and task shaping;
+- project-management creation and status transitions;
+- design gates and contract registration;
+- task packets, branches, worktrees, and dispatch;
+- implementation, four-party review, and integration;
+- product acceptance, protected CI proof, and production release.
+
+The Superpowers plan may contain its standard instruction to use
+`subagent-driven-development` or `executing-plans`. Treat that instruction as
+superseded by this integration. Do not invoke:
+
+- `superpowers:using-git-worktrees`;
+- `superpowers:subagent-driven-development`;
+- `superpowers:executing-plans`;
+- `superpowers:finishing-a-development-branch`.
+
+This prevents two schedulers, worktree owners, review systems, and branch
+finishers from operating on the same [feature].
+
+## Planning workflow
+
+1. Run the Claude plugin preflight:
+
+   ```bash
+   python3 bin/superpowers-planning.py preflight --runtime claude
+   ```
+
+2. Invoke `superpowers:brainstorming`. Follow its human approval gates. Do not
+   create tracker work or launch implementation agents during brainstorming.
+3. Invoke `superpowers:writing-plans` after the written specification is
+   approved. Let it write and self-review the implementation plan.
+4. Do not offer or start a Superpowers execution mode. Instead create the
+   digest-bound handoff:
+
+   ```bash
+   bin/launch-team.sh planning-handoff <team> <spec-path> <plan-path>
+   ```
+
+5. Use the specification and plan as planning inputs, not unquestioned
+   authority. The Product Manager, Team Lead, Principal Architect, and Sceptical
+   Architect still check scope, acceptance criteria, boundaries, dependencies,
+   risks, contracts, task metadata, and implementation order.
+6. Create the [feature] and [tasks] only after the normal Startup Factory
+   planning approvals. Then run the pre-flight design pass and normal team
+   lifecycle through verified production.
+
+The handoff binds the exact committed specification, plan, plugin id, repository
+commit, and execution owner. If either document changes, recreate the handoff
+and repeat the affected planning approvals.
+
+## Claude task-worker methods
+
+Claude task workers may invoke these focused Superpowers skills where relevant:
+
+- `superpowers:test-driven-development`;
+- `superpowers:systematic-debugging`;
+- `superpowers:receiving-code-review`;
+- `superpowers:verification-before-completion`.
+
+These skills improve the method used inside one assigned task. They never expand
+scope, launch their own implementation team, create a second worktree, merge,
+finish the branch, or claim completion without Startup Factory artifacts and
+gates.

--- a/roles/team-lead.md
+++ b/roles/team-lead.md
@@ -56,38 +56,42 @@ comments have no authenticated broker receipt.
 ## Phase 1 — Plan and launch
 
 1. Run the Mandatory Preparation from `SKILL.md` (config, adapter, port files).
-2. Execute Scenario 1 up to — but not including — creating anything in the tracker:
+2. If `<TEAMWORK_ROOT>/<team>/planning/superpowers-handoff.json` exists,
+   validate it with `bin/superpowers-planning.py`, then read the exact bound
+   specification and plan. Use them as planning evidence; do not invoke
+   Superpowers execution, worktree, subagent, or branch-finishing skills.
+3. Execute Scenario 1 up to — but not including — creating anything in the tracker:
    draft the [feature] description and the [task] breakdown (complete vertical
    slices; **repeat every relevant business rule inside every [task] description**.
    Add scheduler metadata to each description: `track:`, `parallel-safe:`,
    `files:`, `resources:`, and optional `model-profile:`.
-3. Send the same draft and evidence to the principal-architect and sceptical-
+4. Send the same draft and evidence to the principal-architect and sceptical-
    architect independently. Require both planning approvals. Resolve findings
    through evidence and revision; unresolved material disagreement follows the
    conflict-aware escalation rule above. Only then create the [feature] and
    [tasks] via the adapter, all `[Planned]`.
-4. **Record the baseline.** At feature-branch creation, write
+5. **Record the baseline.** At feature-branch creation, write
    `<TEAMWORK_ROOT>/<team>/BASELINE.md` (protocol: *Baseline manifest*): test
    counts, known failures with cause, available validation commands. Point
    briefs and assignments at it instead of restating branch lore in messages.
-5. Compose the gate roster. Implementers are fresh task instances launched by
+6. Compose the gate roster. Implementers are fresh task instances launched by
    the dispatcher; Team Lead, Principal Architect, Sceptical Architect, Senior
    Security Engineer, optional reviewer/QA specialists, and integrator remain
    batched queue consumers.
-6. Launch: `bin/launch-team.sh start <team> <featureId> <role>...` (or spawn each
+7. Launch: `bin/launch-team.sh start <team> <featureId> <role>...` (or spawn each
    role natively in your harness from a `compose`d prompt — see
    `reference/orchestration.md` → *Harness mode*).
-7. **Let machinery claim.** `dispatch.sh` owns the claim lock, concurrency cap,
+8. **Let machinery claim.** `dispatch.sh` owns the claim lock, concurrency cap,
    dependency checks, resource collision checks, task packet, worktree, and
    fresh worker launch. You handle only tasks it reports as missing a design
    gate, unsafe to parallelize, anomalous, or blocked.
-8. `EXECUTION=sequential` means one task worker at a time. `parallel` means a
+9. `EXECUTION=sequential` means one task worker at a time. `parallel` means a
    bounded ready wave; null `MAX_ACTIVE_IMPLEMENTERS` defaults conservatively
    to two. Both modes use task branches and worktrees, so review/integration can
    overlap without contaminating the feature checkout.
-9. Rework on an older task outranks new claims. Use the existing freeze protocol
+10. Rework on an older task outranks new claims. Use the existing freeze protocol
    when a later active task consumes its contracts or resources.
-10. **Keep the design gate ahead of the dispatch (any mode).** Settled plan →
+11. **Keep the design gate ahead of the dispatch (any mode).** Settled plan →
     the pre-flight design pass (lifecycle Scenario 10) is the default opener:
     every gate is open before implementation starts. Emergent plan → rolling
     look-ahead: when dispatching [task] N, trigger N+1's `[design-note]` so

--- a/src/startup_factory_cli/cli.py
+++ b/src/startup_factory_cli/cli.py
@@ -51,7 +51,7 @@ def _mutation_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--overwrite-config",
         action="store_true",
-        help="replace the six project configuration files with bundled defaults",
+        help="replace the seven project configuration files with bundled defaults",
     )
 
 

--- a/src/startup_factory_cli/installer.py
+++ b/src/startup_factory_cli/installer.py
@@ -46,6 +46,7 @@ MAX_FILES = 20_000
 
 PRESERVED_CONFIG_FILES = (
     "config/project-management.config.md",
+    "config/planning.config.md",
     "config/team.config.md",
     "config/statuses.config.json",
     "config/automation.config.json",
@@ -269,7 +270,7 @@ def parse_manifest(data: bytes) -> BundleManifest:
     if len(set(normalized_extensions)) != len(normalized_extensions):
         raise InstallerError("extensionRoots contains duplicates")
     if set(normalized_preserved) != set(PRESERVED_CONFIG_FILES):
-        raise InstallerError("bundle preservation policy does not name the six supported config files")
+        raise InstallerError("bundle preservation policy does not name the seven supported config files")
     if set(normalized_extensions) != set(EXTENSION_ROOTS):
         raise InstallerError("bundle preservation policy has unsupported extension roots")
 

--- a/teams/_PLAYBOOK.md
+++ b/teams/_PLAYBOOK.md
@@ -38,7 +38,10 @@ is context, not a trigger.
 
 1. **Intake.** The TPM turns the ask into a [feature] draft: problem statement,
    scope, explicit NOT-in-scope, dependencies, and per-[task] **acceptance
-   criteria** — testable, implementation-free statements.
+   criteria** — testable, implementation-free statements. When a validated
+   Claude/Superpowers planning handoff exists, the TPM and architects read its
+   exact specification and plan as intake evidence. The handoff does not approve
+   scope or authorize execution.
 2. **Planning.** The architect breaks the [feature] into [tasks] (complete
    vertical slices) with the TPM. The TPM must approve scope and acceptance
    criteria **before anything is created in the tracker** — the architect cannot
@@ -46,7 +49,8 @@ is context, not a trigger.
    sign-off is a `[product-approval]` comment (or `[product-pushback]` with the
    required changes) once the [tasks] exist to carry it. Before creation, the
    sceptical-architect independently challenges the plan and both architects
-   must approve it.
+   must approve it. Startup Factory launches and owns the team after this point;
+   no Superpowers execution/worktree/subagent workflow runs alongside it.
 3. **Design gate — every [task].** The implementer posts a `[design-note]` that
    registers its exports in the contract registry
    (`reference/orchestration.md` → *Contract registry*); the principal architect

--- a/tests/launcher-test.sh
+++ b/tests/launcher-test.sh
@@ -50,7 +50,7 @@ git checkout -q -b test-feature
 mkdir -p .claude/skills/pm
 cp -R "$SKILL_DIR/roles" "$SKILL_DIR/reference" "$SKILL_DIR/bin" "$SKILL_DIR/teams" .claude/skills/pm/
 mkdir -p .claude/skills/pm/config
-cp "$SKILL_DIR/config/statuses.config.json" .claude/skills/pm/config/
+cp "$SKILL_DIR/config/statuses.config.json" "$SKILL_DIR/config/planning.config.md" .claude/skills/pm/config/
 cat > .claude/skills/pm/config/team.config.md <<'EOF'
 ```
 TEAM_LEAD_CMD="true"
@@ -144,6 +144,12 @@ check "prompt contains protocol"    grep -q "Orchestration — The Multi-Agent P
 check "prompt contains safety policy" grep -q "Autonomous safety guardrails" .teamwork/test-feature/prompts/backend.md
 check "prompt contains featureId"   grep -q "FEAT-1" .teamwork/test-feature/prompts/backend.md
 check "prompt contains team config" grep -q "POLL_INTERVAL_SECONDS" .teamwork/test-feature/prompts/backend.md
+check "non-Claude command is classified as other" grep -q "LLM runtime family: other" .teamwork/test-feature/prompts/backend.md
+if grep -q "Claude + obra/superpowers planning" .teamwork/test-feature/prompts/backend.md; then
+  echo "FAIL: non-Claude command received Superpowers planning instructions"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-Claude command excludes Superpowers planning instructions"
+fi
 check "pid file written"            test -f .teamwork/test-feature/pids/backend.pid
 check "workspace process marker contains no PID" grep -qx managed .teamwork/test-feature/pids/backend.pid
 for i in $(seq 1 20); do
@@ -153,6 +159,127 @@ done
 check "enforced gate launch uses protected runner argv" grep -Fq "$PWD|/usr/bin/env|-i" "$SANDBOX_RUNNER_LOG"
 check "stub agent ran with prompt"  grep -q "Role: backend" backend-received.txt
 check "mailbox dir created"         test -d .teamwork/test-feature/mailbox/backend
+
+# -- Superpowers prompt wiring is Claude-only --------------------------------
+cat > claude <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > codex <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > gemini <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > custom-wrapper <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x claude codex gemini custom-wrapper
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="./claude {prompt_file}"|' "$CFG_SANDBOX"
+unmarked_harness_prompt="$("$LAUNCH" compose native-harness FEAT-NATIVE-HARNESS frontend)"
+check "unmarked harness defaults to non-Claude" grep -q "LLM runtime family: other" "$unmarked_harness_prompt"
+if grep -q "Claude + obra/superpowers planning" "$unmarked_harness_prompt"; then
+  echo "FAIL: unmarked harness inferred Claude from the unused command map"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: unmarked harness excludes Superpowers despite a Claude CLI command"
+fi
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="./codex {prompt_file}"|' "$CFG_SANDBOX"
+TEAM_RUNNER=background "$LAUNCH" start codex-planning FEAT-CODEX frontend
+codex_prompt=.teamwork/codex-planning/prompts/frontend.md
+check "Codex CLI command is classified as non-Claude" grep -q "LLM runtime family: other" "$codex_prompt"
+if grep -q "Claude + obra/superpowers planning" "$codex_prompt"; then
+  echo "FAIL: Codex CLI command received Superpowers planning instructions"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: Codex CLI command excludes Superpowers planning instructions"
+fi
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="./gemini {prompt_file}"|' "$CFG_SANDBOX"
+TEAM_RUNNER=background "$LAUNCH" start gemini-planning FEAT-GEMINI frontend
+gemini_prompt=.teamwork/gemini-planning/prompts/frontend.md
+check "Gemini CLI command is classified as non-Claude" grep -q "LLM runtime family: other" "$gemini_prompt"
+if grep -q "Claude + obra/superpowers planning" "$gemini_prompt"; then
+  echo "FAIL: Gemini CLI command received Superpowers planning instructions"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: Gemini CLI command excludes Superpowers planning instructions"
+fi
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="./custom-wrapper {prompt_file}"|' "$CFG_SANDBOX"
+TEAM_RUNNER=background "$LAUNCH" start unmarked-wrapper FEAT-UNMARKED frontend
+unmarked_wrapper_prompt=.teamwork/unmarked-wrapper/prompts/frontend.md
+check "unmarked wrapper is classified as non-Claude" grep -q "LLM runtime family: other" "$unmarked_wrapper_prompt"
+if grep -q "Claude + obra/superpowers planning" "$unmarked_wrapper_prompt"; then
+  echo "FAIL: unmarked wrapper received Superpowers planning instructions"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: unmarked wrapper excludes Superpowers planning instructions"
+fi
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="./claude {prompt_file}"|' "$CFG_SANDBOX"
+TEAM_RUNNER=background "$LAUNCH" start claude-planning FEAT-CLAUDE frontend
+claude_prompt=.teamwork/claude-planning/prompts/frontend.md
+check "direct Claude command is classified as Claude" grep -q "LLM runtime family: claude" "$claude_prompt"
+check "direct Claude command receives Superpowers planning boundary" \
+  grep -q "Claude + obra/superpowers planning" "$claude_prompt"
+
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD="STARTUP_FACTORY_LLM_RUNTIME=claude ./custom-wrapper {prompt_file}"|' "$CFG_SANDBOX"
+TEAM_RUNNER=background "$LAUNCH" start wrapper-planning FEAT-WRAPPER frontend
+wrapper_prompt=.teamwork/wrapper-planning/prompts/frontend.md
+check "explicit Claude wrapper marker is classified as Claude" grep -q "LLM runtime family: claude" "$wrapper_prompt"
+check "explicit Claude wrapper receives Superpowers planning boundary" \
+  grep -q "Claude + obra/superpowers planning" "$wrapper_prompt"
+sed_i 's|^FRONTEND_CMD=.*|FRONTEND_CMD=null|' "$CFG_SANDBOX"
+
+harness_prompt="$(STARTUP_FACTORY_LLM_RUNTIME=claude "$LAUNCH" compose harness-planning FEAT-HARNESS reviewer)"
+check "Claude harness override is classified as Claude" grep -q "LLM runtime family: claude" "$harness_prompt"
+check "Claude harness override receives Superpowers planning boundary" \
+  grep -q "Claude + obra/superpowers planning" "$harness_prompt"
+if STARTUP_FACTORY_LLM_RUNTIME=gemini "$LAUNCH" compose invalid-runtime FEAT-INVALID reviewer >/dev/null 2>&1; then
+  echo "FAIL: invalid harness runtime override accepted"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: invalid harness runtime override refused"
+fi
+
+# -- global planning opt-out removes all Superpowers prompt wiring -------------
+PLANNING_CFG=.claude/skills/pm/config/planning.config.md
+sed_i 's/^USE_SUPERPOWERS=true$/USE_SUPERPOWERS=false/' "$PLANNING_CFG"
+native_prompt="$(STARTUP_FACTORY_LLM_RUNTIME=claude "$LAUNCH" compose native-planning FEAT-NATIVE backend)"
+if grep -q "Claude + obra/superpowers planning\\|Claude Superpowers task method" "$native_prompt"; then
+  echo "FAIL: USE_SUPERPOWERS=false left Superpowers prompt wiring"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: USE_SUPERPOWERS=false removes Superpowers prompt wiring"
+fi
+if "$LAUNCH" planning-handoff native-planning docs/superpowers/specs/missing.md docs/superpowers/plans/missing.md >/dev/null 2>&1; then
+  echo "FAIL: disabled planning accepted a handoff"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: disabled planning refuses a handoff"
+fi
+sed_i 's/^USE_SUPERPOWERS=false$/USE_SUPERPOWERS=true/' "$PLANNING_CFG"
+
+# -- committed planning inputs become a digest-bound team handoff --------------
+mkdir -p docs/superpowers/specs docs/superpowers/plans
+printf '# Approved design\n' > docs/superpowers/specs/launcher.md
+printf '# Approved implementation plan\n' > docs/superpowers/plans/launcher.md
+git add docs/superpowers/specs/launcher.md docs/superpowers/plans/launcher.md
+git commit -qm 'planning inputs'
+handoff="$("$LAUNCH" planning-handoff planning-team docs/superpowers/specs/launcher.md docs/superpowers/plans/launcher.md)"
+check "planning-handoff creates a manifest" test -f "$handoff"
+check "planning-handoff assigns execution to Startup Factory" \
+  python3 -c 'import json,sys; assert json.load(open(sys.argv[1]))["executionOwner"] == "startup-factory"' "$handoff"
+planning_prompt="$("$LAUNCH" compose planning-team FEAT-PLAN team-lead)"
+check "team prompt carries validated planning handoff" grep -q "Planning handoff:" "$planning_prompt"
+check "team prompt carries exact approved specification" grep -q "docs/superpowers/specs/launcher.md" "$planning_prompt"
+if grep -q "Claude + obra/superpowers planning" "$planning_prompt"; then
+  echo "FAIL: non-Claude handoff consumer received Superpowers instructions"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-Claude handoff consumer keeps model-neutral planning inputs"
+fi
+claude_planning_prompt="$(STARTUP_FACTORY_LLM_RUNTIME=claude "$LAUNCH" compose planning-team FEAT-PLAN team-lead)"
+check "Claude handoff consumer receives Superpowers planning boundary" \
+  grep -q "Claude + obra/superpowers planning" "$claude_planning_prompt"
 
 # -- agent child environment strips tracker/cloud/host credentials ------------
 cat > env-probe.sh <<'EOF'

--- a/tests/packaging/test_bundle_builder.py
+++ b/tests/packaging/test_bundle_builder.py
@@ -27,6 +27,7 @@ MODULE_SPEC.loader.exec_module(builder)
 
 PRESERVED_CONFIGS = [
     "config/project-management.config.md",
+    "config/planning.config.md",
     "config/team.config.md",
     "config/statuses.config.json",
     "config/automation.config.json",

--- a/tests/packaging/test_cli_installer.py
+++ b/tests/packaging/test_cli_installer.py
@@ -22,6 +22,7 @@ from startup_factory_cli import cli, installer  # noqa: E402
 
 CONFIG_PATHS = (
     "config/project-management.config.md",
+    "config/planning.config.md",
     "config/team.config.md",
     "config/statuses.config.json",
     "config/automation.config.json",
@@ -196,6 +197,7 @@ class CliInstallerTest(unittest.TestCase):
         self.assertRegex(provenance["archiveSha256"], r"^[0-9a-f]{64}$")
         owned = set((target / ".startup-factory-owned-files").read_text().splitlines())
         self.assertIn("config/automation.config.json", owned)
+        self.assertIn("config/planning.config.md", owned)
 
         (target / "config/automation.config.json").write_text("project-owned\n")
         code, output, error = run_cli(
@@ -210,6 +212,7 @@ class CliInstallerTest(unittest.TestCase):
         verified = json.loads(output)
         self.assertEqual(verified["action"], "verify")
         self.assertIn("config/automation.config.json", verified["preservedConfigs"])
+        self.assertIn("config/planning.config.md", verified["preservedConfigs"])
 
         (target / "bin/runtime.sh").write_text("tampered\n")
         code, _, error = run_cli(

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 echo "==> product-acceptance-test.py"
 python3 "$ROOT/tests/product-acceptance-test.py"
+echo "==> superpowers-planning-test.py"
+python3 "$ROOT/tests/superpowers-planning-test.py"
 echo "==> review-evidence-test.py"
 python3 "$ROOT/tests/review-evidence-test.py"
 echo "==> release-lifecycle-test.py"

--- a/tests/superpowers-planning-test.py
+++ b/tests/superpowers-planning-test.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Focused tests for the optional Claude/Superpowers planning boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "bin" / "superpowers-planning.py"
+
+
+def run(*arguments: str, expected: int = 0) -> subprocess.CompletedProcess[str]:
+    process = subprocess.run(
+        [os.fspath(SCRIPT), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert process.returncode == expected, (
+        process.returncode,
+        process.stdout,
+        process.stderr,
+    )
+    return process
+
+
+def git(repo: Path, *arguments: str) -> str:
+    process = subprocess.run(
+        ["git", "-C", os.fspath(repo), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert process.returncode == 0, process.stderr
+    return process.stdout.strip()
+
+
+def write_config(path: Path, enabled: bool) -> None:
+    path.write_text(
+        "```\n"
+        f"USE_SUPERPOWERS={'true' if enabled else 'false'}\n"
+        "SUPERPOWERS_PLUGIN_ID=superpowers@claude-plugins-official\n"
+        "SUPERPOWERS_SPEC_ROOT=docs/superpowers/specs\n"
+        "SUPERPOWERS_PLAN_ROOT=docs/superpowers/plans\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        temp = Path(temporary)
+        enabled = temp / "enabled.md"
+        disabled = temp / "disabled.md"
+        write_config(enabled, True)
+        write_config(disabled, False)
+
+        shipped = json.loads(
+            run(
+                "--config",
+                os.fspath(ROOT / "config" / "planning.config.md"),
+                "show-config",
+            ).stdout
+        )
+        assert shipped["enabled"] is True
+
+        missing_config = json.loads(
+            run(
+                "--config",
+                os.fspath(temp / "missing.md"),
+                "show-config",
+            ).stdout
+        )
+        assert missing_config["enabled"] is True
+
+        shown = json.loads(run("--config", os.fspath(enabled), "show-config").stdout)
+        assert shown["enabled"] is True
+        assert shown["pluginId"] == "superpowers@claude-plugins-official"
+
+        disabled_result = json.loads(
+            run(
+                "--config",
+                os.fspath(disabled),
+                "preflight",
+                "--runtime",
+                "claude",
+            ).stdout
+        )
+        assert disabled_result["status"] == "disabled"
+
+        other_result = json.loads(
+            run(
+                "--config",
+                os.fspath(enabled),
+                "preflight",
+                "--runtime",
+                "other",
+            ).stdout
+        )
+        assert other_result["status"] == "not-applicable"
+
+        plugins = temp / "plugins.json"
+        plugins.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "superpowers@claude-plugins-official",
+                        "enabled": True,
+                        "version": "6.1.1",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        ready = json.loads(
+            run(
+                "--config",
+                os.fspath(enabled),
+                "preflight",
+                "--runtime",
+                "claude",
+                "--plugin-list-json",
+                os.fspath(plugins),
+            ).stdout
+        )
+        assert ready["status"] == "ready"
+        assert ready["version"] == "6.1.1"
+
+        plugins.write_text("[]\n", encoding="utf-8")
+        missing = run(
+            "--config",
+            os.fspath(enabled),
+            "preflight",
+            "--runtime",
+            "claude",
+            "--plugin-list-json",
+            os.fspath(plugins),
+            expected=1,
+        )
+        assert "required Claude plugin is not installed" in missing.stderr
+
+        repo = temp / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        spec = repo / "docs" / "superpowers" / "specs" / "feature-design.md"
+        plan = repo / "docs" / "superpowers" / "plans" / "feature.md"
+        spec.parent.mkdir(parents=True)
+        plan.parent.mkdir(parents=True)
+        spec.write_text("# Approved design\n", encoding="utf-8")
+        plan.write_text("# Implementation plan\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "-qm", "planning inputs")
+
+        handoff = (
+            repo / ".teamwork" / "feature" / "planning" / "superpowers-handoff.json"
+        )
+        created = json.loads(
+            run(
+                "--config",
+                os.fspath(enabled),
+                "create-handoff",
+                "--repo",
+                os.fspath(repo),
+                "--team",
+                "feature",
+                "--spec",
+                spec.relative_to(repo).as_posix(),
+                "--plan",
+                plan.relative_to(repo).as_posix(),
+                "--output",
+                os.fspath(handoff),
+            ).stdout
+        )
+        assert Path(created["handoff"]) == handoff.resolve()
+        manifest = json.loads(handoff.read_text(encoding="utf-8"))
+        assert manifest["executionOwner"] == "startup-factory"
+        assert (
+            "superpowers:subagent-driven-development"
+            in manifest["blockedExecutionSkills"]
+        )
+
+        validated = json.loads(
+            run(
+                "--config",
+                os.fspath(enabled),
+                "validate-handoff",
+                "--repo",
+                os.fspath(repo),
+                "--handoff",
+                os.fspath(handoff),
+                "--team",
+                "feature",
+                "--require-head",
+            ).stdout
+        )
+        assert validated["valid"] is True
+
+        (repo / "README.md").write_text("# Descendant commit\n", encoding="utf-8")
+        git(repo, "add", "README.md")
+        git(repo, "commit", "-qm", "continue after planning")
+        descendant = json.loads(
+            run(
+                "--config",
+                os.fspath(enabled),
+                "validate-handoff",
+                "--repo",
+                os.fspath(repo),
+                "--handoff",
+                os.fspath(handoff),
+            ).stdout
+        )
+        assert descendant["valid"] is True
+        stale_head = run(
+            "--config",
+            os.fspath(enabled),
+            "validate-handoff",
+            "--repo",
+            os.fspath(repo),
+            "--handoff",
+            os.fspath(handoff),
+            "--require-head",
+            expected=1,
+        )
+        assert "not the current HEAD" in stale_head.stderr
+
+        spec.write_text("# Changed design\n", encoding="utf-8")
+        stale = run(
+            "--config",
+            os.fspath(enabled),
+            "validate-handoff",
+            "--repo",
+            os.fspath(repo),
+            "--handoff",
+            os.fspath(handoff),
+            expected=1,
+        )
+        assert "digest does not match" in stale.stderr
+
+        disabled_create = run(
+            "--config",
+            os.fspath(disabled),
+            "create-handoff",
+            "--repo",
+            os.fspath(repo),
+            "--team",
+            "feature",
+            "--spec",
+            spec.relative_to(repo).as_posix(),
+            "--plan",
+            plan.relative_to(repo).as_posix(),
+            "--output",
+            os.fspath(handoff),
+            expected=1,
+        )
+        assert "disabled" in disabled_create.stderr
+
+    print("ALL PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/task-runtime-test.sh
+++ b/tests/task-runtime-test.sh
@@ -38,13 +38,15 @@ python3 "$SKILL_DIR/bin/process-lifecycle.py" init --root "$PROTECTED_FORGERY_RO
 export STARTUP_FACTORY_LIFECYCLE_STATE_ROOT="$LIFECYCLE_ROOT"
 mkdir -p .agent-squad/{bin,config,roles,reference} feat
 cp "$SKILL_DIR"/bin/*.sh "$SKILL_DIR"/bin/*.py .agent-squad/bin/
-cp "$SKILL_DIR/config/statuses.config.json" "$SKILL_DIR/config/automation.config.json" .agent-squad/config/
+cp "$SKILL_DIR/config/statuses.config.json" "$SKILL_DIR/config/automation.config.json" \
+  "$SKILL_DIR/config/planning.config.md" .agent-squad/config/
 cp "$SKILL_DIR/roles/backend.md" "$SKILL_DIR/roles/reviewer.md" \
   "$SKILL_DIR/roles/sceptical-architect.md" "$SKILL_DIR/roles/team-lead.md" \
   "$SKILL_DIR/roles/senior-security-engineer.md" .agent-squad/roles/
 cp "$SKILL_DIR/teams/roles/principal-software-architect.md" \
   "$SKILL_DIR/teams/roles/senior-technical-product-manager.md" .agent-squad/roles/
-cp "$SKILL_DIR/reference/guardrails.md" "$SKILL_DIR/reference/orchestration.md" .agent-squad/reference/
+cp "$SKILL_DIR/reference/guardrails.md" "$SKILL_DIR/reference/orchestration.md" \
+  "$SKILL_DIR/reference/superpowers-planning.md" .agent-squad/reference/
 cat > .agent-squad/config/project-management.config.md <<'EOF'
 ```
 PRODUCT_MANAGEMENT_TOOL=Markdown
@@ -183,6 +185,25 @@ check "task branch is generation/team namespaced" test "$(git -C "$wt" branch --
 prompt="$($LAUNCH compose-task feature-runtime "$FID" backend "$TID" 1)"
 check "lean task prompt exists" test -f "$prompt"
 check "lean prompt points to task packet" grep -q 'Task packet:' "$prompt"
+check "non-Claude task command is classified as other" grep -q 'LLM runtime family: other' "$prompt"
+if grep -q 'Claude Superpowers task method' "$prompt"; then
+  echo "FAIL: non-Claude task prompt received Superpowers worker methods"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-Claude task prompt excludes Superpowers worker methods"
+fi
+claude_prompt="$(STARTUP_FACTORY_LLM_RUNTIME=claude "$LAUNCH" compose-task feature-runtime "$FID" backend "$TID" 1)"
+check "Claude task harness receives Superpowers worker methods" \
+  grep -q 'Claude Superpowers task method' "$claude_prompt"
+PLANNING_CFG=.agent-squad/config/planning.config.md
+sed_i 's/^USE_SUPERPOWERS=true$/USE_SUPERPOWERS=false/' "$PLANNING_CFG"
+disabled_claude_prompt="$(STARTUP_FACTORY_LLM_RUNTIME=claude "$LAUNCH" compose-task feature-runtime "$FID" backend "$TID" 1)"
+if grep -q 'Claude Superpowers task method' "$disabled_claude_prompt"; then
+  echo "FAIL: disabled planning left Claude task worker methods enabled"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: disabled planning removes Claude task worker methods"
+fi
+sed_i 's/^USE_SUPERPOWERS=false$/USE_SUPERPOWERS=true/' "$PLANNING_CFG"
+"$LAUNCH" compose-task feature-runtime "$FID" backend "$TID" 1 >/dev/null
 if grep -q 'The Multi-Agent Protocol' "$prompt"; then
   echo "FAIL: lean prompt inlined full protocol"; FAILURES=$((FAILURES+1))
 else
@@ -202,9 +223,30 @@ printf '[handoff]\nThis arrives after packet creation.\n' | "$OPS" comment "$TID
 "$LAUNCH" compose-task feature-runtime "$FID" backend "$TID" 1 >/dev/null
 check "same attempt reuses immutable packet" test "$(cksum "$packet_md")" = "$packet_checksum"
 
+cat > "$TMP/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cp "$1" claude-task-prompt.txt
+EOF
+chmod +x "$TMP/claude"
+sed_i "s|^TASK_FAST_CMD=.*|TASK_FAST_CMD=\"$TMP/claude {prompt_file}\"|" "$CFG"
+TEAM_RUNNER=background "$LAUNCH" start-task feature-runtime "$FID" backend "$TID" 1
+for _i in $(seq 1 30); do [ -f "$wt/claude-task-prompt.txt" ] && break; sleep 0.1; done
+check "direct Claude task command is classified as Claude" \
+  grep -q 'LLM runtime family: claude' "$wt/claude-task-prompt.txt"
+check "direct Claude task command receives Superpowers worker methods" \
+  grep -q 'Claude Superpowers task method' "$wt/claude-task-prompt.txt"
+rm -f "$wt/claude-task-prompt.txt"
+sed_i 's|^TASK_FAST_CMD=.*|TASK_FAST_CMD="cat {prompt_file} > task-fast-prompt.txt"|' "$CFG"
+
 TEAM_RUNNER=background "$LAUNCH" start-task feature-runtime "$FID" backend "$TID" 1
 for _i in $(seq 1 30); do [ -f "$wt/task-fast-prompt.txt" ] && break; sleep 0.1; done
 check "task-specific model command ran" test -f "$wt/task-fast-prompt.txt"
+if grep -q 'Claude Superpowers task method' "$wt/task-fast-prompt.txt"; then
+  echo "FAIL: non-Claude launched task received Superpowers worker methods"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: non-Claude launched task excludes Superpowers worker methods"
+fi
 check "task pid uses task instance directory" test -d .teamwork/feature-runtime/pids/tasks
 
 "$OPS" claim "$TID" backend >/dev/null

--- a/tests/update-installed-skill-test.sh
+++ b/tests/update-installed-skill-test.sh
@@ -46,6 +46,7 @@ for required_file in \
   adapters/_TEMPLATE.md \
   bin/dispatch.sh \
   bin/launch-team.sh \
+  bin/superpowers-planning.py \
   bin/pm-agent.py \
   bin/policy-check.py \
   bin/release-feature.py \
@@ -55,6 +56,7 @@ for required_file in \
   reference/automation.md \
   reference/deployment.md \
   reference/guardrails.md \
+  reference/superpowers-planning.md \
   roles/senior-security-engineer.md \
   roles/team-lead.md \
   teams/_PLAYBOOK.md
@@ -67,6 +69,7 @@ done
 
 CONFIG_FILES=(
   project-management.config.md
+  planning.config.md
   team.config.md
   statuses.config.json
   automation.config.json
@@ -112,7 +115,7 @@ printf 'custom-backend\n' > "$INSTALL/extensions/tracker-backends/Acme.py"
 printf 'custom-team\n' > "$INSTALL/teams/acme.md"
 printf 'custom-role\n' > "$INSTALL/teams/roles/acme-specialist.md"
 printf 'custom-command\n' > "$INSTALL/teams/commands/acme-command.md"
-for name in project-management.config.md team.config.md statuses.config.json deployment.config.json guardrails.config.json; do
+for name in project-management.config.md planning.config.md team.config.md statuses.config.json deployment.config.json guardrails.config.json; do
   printf 'project-owned:%s\n' "$name" > "$INSTALL/config/$name"
 done
 
@@ -131,7 +134,7 @@ check "custom team survives synchronization" grep -qx 'custom-team' "$INSTALL/te
 check "custom team role survives synchronization" grep -qx 'custom-role' "$INSTALL/teams/roles/acme-specialist.md"
 check "custom team command survives synchronization" grep -qx 'custom-command' "$INSTALL/teams/commands/acme-command.md"
 
-for name in project-management.config.md team.config.md statuses.config.json deployment.config.json guardrails.config.json; do
+for name in project-management.config.md planning.config.md team.config.md statuses.config.json deployment.config.json guardrails.config.json; do
   check "existing $name is preserved" \
     grep -qx "project-owned:$name" "$INSTALL/config/$name"
 done


### PR DESCRIPTION
## What changed

- add optional `obra/superpowers` intake for Claude brainstorming and plan writing
- keep Startup Factory as the execution owner for task shaping, worktrees, dispatch, review, integration, and production release
- add a global `USE_SUPERPOWERS` configuration switch, defaulting to `true`
- gate all Superpowers prompt wiring to Claude runtimes only
- support direct Claude CLI detection, explicitly marked Claude wrappers, and explicit Claude harness composition
- bind approved specifications and plans through digest-checked planning handoffs
- preserve the new planning configuration across installs and upgrades

## Why

Claude users should be able to use Superpowers to improve specification and planning quality without introducing a second execution orchestrator. Mixed-model teams must remain deterministic: Codex, Gemini, and other runtimes continue using the native Startup Factory workflow.

## Impact

- Claude receives Superpowers planning and focused task-worker methods by default.
- Non-Claude runtimes never receive Superpowers-specific instructions.
- `USE_SUPERPOWERS=false` provides a complete project-wide opt-out.
- Existing approved planning inputs remain readable by every team role.

## Validation

- `bash tests/run-all.sh`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /opt/homebrew/bin/python3.12 -m pytest tests/packaging -q`
- focused launcher, task-runtime, and Superpowers planning tests
- skill validation
- shell syntax and `git diff --check`
