### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.10`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.11`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.10"
+version = "0.1.11"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -150,7 +150,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.10")
+        self.assertEqual(project["version"], "0.1.11")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -301,7 +301,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.10")
+        self.assertEqual(metadata["Version"], "0.1.11")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
Release 0.1.11 — first release carrying DeepSeek Harness (dsh) runtime support (#38): documented `dsh --profile headless` command template, `--agent deepseek-harness` installer mapping, runtime-classification test coverage, and README setup/model-routing guidance.

Version bumped in the three synced locations (pyproject.toml, README pin example, packaging metadata tests). On merge, the Release workflow validates main, builds reproducible artifacts, publishes to PyPI via trusted publishing (updates `uvx startup-factory`), and publishes the immutable GitHub release v0.1.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)