### PR TITLE
Bump version to 0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ licensed**
 Start with one agent and the local Markdown tracker. You do not need a tracker
 account, API key, application server, or coordinator database.
 
-1. **Install Startup Factory from your project root.** Codex and Aider use the
-   shared Agent Skills project directory:
+1. **Install Startup Factory from your project root.** Codex, Aider, and
+   DeepSeek Harness use the shared Agent Skills project directory:
 
    ```bash
    uvx startup-factory@latest install --agent codex
@@ -68,7 +68,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.11`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.12`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 
@@ -677,6 +677,9 @@ uvx startup-factory@latest install --agent codex
 
 # Claude Code
 uvx startup-factory@latest install --agent claude-code
+
+# DeepSeek Harness
+uvx startup-factory@latest install --agent deepseek-harness
 
 # Alternative isolated runner
 pipx run startup-factory install --agent codex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.11"
+version = "0.1.12"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -150,7 +150,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.11")
+        self.assertEqual(project["version"], "0.1.12")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -301,7 +301,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.11")
+        self.assertEqual(metadata["Version"], "0.1.12")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
Release 0.1.12 — README install-example completeness for DeepSeek Harness: the quickstart now names DeepSeek Harness among the shared Agent Skills directory users, and the install-variants block gains a `uvx startup-factory@latest install --agent deepseek-harness` example. Version bumped in the three synced locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)