### PR TITLE
Automate verified uvx releases

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -48,9 +48,40 @@ jobs:
         id: package
         shell: bash
         run: |
+          set -euo pipefail
           version="$(python -c 'import pathlib,tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
           test -n "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Require an unreleased version before merge
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          VERSION: ${{ steps.package.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_version="$(
+            git show "origin/$BASE_REF:pyproject.toml" |
+              python -c 'import sys,tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])'
+          )"
+          python - "$base_version" "$VERSION" <<'PY'
+          import re
+          import sys
+
+          base, proposed = sys.argv[1:]
+          stable = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+          if stable.fullmatch(base) is None or stable.fullmatch(proposed) is None:
+              raise SystemExit("release versions must use stable numeric SemVer")
+          if tuple(map(int, proposed.split("."))) <= tuple(map(int, base.split("."))):
+              raise SystemExit(
+                  f"project.version must increase before merge: {base} -> {proposed}"
+              )
+          PY
+          if git rev-parse -q --verify "refs/tags/v$VERSION^{commit}" >/dev/null; then
+            echo "v$VERSION is already published; bump project.version before merging" >&2
+            exit 1
+          fi
 
       - name: Build the source bundle twice
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.sha }}
+  group: release-main
   cancel-in-progress: false
 
 jobs:
@@ -306,11 +306,59 @@ jobs:
         with:
           attestations: true
 
+  verify-uvx:
+    name: Verify the public uvx installation
+    needs:
+      - build
+      - publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Install the pinned uv client
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.6"
+          enable-cache: "false"
+
+      - name: Resolve the published release through uvx
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          exact_output=""
+          latest_output=""
+          for attempt in $(seq 1 18); do
+            if exact_output="$(uvx --refresh "startup-factory@$VERSION" version --json 2>&1)" &&
+              latest_output="$(uvx --refresh "startup-factory@latest" version --json 2>&1)"; then
+              python - "$VERSION" "$exact_output" "$latest_output" <<'PY'
+          import json
+          import sys
+
+          expected, *responses = sys.argv[1:]
+          for raw in responses:
+              result = json.loads(raw.splitlines()[-1])
+              if result != {"ok": True, "version": expected}:
+                  raise SystemExit(f"unexpected uvx version response: {result!r}")
+          PY
+              printf '%s\n' "$exact_output" "$latest_output"
+              exit 0
+            fi
+            printf 'uvx has not resolved startup-factory %s yet (attempt %s/18)\n' \
+              "$VERSION" "$attempt" >&2
+            sleep 10
+          done
+          printf '%s\n' "$exact_output" "$latest_output" >&2
+          exit 1
+
   github-release:
     name: Publish the exact tested GitHub release assets
     needs:
       - build
-      - publish
+      - verify-uvx
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.14`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.15`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 
@@ -874,7 +874,8 @@ requires byte-identical output, embeds those exact bytes in the wheel and source
 distribution, exercises the built wheel, generates GitHub provenance
 attestations, and publishes through PyPI Trusted Publishing. The GitHub Release
 is created from the same already-tested artifacts; nothing is rebuilt during
-publication.
+publication. A post-publish job resolves the exact public package with `uvx`
+and verifies its reported version before the GitHub Release is finalized.
 
 Before the first release, a maintainer must register the `startup-factory` PyPI
 Trusted Publisher for `.github/workflows/release.yml` on the `pypi` GitHub
@@ -883,9 +884,22 @@ required reviewers for unattended publication, protect `main` with Package CI
 as a required check, and enable immutable GitHub Releases. Every successful
 push produced by a merge to `main` runs the release workflow. The merge must
 advance the version in `pyproject.toml` because PyPI package versions are
-immutable. After the exact merged commit is tested, attested, and published to
-PyPI, the workflow creates the matching `vX.Y.Z` tag and GitHub Release from the
-same artifacts.
+immutable; Package CI rejects a pull request that still names an existing
+`vX.Y.Z` tag so this is caught before merge. After the exact merged commit is
+tested, attested, and published to PyPI, CI waits for the public
+`uvx startup-factory@X.Y.Z` and `uvx startup-factory@latest` paths to resolve
+that version and then creates the matching tag and GitHub Release from the same
+artifacts. Release runs are serialized so closely spaced merges cannot publish
+out of order. There is no separate `uvx` registry: `uvx` installs the
+distribution published on PyPI.
+
+The unattended merge-to-release path is therefore:
+
+```text
+PR Package CI -> merge to main -> full release validation -> reproducible build
+-> attest -> PyPI Trusted Publishing -> public uvx verification
+-> immutable vX.Y.Z GitHub Release
+```
 
 Multi-agent teams require the **target project** to be a git repository because
 every implementation attempt receives a task branch and git worktree. The skill
@@ -920,6 +934,51 @@ VALIDATE_TEST="<your deterministic test command>"
 TRACKER_WRITERS=broker
 AGENT_SANDBOX_ENFORCED=true
 BROKER_LIFECYCLE_ROOT=/absolute/operator-owned/mode-0700/path
+```
+
+These are runtime settings, not prompt flags. A prompt that says "Turbo" does
+not enable the mode, create the protected lifecycle directory, or weaken a
+failed readiness check. Configure `config/team.config.md` in the installed
+Startup Factory bundle first. Use real project commands rather than no-op
+placeholders; for example, `WORKTREE_SETUP="uv sync --frozen"` with
+`VALIDATE_TEST="uv run pytest -q"`, or `WORKTREE_SETUP="npm ci"` with
+`VALIDATE_TEST="npm test"`.
+
+Once the operator-owned prerequisites exist, this prompt is the recommended
+entry point:
+
+```text
+Use the installed Startup Factory skill to deliver [FEATURE] with the
+full-stack team in Safe Turbo mode.
+
+Before launching agents, verify TURBO_MODE=safe, EXECUTION=parallel,
+MAX_ACTIVE_IMPLEMENTERS=2, TRACKER_WRITERS=broker, enforced agent sandboxing,
+a meaningful WORKTREE_SETUP and validation command, an external protected
+BROKER_LIFECYCLE_ROOT, and REVIEW_MODE=parallel. Run preflight and fail closed
+with a precise remediation message if any prerequisite is missing; do not
+bypass or weaken a gate.
+
+Plan dependency- and resource-safe tasks, dispatch at most two implementers in
+parallel, keep each attempt in its own worktree, and keep integration serialized.
+Run Principal Architect, Sceptical Principal Architect, QA, and risk-triggered
+Security review independently against the same immutable package, with Team
+Lead making the final decision.
+
+Monitor authenticated heartbeat and lifecycle status. For a stalled task, have
+Team Lead nudge the exact attempt, wait the configured grace period, and request
+an authenticated restart only if that same attempt is still stalled. Retire an
+idle gate role when its queue is empty. Report active workers, queued tasks,
+validation failures, restarts, review findings, and final integration status.
+```
+
+After the project has a proven stable Turbo configuration, the short form is:
+
+```text
+Deliver [FEATURE] with the installed Startup Factory skill, the full-stack
+preset, and Safe Turbo mode. Start with two parallel implementers, preserve all
+architecture, QA, security, and integration gates, monitor authenticated
+heartbeats, and use Team Lead nudge/restart/retire controls for stalled or idle
+agents. Fail closed if Turbo preflight is not green.
 ```
 
 The selected team must also declare `REVIEW_MODE=parallel`; the full-stack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.14"
+version = "0.1.15"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -28,6 +28,7 @@ PROJECT_MANAGEMENT_CONFIG = ROOT / "config" / "project-management.config.md"
 TEAM_CONFIG = ROOT / "config" / "team.config.md"
 README = ROOT / "README.md"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PACKAGE_CI_WORKFLOW = ROOT / ".github" / "workflows" / "package-ci.yml"
 RESOURCE_ARCHIVE = "startup_factory_cli/resources/startup-factory.tar.gz"
 RESOURCE_CHECKSUM = f"{RESOURCE_ARCHIVE}.sha256"
 
@@ -150,7 +151,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.14")
+        self.assertEqual(project["version"], "0.1.15")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -183,6 +184,13 @@ class BundledDefaultsTests(unittest.TestCase):
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_pull_requests_must_use_an_unreleased_version(self) -> None:
+        workflow = PACKAGE_CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("Require an unreleased version before merge", workflow)
+        self.assertIn("if: github.event_name == 'pull_request'", workflow)
+        self.assertIn("project.version must increase before merge", workflow)
+        self.assertIn('refs/tags/v$VERSION^{commit}', workflow)
+
     def test_release_runs_for_merged_main_commits(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("    branches:\n      - main", workflow)
@@ -190,6 +198,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('test "$GITHUB_REF" = "refs/heads/main"', workflow)
         self.assertIn('test "$commit" = "$GITHUB_SHA"', workflow)
         self.assertIn("bump project.version", workflow)
+        self.assertIn("  group: release-main", workflow)
 
     def test_github_release_tag_comes_from_the_package_version(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -212,6 +221,19 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_github_release_commands_have_explicit_repository_context(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("          GH_REPO: ${{ github.repository }}", workflow)
+
+    def test_public_uvx_install_is_verified_before_github_release(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("  verify-uvx:\n", workflow)
+        self.assertIn("    name: Verify the public uvx installation", workflow)
+        self.assertIn(
+            "        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1",
+            workflow,
+        )
+        self.assertIn('uvx --refresh "startup-factory@$VERSION" version --json', workflow)
+        self.assertIn('uvx --refresh "startup-factory@latest" version --json', workflow)
+        github_release = workflow.split("  github-release:\n", 1)[1]
+        self.assertIn("      - verify-uvx", github_release.split("    runs-on:", 1)[0])
 
     def test_draft_release_target_is_verified_before_the_tag_exists(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -301,7 +323,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.14")
+        self.assertEqual(metadata["Version"], "0.1.15")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])


### PR DESCRIPTION
## Summary

- remove the final manual step from merge-to-release publishing
- serialize releases from `main`
- require pull requests to advance to a new stable SemVer before merge
- verify both `uvx startup-factory@<version>` and `uvx startup-factory@latest` from public PyPI before finalizing the GitHub release
- document the automated pipeline and Safe Turbo prompt
- prepare version `0.1.15`

## Verification

- `python3 -m unittest discover -s tests/packaging -p 'test_*.py' -v` — 45 passed, 1 expected skip
- `TEAM_RUNNER=background ./tests/run-all.sh --smoke` — all tests passed
- workflow YAML parse and embedded shell syntax checks passed
- `git diff --check` passed

The repository `pypi` environment is restricted to `main` without required reviewers, and the active `Protect main CI release` ruleset requires the Package CI job before merge.