### PR TITLE
Fix v0.1.1 release runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,13 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$source_date_epoch" >> "$GITHUB_ENV"
 
       - name: Run the full runtime suite
-        run: bash tests/run-all.sh
+        shell: bash
+        run: |
+          set -euo pipefail
+          runtime_tmp="$RUNNER_TEMP/startup-factory-runtime"
+          install -d -m 700 "$runtime_tmp"
+          /usr/bin/python3 -c 'import sys; assert sys.version_info >= (3, 10)'
+          PATH="/usr/bin:/bin" TMPDIR="$runtime_tmp" /bin/bash tests/run-all.sh
 
       - name: Run packaging unit tests
         run: python -m unittest discover -s tests/packaging -p "test_*.py" -v

--- a/README.md
+++ b/README.md
@@ -515,12 +515,12 @@ the default.
    ```
 
    For Claude Code use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.0`. `uvx` creates an isolated
+   environments, for example `startup-factory@0.1.1`. `uvx` creates an isolated
    environment for the installer and leaves no Startup Factory package in your
    project environment.
 
-   > The `uvx` path requires the first `v0.1.0` package release. Before that tag
-   > is published, use the [auditable shell compatibility path](#shell-compatibility-path).
+   > The `uvx` path downloads the published PyPI package. For a Git checkout or
+   > offline use, use the [auditable shell compatibility path](#shell-compatibility-path).
 
    This quick start demonstrates the one-agent workflow. Set `TEAM_MODE=false`
    in the installed `config/project-management.config.md` before continuing;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.0"
+version = "0.1.1"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:  # pragma: no cover - metadata tests run on 3.11+
 ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = ROOT / "pyproject.toml"
 PROJECT_MANAGEMENT_CONFIG = ROOT / "config" / "project-management.config.md"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 RESOURCE_ARCHIVE = "startup_factory_cli/resources/startup-factory.tar.gz"
 RESOURCE_CHECKSUM = f"{RESOURCE_ARCHIVE}.sha256"
 
@@ -122,7 +123,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.0")
+        self.assertEqual(project["version"], "0.1.1")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -154,17 +155,29 @@ class BundledDefaultsTests(unittest.TestCase):
         self.assertNotRegex(config, r"(?m)^TEAM_MODE=false(?:\s|$)")
 
 
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_runtime_suite_uses_a_private_temporary_directory(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('runtime_tmp="$RUNNER_TEMP/startup-factory-runtime"', workflow)
+        self.assertIn('install -d -m 700 "$runtime_tmp"', workflow)
+        self.assertIn(
+            'PATH="/usr/bin:/bin" TMPDIR="$runtime_tmp" /bin/bash tests/run-all.sh',
+            workflow,
+        )
+        self.assertNotIn("        run: bash tests/run-all.sh", workflow)
+
+
 class SdistCanonicalizationTests(unittest.TestCase):
     def _write_sdist(self, path: Path, *, mtime: int, uid: int) -> None:
         with tarfile.open(path, "w:gz") as archive:
-            directory = tarfile.TarInfo("startup_factory-0.1.0")
+            directory = tarfile.TarInfo("startup_factory-0.1.1")
             directory.type = tarfile.DIRTYPE
             directory.mode = 0o755
             directory.mtime = mtime
             directory.uid = uid
             archive.addfile(directory)
             payload = b"metadata fixture\n"
-            member = tarfile.TarInfo("startup_factory-0.1.0/PKG-INFO")
+            member = tarfile.TarInfo("startup_factory-0.1.1/PKG-INFO")
             member.mode = 0o644
             member.mtime = mtime
             member.uid = uid
@@ -223,7 +236,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.0")
+        self.assertEqual(metadata["Version"], "0.1.1")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## Summary

- run the release runtime suite with a private, mode-700 `$RUNNER_TEMP` directory
- bump the public package version and README pin to `0.1.1`
- add a regression test for the release workflow invariant

## Why

The protected `v0.1.0` release failed before publication because `tests/task-runtime-test.sh` rejected the runner's default `/tmp` path as group/world-writable. This mirrors the secure temporary-directory setup already used by Package CI. The failed `v0.1.0` tag remains unchanged as an audit record.

## Verification

- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v`
- full `tests/run-all.sh` suite with a secure, disjoint `TMPDIR` (`ALL TESTS PASS`)
- `git diff --check`
