### PR TITLE
Release Startup Factory 0.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.8`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.9`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.8"
+version = "0.1.9"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -123,7 +123,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.8")
+        self.assertEqual(project["version"], "0.1.9")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -274,7 +274,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.8")
+        self.assertEqual(metadata["Version"], "0.1.9")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## Release

Bump Startup Factory from 0.1.8 to 0.1.9 so the protected main-branch workflow can publish the merged README prompt cookbook as a new immutable release.

## Changed

- package version: 0.1.9
- pinned README example: 0.1.9
- packaging identity assertions: 0.1.9

## Validation

- `bash tests/run-all.sh --smoke`
- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v` — 41 passed, 1 expected artifact-only skip
- `git diff --check`