### PR TITLE
Fix GitHub release repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,7 @@ jobs:
       - name: Reconcile a draft release, verify bytes, then publish
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           SOURCE_COMMIT: ${{ needs.build.outputs.source_commit }}
           VERSION: ${{ needs.build.outputs.version }}
         shell: bash

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -166,6 +166,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("        run: bash tests/run-all.sh", workflow)
 
+    def test_github_release_commands_have_explicit_repository_context(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("          GH_REPO: ${{ github.repository }}", workflow)
+
 
 class SdistCanonicalizationTests(unittest.TestCase):
     def _write_sdist(self, path: Path, *, mtime: int, uid: int) -> None:


### PR DESCRIPTION
## Summary

- give the GitHub Release job explicit `GH_REPO` context
- add a regression assertion for repository context

## Why

The `v0.1.1` workflow successfully published to PyPI, then its GitHub Release job failed because it ran without a checkout and `gh release` could not infer a repository. Explicit `GH_REPO` lets every `gh release` command use the remote repository without relying on local Git state.

## Verification

- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v`
- from `/private/tmp` (no Git checkout): `GH_REPO=alexrolls/startup-factory gh release view v0.1.1 --json isDraft,tagName,url`
- `git diff --check`
