### PR TITLE
Release version 0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ the default.
    ```
 
    For Claude Code use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.6`. `uvx` creates an isolated
+   environments, for example `startup-factory@0.1.7`. `uvx` creates an isolated
    environment for the installer and leaves no Startup Factory package in your
    project environment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.6"
+version = "0.1.7"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -123,7 +123,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.6")
+        self.assertEqual(project["version"], "0.1.7")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -274,7 +274,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.6")
+        self.assertEqual(metadata["Version"], "0.1.7")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## What changed

- Bump the package version from `0.1.6` to `0.1.7`.
- Update the controlled-install example and packaging metadata assertions.

## Why

PR #30 merged the project retrospective learning loop. PyPI versions are immutable, so the merged feature needs a new package version before the protected release workflow can publish it.

## Impact

Merging this PR triggers the protected release workflow for `0.1.7`: full runtime validation, reproducible builds, package identity tests, provenance attestations, PyPI Trusted Publishing, and the matching immutable GitHub release.

## Validation

- `TEAM_RUNNER=background bash tests/run-all.sh --full` — `ALL TESTS PASS`
- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v` — 29 passed, 1 expected skip
- `git diff --check`
