### PR TITLE
security: redact credentials from outbound tracker writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ the default.
    ```
 
    For Claude Code use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.4`. `uvx` creates an isolated
+   environments, for example `startup-factory@0.1.5`. `uvx` creates an isolated
    environment for the installer and leaves no Startup Factory package in your
    project environment.
 

--- a/bin/pm-agent.py
+++ b/bin/pm-agent.py
@@ -46,6 +46,7 @@ RELEASE_SNAPSHOT_FILES = {
     "outbox_capability.py": Path("bin/outbox_capability.py"),
     "broker_evidence.py": Path("bin/broker_evidence.py"),
     "runtime-state.py": Path("bin/runtime-state.py"),
+    "ticket_content_security.py": Path("bin/ticket_content_security.py"),
     "task_metadata.py": Path("bin/task_metadata.py"),
     "product_acceptance.py": Path("bin/product_acceptance.py"),
     "teamwork-path.py": Path("bin/teamwork-path.py"),

--- a/bin/release-feature.py
+++ b/bin/release-feature.py
@@ -764,6 +764,7 @@ def trusted_file_specs() -> dict[str, tuple[Path, Path]]:
         "outbox_capability.py": ((SKILL_DIR / "bin" / "outbox_capability.py").resolve(), Path("bin/outbox_capability.py")),
         "broker_evidence.py": ((SKILL_DIR / "bin" / "broker_evidence.py").resolve(), Path("bin/broker_evidence.py")),
         "runtime-state.py": ((SKILL_DIR / "bin" / "runtime-state.py").resolve(), Path("bin/runtime-state.py")),
+        "ticket_content_security.py": ((SKILL_DIR / "bin" / "ticket_content_security.py").resolve(), Path("bin/ticket_content_security.py")),
         "task_metadata.py": ((SKILL_DIR / "bin" / "task_metadata.py").resolve(), Path("bin/task_metadata.py")),
         "product_acceptance.py": ((SKILL_DIR / "bin" / "product_acceptance.py").resolve(), Path("bin/product_acceptance.py")),
         "teamwork-path.py": ((SKILL_DIR / "bin" / "teamwork-path.py").resolve(), Path("bin/teamwork-path.py")),

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -57,6 +57,33 @@ def die(msg):
 SKILL_DIR = sys.argv[1]
 ARGS = sys.argv[2:]
 
+# Tracker writes are a data-loss-prevention boundary.  Reuse the same bounded,
+# standard-library scanner that protects inbound ticket packets so no backend or
+# project-owned adapter can receive a raw credential from agent-authored text.
+sys.path.insert(0, os.path.join(SKILL_DIR, 'bin'))
+try:
+    from ticket_content_security import TicketContentSecurityError, protect_ticket_content
+except (ImportError, OSError) as e:
+    die("cannot load ticket content security policy: %s — andon" % e)
+
+def protect_outbound_ticket_text(value, destination, structural=False):
+    """Return tracker-safe text, or refuse unsafe structural field values."""
+    try:
+        protected = protect_ticket_content(value, 'outbound.%s' % destination)
+    except TicketContentSecurityError as e:
+        die("outbound %s failed the ticket content security policy: %s — andon"
+            % (destination, e))
+    if structural and protected.flagged:
+        # Redacting an identifier or assignee would silently change routing and
+        # idempotency semantics.  Refuse it without echoing attacker content.
+        die("unsafe content detected in outbound %s; tracker mutation refused — andon"
+            % destination)
+    if protected.redaction_count:
+        print("tracker-ops: warning — redacted %d potential credential(s) from "
+              "outbound %s before tracker mutation"
+              % (protected.redaction_count, destination), file=sys.stderr)
+    return protected.safe_text
+
 # ---- config -----------------------------------------------------------------
 def read_config_keys(path):
     keys = {}
@@ -1993,7 +2020,8 @@ def op_task_reopen(args):
 def op_comment(args):
     if len(args) not in (1, 2):
         die("usage: comment <taskId> [bodyfile]  (no file / '-' = stdin)")
-    body = read_body(args[1] if len(args) == 2 else None)
+    body = protect_outbound_ticket_text(
+        read_body(args[1] if len(args) == 2 else None), 'comment-body')
     if body.count('\n') + 1 > 50:
         print("tracker-ops: warning — comment body exceeds the 50-line budget "
               "(protocol: move detail to <TEAMWORK_ROOT>/<team>/artifacts/ and cite the path)",
@@ -2007,10 +2035,13 @@ def op_comment_once(args):
     task_id, delivery_id = args[0], args[1]
     if not re.fullmatch(r'[A-Za-z0-9._:-]+', delivery_id):
         die("invalid delivery id '%s'" % delivery_id)
+    delivery_id = protect_outbound_ticket_text(
+        delivery_id, 'comment-delivery-id', structural=True)
     body = read_body(args[2])
     token = "delivery-id: %s" % delivery_id
     if token not in body:
         body += "\n\n" + token
+    body = protect_outbound_ticket_text(body, 'comment-body')
     if not backend.comment_exists(task_id, token):
         backend.comment(task_id, body)
     print("comment delivery %s recorded on %s" % (delivery_id, task_id))
@@ -2020,7 +2051,9 @@ def op_update_comment(args):
         die("usage: update-comment <taskId> <commentId> [bodyfile]  (no file / '-' = stdin)")
     if not hasattr(backend, 'update_comment'):
         die("adapter '%s' does not support update-comment" % ADAPTER)
-    backend.update_comment(args[0], args[1], read_body(args[2] if len(args) == 3 else None))
+    body = protect_outbound_ticket_text(
+        read_body(args[2] if len(args) == 3 else None), 'comment-body')
+    backend.update_comment(args[0], args[1], body)
     print("comment %s updated on %s" % (args[1], args[0]))
 
 def op_upsert_progress(args):
@@ -2029,6 +2062,7 @@ def op_upsert_progress(args):
     body = read_body(args[1] if len(args) == 2 else None)
     if not body.lstrip().startswith('[progress]'):
         die("upsert-progress body must begin with [progress]")
+    body = protect_outbound_ticket_text(body, 'progress-body')
     fresh_task_status(args[0])
     cid = backend.upsert_progress(args[0], body)
     print("progress updated on %s%s" % (args[0], " (id: %s)" % cid if cid else ""))
@@ -2039,6 +2073,7 @@ def op_upsert_digest(args):
     body = read_body(args[1] if len(args) == 2 else None)
     if not body.lstrip().startswith('[digest]'):
         die("upsert-digest body must begin with [digest]")
+    body = protect_outbound_ticket_text(body, 'digest-body')
     backend.upsert_digest(args[0], body)
     print("digest updated on %s" % args[0])
 
@@ -2048,6 +2083,7 @@ def op_upsert_deployment(args):
     body = read_body(args[1] if len(args) == 2 else None)
     if not body.lstrip().startswith('[deployment]'):
         die("upsert-deployment body must begin with [deployment]")
+    body = protect_outbound_ticket_text(body, 'deployment-body')
     backend.upsert_deployment(args[0], body)
     print("deployment updated on %s" % args[0])
 
@@ -2066,6 +2102,9 @@ def op_claim(args):
     if len(args) != 2:
         die("usage: claim <taskId> <role> [--to <Status>]")
     task_id, role = args
+    role = protect_outbound_ticket_text(role, 'assignee-role', structural=True).strip()
+    if not role or '\n' in role or len(role) > 128:
+        die("claim role must be a non-empty single-line value of at most 128 characters")
     init = initial_status()
     expected = expected or init['name']
     if expected != init['name']:
@@ -2085,6 +2124,8 @@ def op_claim(args):
     claim_id = claim_id or ('claim-' + hashlib.sha256(('%s\0%s\0%s' % (task_id, role, to)).encode()).hexdigest()[:24])
     if not re.fullmatch(r'[A-Za-z0-9._:-]{8,128}', claim_id):
         die("invalid claim id '%s'" % claim_id)
+    claim_id = protect_outbound_ticket_text(
+        claim_id, 'claim-id', structural=True)
     token = "claim-id: %s" % claim_id
     current = backend.current_status(task_id)
     if current is None:
@@ -2098,7 +2139,10 @@ def op_claim(args):
         die("claim conflict: expected [%s], observed [%s] for %s — no launch" % (expected, current, task_id))
     if not backend.comment_exists(task_id, token):
         fresh_task_status(task_id, expected)
-        backend.comment(task_id, "[claim]\n%s\nrole: %s\ntarget-status: %s\n\n— dispatcher" % (token, role, to))
+        body = protect_outbound_ticket_text(
+            "[claim]\n%s\nrole: %s\ntarget-status: %s\n\n— dispatcher"
+            % (token, role, to), 'comment-body')
+        backend.comment(task_id, body)
     if hasattr(backend, 'set_assignee'):
         fresh_task_status(task_id, expected)
         backend.set_assignee(task_id, role)
@@ -2127,17 +2171,24 @@ def op_record_denial(args):
     task_id = args[0]
     if not actor or not reason:
         die("record-denial requires --actor and --reason")
-    actor = sanitize_untrusted(actor.replace('\n', ' '), 128)
-    reason = sanitize_untrusted(reason.replace('\n', '; '), 500)
+    actor = protect_outbound_ticket_text(
+        sanitize_untrusted(actor.replace('\n', ' '), 128),
+        'denial-actor', structural=True)
+    reason = protect_outbound_ticket_text(
+        sanitize_untrusted(reason.replace('\n', '; '), 500), 'denial-reason')
     if not actor or not reason:
         die("record-denial actor/reason must not be empty after sanitization")
-    attempted = sanitize_untrusted(read_body(args[1] if len(args) == 2 else None), 1800)
+    attempted = protect_outbound_ticket_text(
+        sanitize_untrusted(read_body(args[1] if len(args) == 2 else None), 1800),
+        'denial-attempt')
     if not attempted:
         die("record-denial requires a non-empty attempted-action description")
     denial_id = denial_id or ('denial-' + hashlib.sha256(
         ('%s\0%s\0%s\0%s' % (task_id, actor, reason, attempted)).encode()).hexdigest()[:24])
     if not re.fullmatch(r'[A-Za-z0-9._:-]{8,128}', denial_id):
         die("invalid denial id '%s'" % denial_id)
+    denial_id = protect_outbound_ticket_text(
+        denial_id, 'denial-id', structural=True)
     token = "denial-id: %s" % denial_id
     if backend.comment_exists(task_id, token):
         print("%s denial %s already recorded" % (task_id, denial_id))
@@ -2147,6 +2198,7 @@ def op_record_denial(args):
             "Denial reason: %s\n\n"
             "This action was blocked by the fail-closed policy gate and was not executed.\n\n"
             "— policy gate" % (token, actor, attempted, reason))
+    body = protect_outbound_ticket_text(body, 'comment-body')
     backend.comment(task_id, body)
     print("%s denial recorded (denial-id: %s)" % (task_id, denial_id))
 
@@ -2156,12 +2208,14 @@ def op_integrate(args):
     task_id, commit = args[0], args[1]
     if not re.fullmatch(r'[0-9a-f]{7,40}', commit):
         die("'%s' does not look like a commit hash" % commit)
-    extra = read_body(args[2]) if len(args) == 3 else None
+    extra = (protect_outbound_ticket_text(read_body(args[2]), 'integration-comment-body')
+             if len(args) == 3 else None)
     term = terminal_status()
     body = "Integrated: commit %s." % commit
     if extra:
         body += "\n\n" + extra
     body += "\n\n— integrator"
+    body = protect_outbound_ticket_text(body, 'comment-body')
     current_name = backend.current_status(task_id)
     if current_name is None:
         die("cannot reverse-map the current status of %s — andon" % task_id)

--- a/bin/update-installed-skill.sh
+++ b/bin/update-installed-skill.sh
@@ -192,6 +192,7 @@ for required_file in \
   bin/policy-check.py \
   bin/release-feature.py \
   bin/runtime-state.py \
+  bin/ticket_content_security.py \
   bin/tracker-ops.sh \
   bin/update-installed-skill.sh \
   config/project-management.config.md \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.4"
+version = "0.1.5"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/reference/guardrails.md
+++ b/reference/guardrails.md
@@ -129,6 +129,18 @@ Pre-integration launch and workspace handling are also fail closed:
   driver's parameterized-query API; labeling or escaping a ticket payload is
   not a SQL-injection defense at the database boundary. Tool calls remain
   independently allowlisted and validated against task intent.
+- Every agent-authored tracker write supported by `bin/tracker-ops.sh` passes
+  through that same scanner immediately before the selected backend is called.
+  Potential API keys, passwords, tokens, private keys, and other recognized
+  credentials are replaced with `[REDACTED POTENTIAL SECRET]` in comments and
+  managed progress, digest, deployment, denial, and integration text. Unsafe
+  structural values such as assignee roles and idempotency identifiers fail
+  closed because silently rewriting them would alter routing or retry semantics.
+  Adapter implementations, including project-owned adapters, receive only the
+  protected value. The warning and error paths never echo the detected secret.
+  SQL, shell, file-deletion, and other dangerous examples remain inert ticket
+  data: posting them is not execution and does not bypass the independent tool
+  and release-policy gates described above.
 - `TEAMWORK_ROOT` must be repository-relative, cannot contain `..`, and every
   managed child path is resolved before a read, directory creation, or write.
   Absolute roots and every existing symlink component are rejected, including a

--- a/tests/deployment-test.sh
+++ b/tests/deployment-test.sh
@@ -189,6 +189,7 @@ trusted={name:digest(pathlib.Path(root)/rel) for name,rel in {
   "outbox_capability.py":"bin/outbox_capability.py",
   "broker_evidence.py":"bin/broker_evidence.py",
   "runtime-state.py":"bin/runtime-state.py",
+  "ticket_content_security.py":"bin/ticket_content_security.py",
   "task_metadata.py":"bin/task_metadata.py",
   "product_acceptance.py":"bin/product_acceptance.py",
   "statuses.config.json":"config/statuses.config.json",

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -123,7 +123,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.4")
+        self.assertEqual(project["version"], "0.1.5")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -274,7 +274,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.4")
+        self.assertEqual(metadata["Version"], "0.1.5")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])

--- a/tests/tracker-adapter-pagination-test.py
+++ b/tests/tracker-adapter-pagination-test.py
@@ -23,8 +23,11 @@ def load_definitions(adapter, extra_config=""):
     temp = tempfile.TemporaryDirectory()
     skill = Path(temp.name)
     (skill / "config").mkdir()
+    (skill / "bin").mkdir()
     shutil.copy(ROOT / "config" / "statuses.config.json",
                 skill / "config" / "statuses.config.json")
+    shutil.copy(ROOT / "bin" / "ticket_content_security.py",
+                skill / "bin" / "ticket_content_security.py")
     (skill / "config" / "project-management.config.md").write_text(
         "PRODUCT_MANAGEMENT_TOOL=%s\nSTATUS_CONFIG=config/statuses.config.json\n%s"
         % (adapter, extra_config))

--- a/tests/tracker-ops-test.sh
+++ b/tests/tracker-ops-test.sh
@@ -26,6 +26,7 @@ refuse() { # refuse <desc> <needle> <cmd...>
 CUSTOM_SKILL="$TMP/custom-skill"
 mkdir -p "$CUSTOM_SKILL/bin" "$CUSTOM_SKILL/config" "$CUSTOM_SKILL/extensions/tracker-backends"
 cp "$SKILL_DIR/bin/tracker-ops.sh" "$CUSTOM_SKILL/bin/"
+cp "$SKILL_DIR/bin/ticket_content_security.py" "$CUSTOM_SKILL/bin/"
 cp "$SKILL_DIR/config/statuses.config.json" "$CUSTOM_SKILL/config/"
 cat > "$CUSTOM_SKILL/config/project-management.config.md" <<'EOF'
 ```
@@ -89,6 +90,13 @@ check "custom backend receives the task primitive" \
   grep -qx 'task=ACME-1' "$TMP/custom-backend.out"
 check "custom backend receives the core-validated body" \
   grep -qx 'body=custom body' "$TMP/custom-backend.out"
+OUTBOUND_SECRET='sk-proj-abcdefghijklmnopqrstuvwxyz012345'
+printf 'api_key=%s\n' "$OUTBOUND_SECRET" | CUSTOM_BACKEND_OUT="$TMP/custom-backend.out" \
+  "$CUSTOM_OPS" comment ACME-1 - >/dev/null
+check "custom backend never receives a raw credential" \
+  bash -c "! grep -Fq '$OUTBOUND_SECRET' '$TMP/custom-backend.out'"
+check "custom backend receives the redacted comment" \
+  grep -Fq '[REDACTED POTENTIAL SECRET]' "$TMP/custom-backend.out"
 
 ln -s Acme.py "$CUSTOM_SKILL/extensions/tracker-backends/AcmeLink.py"
 cat > "$CUSTOM_SKILL/config/project-management.config.md" <<'EOF'
@@ -123,6 +131,7 @@ check "refused custom operations never reach mutation primitives" \
 cd "$TMP"
 mkdir -p skill/config skill/bin
 cp "$SKILL_DIR/bin/tracker-ops.sh" skill/bin/
+cp "$SKILL_DIR/bin/ticket_content_security.py" skill/bin/
 cp "$SKILL_DIR/config/statuses.config.json" skill/config/
 cat > skill/config/project-management.config.md <<'EOF'
 ```
@@ -158,11 +167,17 @@ EOF
 T="feat/feature.md"
 
 # -- generated PM surfaces: one task progress block + one feature digest -------
+printf '[progress]\ncredential: %s\n' "$OUTBOUND_SECRET" | "$OPS" upsert-progress "$T#2" - >/dev/null
+check "progress projection never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "progress projection stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 printf '[progress]\nstage: planned\nsummary: queued\n' | "$OPS" upsert-progress "$T#2" -
 printf '[progress]\nstage: ready\nsummary: design approved\n' | "$OPS" upsert-progress "$T#2" -
 check "progress upsert keeps one managed block" test "$(grep -c 'agent-squad:progress:start' "$T")" -eq 1
 check "progress upsert replaces old content" grep -q '^> stage: ready$' "$T"
 if grep -q '^> stage: planned$' "$T"; then echo "FAIL: stale progress retained"; FAILURES=$((FAILURES+1)); else echo "ok: stale progress removed"; fi
+printf '[digest]\ncredential: %s\n' "$OUTBOUND_SECRET" | "$OPS" upsert-digest "$T" - >/dev/null
+check "digest projection never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "digest projection stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 printf '[digest]\nT#1 - planned\n' | "$OPS" upsert-digest "$T" -
 printf '[digest]\nT#1 - active\n' | "$OPS" upsert-digest "$T" -
 check "digest upsert keeps one managed block" test "$(grep -c 'agent-squad:digest:start' "$T")" -eq 1
@@ -182,6 +197,9 @@ check "sibling task untouched"   grep -q '^## 2 Wire endpoint \[Planned\]$' "$T"
 printf '[design-note] Approach: "quote" & $dollar.\nSecond line.\n' | "$OPS" comment "$T#1" -
 check "comment marker extracted"  grep -q '> \[design-note\] (....-..-..): Approach: "quote" & $dollar\.' "$T"
 check "comment multiline quoted"  grep -q '^> Second line\.$' "$T"
+printf '[security-test] api_key=%s\n' "$OUTBOUND_SECRET" | "$OPS" comment "$T#1" - >/dev/null
+check "comment never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "comment stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 
 # -- comment: body from a file ---------------------------------------------------
 printf 'From a file.\n' > body.txt
@@ -219,6 +237,8 @@ printf '[review-request]\nFiles: a.py\n' > delivery.txt
 "$OPS" comment-once "$T#1" delivery-123 delivery.txt
 "$OPS" comment-once "$T#1" delivery-123 delivery.txt
 check "comment-once retry keeps one delivery" test "$(grep -c 'delivery-id: delivery-123' "$T")" -eq 1
+refuse "secret-bearing delivery identifier is refused" "unsafe content detected in outbound comment-delivery-id" \
+  "$OPS" comment-once "$T#1" "$OUTBOUND_SECRET" delivery.txt
 
 # -- record-denial: guardrail DENY becomes idempotent ticket-level evidence -----
 printf 'deploy.apply argv: terraform destroy -auto-approve (production)\n' > denied.txt
@@ -232,6 +252,10 @@ check "denial carries an id"               grep -q '^> denial-id: denial-' "$T"
 check "denial retry is idempotent" bash -c \
   "'$OPS' record-denial '$T#1' --actor deep-infra/devops --reason 'infrastructure destroy is forbidden' denied.txt \
    && [ \"\$(grep -c 'denial-id: ' '$T')\" -eq 1 ]"
+printf 'attempted request included password=%s\n' "$OUTBOUND_SECRET" | "$OPS" record-denial "$T#1" \
+  --actor policy-gate --reason "credential exposure is forbidden" --denial-id denial-secret-0001 - >/dev/null
+check "denial evidence never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "denial evidence stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 printf 'curl 169.254.169.254 \x01\x02with control bytes\n' | "$OPS" record-denial "$T#1" \
   --actor full-stack/backend --reason "metadata credential access is forbidden" --denial-id denial-ctrl-0001 -
 check "denial strips control bytes" bash -c "grep -q 'curl 169.254.169.254 *with control bytes' '$T' && ! grep -q \$'\x01' '$T'"
@@ -299,11 +323,25 @@ refuse "integration broker cannot release Blocked" "outbound \[Blocked\].*human-
 check "all refused outbound transitions preserve Blocked" \
   test "$(grep -c '\[Blocked\]$' held.md)" -eq 4
 
+cat > secure-fields.md <<'EOF'
+# Secure structural fields [Planned]
+
+## 1 Reject credential routing [Planned]
+
+**Assignee:** —
+EOF
+refuse "secret-bearing assignee role is refused before mutation" "unsafe content detected in outbound assignee-role" \
+  "$OPS" claim secure-fields.md#1 "$OUTBOUND_SECRET"
+check "refused assignee role leaves task and assignee unchanged" bash -c \
+  "grep -q '^## 1 Reject credential routing \[Planned\]$' secure-fields.md && grep -q '^\\*\\*Assignee:\\*\\* —$' secure-fields.md"
+
 # -- integrate: terminal move + hash citation + extra body -----------------------
-printf 'VALIDATE_TEST green. Merged: a.py\n' | "$OPS" integrate "$T#1" abc1234 -
+printf 'VALIDATE_TEST green. Merged: a.py\napi_key=%s\n' "$OUTBOUND_SECRET" | "$OPS" integrate "$T#1" abc1234 -
 check "integrate terminal status" grep -q '^## 1 Add form \[Ready to deploy\]$' "$T"
 check "integrate cites the hash"  grep -q 'Integrated: commit abc1234\.' "$T"
 check "integrate appends body"    grep -q 'VALIDATE_TEST green\. Merged: a\.py' "$T"
+check "integration comment never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "integration comment stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 check "integrate signed"          grep -q -- '— integrator' "$T"
 printf 'VALIDATE_TEST green. Merged: a.py\n' | "$OPS" integrate "$T#1" abc1234 -
 check "integrate retry is idempotent" test "$(grep -c 'Integrated: commit abc1234\.' "$T")" -eq 1
@@ -367,6 +405,9 @@ assert d['orphans'] == []
 "
 
 # -- feature projection and state use their own configured state machine --------
+printf '[deployment]\ncredential: %s\n' "$OUTBOUND_SECRET" | "$OPS" upsert-deployment "$T" - >/dev/null
+check "deployment projection never stores a raw credential" bash -c "! grep -Fq '$OUTBOUND_SECRET' '$T'"
+check "deployment projection stores a redaction marker" grep -Fq '[REDACTED POTENTIAL SECRET]' "$T"
 printf '[deployment]\nstate: verifying\n' | "$OPS" upsert-deployment "$T" -
 printf '[deployment]\nstate: succeeded\n' | "$OPS" upsert-deployment "$T" -
 check "deployment upsert keeps one managed block" test "$(grep -c 'agent-squad:deployment:start' "$T")" -eq 1

--- a/tests/update-installed-skill-test.sh
+++ b/tests/update-installed-skill-test.sh
@@ -51,6 +51,7 @@ for required_file in \
   bin/policy-check.py \
   bin/release-feature.py \
   bin/runtime-state.py \
+  bin/ticket_content_security.py \
   bin/tracker-ops.sh \
   extensions/tracker-backends/README.md \
   reference/automation.md \


### PR DESCRIPTION
## Summary

- reuse the existing dependency-free `ticket_content_security.py` scanner immediately before tracker backend mutations
- redact detected API keys, passwords, tokens, private keys, and other credentials from comments and managed progress/digest/deployment/denial/integration text
- fail closed on unsafe structural values such as assignee roles and idempotency identifiers, where redaction would alter routing or retry semantics
- include the scanner in protected supervisor/release snapshots and installer completeness checks
- bump the package to 0.1.5 (confirmed available on PyPI)

SQL, shell, drop-table, and file-deletion examples remain inert ticket data. This boundary neither executes nor reinterprets them; independent tool and release-policy gates continue to block destructive actions.

## Validation

- `TEAM_RUNNER=background bash tests/run-all.sh` — ALL TESTS PASS
- backend coverage proves raw credentials never reach the built-in Markdown adapter or a project-owned custom adapter
- coverage includes comments, progress, digest, deployment, denial, integration, assignee roles, and delivery identifiers
- protected production release snapshot and packaging tests pass