### PR TITLE
Enable team mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,10 @@ the default.
    > The `uvx` path requires the first `v0.1.0` package release. Before that tag
    > is published, use the [auditable shell compatibility path](#shell-compatibility-path).
 
+   This quick start demonstrates the one-agent workflow. Set `TEAM_MODE=false`
+   in the installed `config/project-management.config.md` before continuing;
+   fresh installations otherwise use the team workflow by default.
+
 2. **Ask your agent, in plain language:**
 
    ```
@@ -884,10 +888,11 @@ instead copied to operator-protected storage outside agent mounts.
 |---|---|---|
 | `PRODUCT_MANAGEMENT_TOOL` | Active tracker (matches an `adapters/<Name>.md`) | `Markdown` |
 | per-tool block | Access mode + defaults for the active tracker (see above) | — |
-| `TEAM_MODE` | `true` enables the multi-agent status-ownership model | `false` |
+| `TEAM_MODE` | `true` enables the multi-agent status-ownership model; set `false` for the single-agent workflow | `true` |
 | `STRICT_STATUS` | `true` = refuse an action if a `[task]` isn't in the expected status (the "andon cord") | `true` |
 
-> Set **`TEAM_MODE=true`** before running a team.
+> Team mode is enabled in new installations. Set **`TEAM_MODE=false`** to opt
+> into the single-agent workflow.
 
 ### `config/planning.config.md` — optional Claude planning intake
 
@@ -1088,7 +1093,8 @@ every agent mount, for authenticated PID/start-time/tmux lifecycle authority.
 
 ### One agent
 
-Just talk to your agent in the generic vocabulary:
+Set `TEAM_MODE=false` in `config/project-management.config.md`, then talk to
+your agent in the generic vocabulary:
 
 - *"Plan a feature: …"* → creates a `[feature]` + `[tasks]`
 - *"Start task ENG-142"* → generic `[Active]` / shipped `In Progress`, then implements
@@ -1100,9 +1106,9 @@ Just talk to your agent in the generic vocabulary:
 
 ### A whole team
 
-1. Set the bundle path for your installation, then set `TEAM_MODE=true`,
-   configure role commands, `WORKTREE_SETUP`, and at least one real `VALIDATE_*`
-   command in `$SF_HOME/config/team.config.md`:
+1. Set the bundle path for your installation, confirm the shipped
+   `TEAM_MODE=true` setting, configure role commands, `WORKTREE_SETUP`, and at
+   least one real `VALIDATE_*` command in `$SF_HOME/config/team.config.md`:
 
    ```bash
    SF_HOME=.agents/skills/startup-factory        # Codex / shared Agent Skills
@@ -1352,8 +1358,9 @@ team-lead signature—does not create that receipt and grants no authority.
    non-empty, non-no-op `WORKTREE_SETUP` and at
    least one meaningful `VALIDATE_SCRIPT`, `VALIDATE_BUILD`, `VALIDATE_TEST`,
    `VALIDATE_LINT`, or `VALIDATE_FORMAT` command in `config/team.config.md`.
-2. Set `TEAM_MODE=true`, `TRACKER_WRITERS=broker`, and a scriptable, explicit tracker
-   scope. Linear requires `LINEAR_ACCESS=rest` plus `LINEAR_DEFAULT_TEAM`; Jira requires
+2. Keep the shipped `TEAM_MODE=true` default, set `TRACKER_WRITERS=broker`, and
+   configure a scriptable, explicit tracker scope. Linear requires
+   `LINEAR_ACCESS=rest` plus `LINEAR_DEFAULT_TEAM`; Jira requires
    `JIRA_ACCESS=rest` plus an exact `JIRA_PROJECT_KEY` and `JIRA_TASK_ISSUE_TYPE`;
    GitHub requires an explicit `GITHUB_REPO`.
    Review `reference/guardrails.md`; ordinary agents must have no cloud/database

--- a/SKILL.md
+++ b/SKILL.md
@@ -140,7 +140,7 @@ each generic operation through the adapter's *Operations* table:
 | File a bug / follow-up found mid-work | 6 — File newly-discovered work |
 | Work is stuck / blocked / cannot proceed | 7 — Block a `[task]` |
 | (anything wrong / blocked / failed) | 8 — Andon cord: stop & report |
-| Run an agent team on a feature ("launch the team") | Team: set `TEAM_MODE=true`; gate roles use `start`/`compose`, task workers use `start-task`/`compose-task`, and `dispatch.sh` owns claims and bounded scheduling |
+| Run an agent team on a feature ("launch the team") | Team: keep the shipped `TEAM_MODE=true` default; gate roles use `start`/`compose`, task workers use `start-task`/`compose-task`, and `dispatch.sh` owns claims and bounded scheduling |
 | Connect a new tool / switch tools | 9 — Connect / switch |
 | Design/plan everything up front, sign off all designs before coding | 10 — Pre-flight design pass |
 | Monitor queued and Blocked work; launch eligible queued tasks automatically | 11 — Portfolio automation; install the skill outside the target checkout, provision an external mode-0700 lifecycle root outside every agent mount, set its absolute project/config environment, `scanIntervalMinutes` (default 3), and `ignoredTaskLabels` (default `human-work`), then run `bin/pm-agent.py --once` with protected Python `-I -S -E -s` |

--- a/config/project-management.config.md
+++ b/config/project-management.config.md
@@ -60,7 +60,7 @@ MARKDOWN_ROOT=.workspace/task-manager   # Where feature/task files live (repo-re
 Apply regardless of tool.
 
 ```
-TEAM_MODE=false        # true enables the status-ownership model in reference/team-roles.md
+TEAM_MODE=true         # false opts out to the single-agent workflow
 STRICT_STATUS=true     # true = before any write, verify the current status and that the
                        #        intended move is in that status's transitions list
                        #        (the "andon cord" — see reference/lifecycle.md)

--- a/reference/automation.md
+++ b/reference/automation.md
@@ -39,8 +39,8 @@ or delivery decision needs judgment.
 Automation is fail-closed by default. Install the reviewed skill outside the
 target checkout and every agent mount; the supervisor, Python interpreter,
 automation/team/project-management configs, runner, and broker scripts must be
-owned by the scheduler identity or root and not group/world writable. Set
-`TEAM_MODE=true`, configure the scriptable adapter, copy
+owned by the scheduler identity or root and not group/world writable. Keep the
+shipped `TEAM_MODE=true` setting, configure the scriptable adapter, copy
 `config/automation.config.json` to that protected installation, set `enabled`,
 and verify a dry run from the target checkout:
 

--- a/reference/lifecycle.md
+++ b/reference/lifecycle.md
@@ -2,9 +2,10 @@
 
 How work is created, tracked, and closed out. Every scenario is written in the generic
 vocabulary (`reference/vocabulary.md`); the active adapter (`adapters/<Tool>.md`) supplies
-the concrete verb for each operation. These playbooks are **single-agent by default** —
-one agent drives the whole flow. If `TEAM_MODE=true`, transition *ownership* splits across
-roles per `reference/team-roles.md`, but the scenarios themselves are identical.
+the concrete verb for each operation. The shipped skill enables **team mode by default**:
+transition *ownership* splits across roles per `reference/team-roles.md`, while the
+scenarios themselves remain identical. Set `TEAM_MODE=false` explicitly when one agent
+should drive the whole flow.
 
 Throughout: **an "operation"** (create feature, set status, add comment…) means "do the
 thing described in the active adapter's *Operations* section." Never invent an operation

--- a/teams/README.md
+++ b/teams/README.md
@@ -23,8 +23,8 @@ optional evidence/finding roles.
 
 ## Use a team
 
-1. Configure your tracker (`config/project-management.config.md`, set
-   `TEAM_MODE=true`) and the team layer (`config/team.config.md`): set
+1. Configure your tracker (`config/project-management.config.md`; the shipped
+   default is `TEAM_MODE=true`) and the team layer (`config/team.config.md`): set
    `TEAM_DEFAULT_CMD` — roles with no `<ROLE>_CMD` key of their own fall back to
    it, so you don't need a key per role. Add `<ROLE>_CMD` (e.g.
    `SENIOR_STAFF_ENGINEER_CMD`) only to pin a specific CLI to a specific role; set

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:  # pragma: no cover - metadata tests run on 3.11+
 
 ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = ROOT / "pyproject.toml"
+PROJECT_MANAGEMENT_CONFIG = ROOT / "config" / "project-management.config.md"
 RESOURCE_ARCHIVE = "startup_factory_cli/resources/startup-factory.tar.gz"
 RESOURCE_CHECKSUM = f"{RESOURCE_ARCHIVE}.sha256"
 
@@ -144,6 +145,13 @@ class ProjectMetadataTests(unittest.TestCase):
             setuptools["package-data"]["startup_factory_cli"],
             ["resources/*.tar.gz", "resources/*.sha256"],
         )
+
+
+class BundledDefaultsTests(unittest.TestCase):
+    def test_team_mode_is_enabled_by_default(self) -> None:
+        config = PROJECT_MANAGEMENT_CONFIG.read_text(encoding="utf-8")
+        self.assertRegex(config, r"(?m)^TEAM_MODE=true(?:\s|$)")
+        self.assertNotRegex(config, r"(?m)^TEAM_MODE=false(?:\s|$)")
 
 
 class SdistCanonicalizationTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- make `TEAM_MODE=true` the default for fresh skill installations
- document `TEAM_MODE=false` as the explicit single-agent opt-out
- align lifecycle, automation, and team onboarding guidance
- add a regression test for the bundled default

## Why

The team workflow should be enabled at the skill level without requiring every
new installation to flip the setting manually.

## Validation

- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v`
- 23 tests passed; one built-distribution-only test class skipped as expected
- `git diff --check`
