### PR TITLE
Fix draft release tag verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,29 @@ jobs:
             gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq .sha
           }
 
+          verify_release_target() {
+            local tag_commit release_target
+            if tag_commit="$(resolve_tag_commit 2>/dev/null)"; then
+              test "$tag_commit" = "$SOURCE_COMMIT" || {
+                echo "$RELEASE_TAG points to a different commit" >&2
+                exit 1
+              }
+              return
+            fi
+            # GitHub does not materialize a new tag until its draft release is
+            # published. Verify the immutable draft target instead of requiring
+            # that not-yet-created tag to resolve prematurely.
+            release_target="$(
+              gh release view "$RELEASE_TAG" \
+                --json targetCommitish \
+                --jq .targetCommitish
+            )"
+            test "$release_target" = "$SOURCE_COMMIT" || {
+              echo "$RELEASE_TAG draft targets a different commit" >&2
+              exit 1
+            }
+          }
+
           tag_exists=false
           if tag_commit="$(resolve_tag_commit 2>/dev/null)"; then
             tag_exists=true
@@ -367,7 +390,7 @@ jobs:
             gh release create "${create_args[@]}"
           fi
 
-          test "$(resolve_tag_commit)" = "$SOURCE_COMMIT"
+          verify_release_target
 
           expected="$RUNNER_TEMP/expected-assets"
           existing="$RUNNER_TEMP/existing-assets"
@@ -392,5 +415,6 @@ jobs:
             cmp "release-assets/$name" "$downloaded/$name"
           done < "$expected"
 
-          test "$(resolve_tag_commit)" = "$SOURCE_COMMIT"
+          verify_release_target
           gh release edit "$RELEASE_TAG" --draft=false
+          test "$(resolve_tag_commit)" = "$SOURCE_COMMIT"

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ the default.
    ```
 
    For Claude Code use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.3`. `uvx` creates an isolated
+   environments, for example `startup-factory@0.1.4`. `uvx` creates an isolated
    environment for the installer and leaves no Startup Factory package in your
    project environment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.3"
+version = "0.1.4"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -123,7 +123,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.3")
+        self.assertEqual(project["version"], "0.1.4")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -185,6 +185,24 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_github_release_commands_have_explicit_repository_context(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("          GH_REPO: ${{ github.repository }}", workflow)
+
+    def test_draft_release_target_is_verified_before_the_tag_exists(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        publish = workflow.split(
+            "      - name: Reconcile a draft release, verify bytes, then publish",
+            1,
+        )[1]
+        edit_index = publish.index(
+            '          gh release edit "$RELEASE_TAG" --draft=false'
+        )
+        before_publish = publish[:edit_index]
+        after_publish = publish[edit_index:]
+
+        self.assertIn("          verify_release_target() {", before_publish)
+        self.assertIn("                --json targetCommitish", before_publish)
+        self.assertEqual(before_publish.count("          verify_release_target\n"), 2)
+        self.assertNotIn('test "$(resolve_tag_commit)"', before_publish)
+        self.assertIn('test "$(resolve_tag_commit)"', after_publish)
 
 
 class SdistCanonicalizationTests(unittest.TestCase):
@@ -256,7 +274,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.3")
+        self.assertEqual(metadata["Version"], "0.1.4")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## Summary

- Verify a draft release's `targetCommitish` while its new tag does not yet exist.
- Preserve exact commit verification before asset reconciliation and again after publication creates the tag.
- Add a regression test that forbids premature tag resolution.
- Bump the release version to `0.1.4`.

## Root cause

The `0.1.3` workflow created a draft release with `--target` and immediately resolved `v0.1.3` through the commits API. GitHub materializes a new tag only when the draft is published, so the valid draft failed with HTTP 422 before asset upload.

## Recovery completed

- Created annotated `v0.1.3` at exact source commit `2f0e924b9b39c1b200b6205e94cbdade5a15eb7d`.
- Re-ran failed jobs for release run `29813068909`.
- Rerun attempt #2 passed and published the original attested GitHub release assets.

## Validation

- `TEAM_RUNNER=background bash tests/run-all.sh` — all tests passed
- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v` — 28 passed, 1 skipped
- Release workflow YAML parsed successfully
- Embedded release shell passed `bash -n`
- `git diff --check`
