### PR TITLE
fix(release): make the uvx verification retry actually retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,19 +331,37 @@ jobs:
           set -euo pipefail
           exact_output=""
           latest_output=""
+          # The version check belongs in the `if` CONDITION, not its body. A
+          # freshly published version is not immediately visible to the index
+          # `uvx --refresh "…@latest"` resolves against, so the first attempts
+          # legitimately report the previous version. With the check inside the
+          # body, `set -e` aborted the whole step on that first stale answer:
+          # the retry budget below only ever covered `uvx` itself failing, never
+          # the propagation lag it exists for. A transient lag then skipped the
+          # github-release job, leaving the package on PyPI with no tag or
+          # release — a half-published release that reads as a failed one.
+          #
+          # As part of the condition, a stale answer makes the condition false,
+          # so the loop retries as intended. A genuinely wrong version still
+          # fails: it simply fails after the budget is exhausted rather than on
+          # the first attempt.
           for attempt in $(seq 1 18); do
             if exact_output="$(uvx --refresh "startup-factory@$VERSION" version --json 2>&1)" &&
-              latest_output="$(uvx --refresh "startup-factory@latest" version --json 2>&1)"; then
+              latest_output="$(uvx --refresh "startup-factory@latest" version --json 2>&1)" &&
               python - "$VERSION" "$exact_output" "$latest_output" <<'PY'
           import json
           import sys
 
           expected, *responses = sys.argv[1:]
           for raw in responses:
-              result = json.loads(raw.splitlines()[-1])
+              try:
+                  result = json.loads(raw.splitlines()[-1])
+              except (IndexError, ValueError):
+                  raise SystemExit("uvx did not return a JSON version response")
               if result != {"ok": True, "version": expected}:
                   raise SystemExit(f"unexpected uvx version response: {result!r}")
           PY
+            then
               printf '%s\n' "$exact_output" "$latest_output"
               exit 0
             fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ licensed**
 
 ![Startup Factory demo](https://raw.githubusercontent.com/alexrolls/startup-factory/main/exports/execmatchai-issues-57s-70s.gif)
 
+## What's new in 0.1.18
+
+This release fixes the public installation check that gates a release. The step
+retries while a freshly published version propagates, but the version comparison
+ran inside the `if` body, so the first not-yet-propagated answer aborted the step
+instead of retrying — and because the GitHub release job depends on that check,
+a transient lag published to PyPI and then skipped the tag and release entirely.
+
+The comparison is now part of the retry condition, so propagation lag is retried
+as intended while a genuinely wrong published version still fails the release
+after the retry budget is exhausted.
+
 ## What's new in 0.1.17
 
 This release keeps an exhaustive tracker read inside a hosted tracker's request
@@ -104,7 +116,7 @@ account, API key, application server, or coordinator database.
    ```
 
    For Claude Code, use `--agent claude-code`. Pin a release in controlled
-   environments, for example `startup-factory@0.1.17`. For a Git checkout or an
+   environments, for example `startup-factory@0.1.18`. For a Git checkout or an
    offline installation, use the
    [auditable shell compatibility path](#shell-compatibility-path).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.17"
+version = "0.1.18"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -151,7 +151,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.17")
+        self.assertEqual(project["version"], "0.1.18")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -348,7 +348,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.17")
+        self.assertEqual(metadata["Version"], "0.1.18")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -235,6 +235,31 @@ class ReleaseWorkflowTests(unittest.TestCase):
         github_release = workflow.split("  github-release:\n", 1)[1]
         self.assertIn("      - verify-uvx", github_release.split("    runs-on:", 1)[0])
 
+    def test_uvx_version_check_is_part_of_the_retry_condition(self) -> None:
+        # A freshly published version is not immediately visible to the index
+        # `@latest` resolves against, so the first attempts legitimately report
+        # the previous version. The check must therefore be part of the `if`
+        # condition: inside the body, `set -e` aborts the step on the first
+        # stale answer and the retry budget never applies to the propagation lag
+        # it exists for — which skips github-release and half-publishes a release.
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        step = workflow.split("      - name: Resolve the published release through uvx", 1)[1]
+        step = step.split("\n  github-release:", 1)[0]
+        loop = step.split("for attempt in", 1)[1]
+        # The condition ends at a `then` on its own line. Requiring the split to
+        # actually find one matters: without it, a body-style `; then` leaves the
+        # whole loop as the "condition" and every assertion below passes
+        # vacuously — which is exactly the shape this test exists to reject.
+        head, sep, _tail = loop.partition("\n            then\n")
+        self.assertTrue(sep, "the uvx retry condition must end at a standalone `then`")
+        self.assertIn('uvx --refresh "startup-factory@$VERSION"', head)
+        self.assertIn('uvx --refresh "startup-factory@latest"', head)
+        self.assertIn('python - "$VERSION" "$exact_output" "$latest_output"', head)
+        # The retry must still exist, and the step must still fail closed.
+        self.assertIn("$(seq 1 18)", step)
+        self.assertIn("sleep 10", step)
+        self.assertIn("exit 1", step)
+
     def test_draft_release_target_is_verified_before_the_tag_exists(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         publish = workflow.split(


### PR DESCRIPTION
## What failed

On the 0.1.17 release, `verify-uvx` failed with:

```
unexpected uvx version response: {'ok': True, 'version': '0.1.16'}
```

**1.5 seconds** into a loop designed to wait three minutes.

## Why

The step wraps 18 attempts around resolving the freshly published version, but the version comparison ran **inside** the `if` body:

```bash
if exact_output="$(uvx --refresh "startup-factory@$VERSION" …)" &&
  latest_output="$(uvx --refresh "startup-factory@latest" …)"; then
  python - … <<'PY'     # ← inside the body
```

Under `set -euo pipefail`, a non-zero exit here kills the step. `uvx` had *succeeded* — it just resolved the previous version, because a freshly published release is not instantly visible to the index `@latest` resolves against. So the retry budget only ever covered `uvx` itself failing, never the propagation lag it exists for.

## Why it matters beyond one red check

`github-release` needs `verify-uvx`. The PyPI publish had already succeeded, so the lag left **0.1.17 installable from PyPI with no tag and no GitHub release** — a half-published release that reads as a failed one, recoverable only by manually rerunning the failed jobs.

## The fix

Move the comparison into the `if` **condition**. A stale answer now falsifies the condition and the loop retries as designed.

The step still fails closed: a genuinely wrong published version exhausts the budget and exits 1 — it fails later, not never. Malformed output is also a typed failure now rather than an `IndexError`/`ValueError` traceback out of the JSON parse.

## Verification

Both behaviours were reproduced against stubs before and after the change:

| stub | before | after |
|---|---|---|
| stale for N attempts, then catches up | **exit 1, zero retries** | retries, then `VERIFIED`, exit 0 |
| never catches up (genuinely wrong) | exit 1 | exit 1 after the full budget |

The extracted step was also syntax-checked as real shell (`bash -n`), since the fix puts a heredoc inside an `if` condition.

The new test pins the condition **boundary**, not just the strings: it requires the condition to end at a standalone `then`. That assertion is load-bearing — without it the test passes vacuously against the old body-style shape, because the whole loop then reads as the "condition". Confirmed by running it against the pre-fix workflow (fails) and the fixed one (passes).

`tests/run-all.sh --smoke` passes, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)