### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.9`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.10`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.9"
+version = "0.1.10"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -150,7 +150,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.9")
+        self.assertEqual(project["version"], "0.1.10")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -301,7 +301,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.9")
+        self.assertEqual(metadata["Version"], "0.1.10")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## Summary
- bump the Python package version from `0.1.9` to `0.1.10`
- update the pinned-install example in the README
- synchronize source and built-distribution version assertions

This release includes the Codex CLI automation compatibility fix merged in #36.

## Validation
- `python3 -m unittest discover -s tests/packaging -p "test_*.py" -v` (42 passed, 1 skipped)
- `git diff --check`