### PR TITLE
fix: update Codex CLI automation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,8 +927,8 @@ opt-out.
 ```
 TEAM_LEAD_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
 PRINCIPAL_ARCHITECT_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
-SCEPTICAL_ARCHITECT_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
-BACKEND_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
+SCEPTICAL_ARCHITECT_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
+BACKEND_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
 REVIEWER_CMD="gemini --yolo \"$(cat '{prompt_file}')\""
 TEAM_DEFAULT_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
 ```
@@ -938,7 +938,7 @@ Command templates for common CLIs:
 | LLM / CLI | Command template |
 |---|---|
 | Claude Code | `claude -p "$(cat '{prompt_file}')" --permission-mode acceptEdits` |
-| Codex CLI | `codex exec --full-auto "$(cat '{prompt_file}')"` |
+| Codex CLI | `codex exec --approve-for-me "$(cat '{prompt_file}')"` |
 | Gemini CLI | `gemini --yolo "$(cat '{prompt_file}')"` |
 | Any file-reading CLI | `yourcli --prompt-file {prompt_file}` |
 
@@ -1007,8 +1007,9 @@ Omit the variable for Codex, Gemini, and other runtimes.
 why the many specialized preset-team roles need no per-role keys — set
 `TEAM_DEFAULT_CMD` once and only override the roles you want on a different model.
 
-> ⚠️ **Safety:** those templates use auto-approve flags (`acceptEdits`,
-> `--full-auto`, `--yolo`) so agents can work unattended. Workers may commit
+> ⚠️ **Safety:** those templates use unattended execution modes (`acceptEdits`,
+> `--approve-for-me`, `--yolo`). Codex keeps its workspace-write sandbox and
+> routes approval requests through automatic review. Workers may commit
 > untrusted checkpoints only to task branches; only the integrator writes the
 > feature branch. Every implementer is isolated in its own git worktree — but still run teams on a branch you can
 > throw away, and review the tracker before merging to your main branch.

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -25,11 +25,11 @@ exceptions: they require and roster Security for every task.
 ```
 TEAM_LEAD_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
 PRINCIPAL_ARCHITECT_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
-SCEPTICAL_ARCHITECT_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
-SENIOR_SECURITY_ENGINEER_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
+SCEPTICAL_ARCHITECT_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
+SENIOR_SECURITY_ENGINEER_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
 INTEGRATOR_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"
-BACKEND_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
-FRONTEND_CMD="codex exec --full-auto \"$(cat '{prompt_file}')\""
+BACKEND_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
+FRONTEND_CMD="codex exec --approve-for-me \"$(cat '{prompt_file}')\""
 QA_CMD=null
 REVIEWER_CMD="gemini --yolo \"$(cat '{prompt_file}')\""
 TEAM_DEFAULT_CMD="claude -p \"$(cat '{prompt_file}')\" --permission-mode acceptEdits"

--- a/docs/superpowers/plans/2026-07-06-agent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-06-agent-orchestration.md
@@ -56,8 +56,8 @@ roster per [feature] — e.g. no frontend [tasks] → no frontend agent).
 TEAM_LEAD_CMD="claude -p \"$(cat {prompt_file})\" --permission-mode acceptEdits"
 PRINCIPAL_ARCHITECT_CMD="claude -p \"$(cat {prompt_file})\" --permission-mode acceptEdits"
 INTEGRATOR_CMD="claude -p \"$(cat {prompt_file})\" --permission-mode acceptEdits"
-BACKEND_CMD="codex exec --full-auto \"$(cat {prompt_file})\""
-FRONTEND_CMD="codex exec --full-auto \"$(cat {prompt_file})\""
+BACKEND_CMD="codex exec --approve-for-me \"$(cat {prompt_file})\""
+FRONTEND_CMD="codex exec --approve-for-me \"$(cat {prompt_file})\""
 QA_CMD=null
 REVIEWER_CMD="gemini --yolo \"$(cat {prompt_file})\""
 ```

--- a/docs/superpowers/specs/2026-07-06-agent-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-06-agent-orchestration-design.md
@@ -206,7 +206,7 @@ interactive user prompt; it uses the escalation channel instead.
 
   ```
   TEAM_LEAD_CMD="claude -p --dangerously-skip-permissions {prompt_file}"
-  BACKEND_CMD="codex exec --full-auto {prompt_file}"
+  BACKEND_CMD="codex exec --approve-for-me {prompt_file}"
   REVIEWER_CMD="gemini --yolo {prompt_file}"
   ```
 

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -25,6 +25,8 @@ except ModuleNotFoundError:  # pragma: no cover - metadata tests run on 3.11+
 ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = ROOT / "pyproject.toml"
 PROJECT_MANAGEMENT_CONFIG = ROOT / "config" / "project-management.config.md"
+TEAM_CONFIG = ROOT / "config" / "team.config.md"
+README = ROOT / "README.md"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 RESOURCE_ARCHIVE = "startup_factory_cli/resources/startup-factory.tar.gz"
 RESOURCE_CHECKSUM = f"{RESOURCE_ARCHIVE}.sha256"
@@ -119,6 +121,31 @@ class ProjectMetadataTests(unittest.TestCase):
         build_system = self.config["build-system"]
         self.assertEqual(build_system["build-backend"], "setuptools.build_meta")
         self.assertEqual(build_system["requires"], ["setuptools==83.0.0"])
+
+    def test_codex_command_templates_use_automatic_review(self) -> None:
+        team_config = TEAM_CONFIG.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
+        codex_commands = [
+            line
+            for line in team_config.splitlines()
+            if line.startswith(
+                (
+                    "SCEPTICAL_ARCHITECT_CMD=",
+                    "SENIOR_SECURITY_ENGINEER_CMD=",
+                    "BACKEND_CMD=",
+                    "FRONTEND_CMD=",
+                )
+            )
+            and "codex exec" in line
+        ]
+
+        self.assertEqual(len(codex_commands), 4)
+        self.assertTrue(
+            all("--approve-for-me" in command for command in codex_commands)
+        )
+        self.assertNotIn("--full-auto", team_config)
+        self.assertIn("codex exec --approve-for-me", readme)
+        self.assertNotIn("codex exec --full-auto", readme)
 
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]


### PR DESCRIPTION
## Summary
- replace obsolete `--full-auto` Codex role templates with `--approve-for-me`
- update README and planning examples to describe the workspace-write automatic-review behavior
- add a packaging regression test covering every shipped Codex role mapping

## Why
Current Codex CLI releases no longer accept `--full-auto`. `--approve-for-me` is the supported unattended option and routes approval requests through automatic review while retaining the workspace-write sandbox.

Official CLI documentation: https://learn.chatgpt.com/docs/codex/cli

## Validation
- `python3 -m unittest discover -s tests/packaging -p "test_*.py" -v` (42 passed, 1 skipped)
- `bash tests/run-all.sh --smoke` (all passed)
- `TEAM_RUNNER=background bash tests/launcher-test.sh` (all passed)
- full offline suite components passed; one asynchronous launcher log assertion flaked during the aggregate run and passed on immediate standalone rerun
- `git diff --check`