### PR TITLE
Make idle dispatch affordable, make a stalled board visible, and stop relaunches destroying verdicts

### DIFF
--- a/bin/agent-health.py
+++ b/bin/agent-health.py
@@ -40,6 +40,12 @@ def load_sibling(name: str, filename: str):
 
 heartbeat_status = load_sibling("startup_factory_heartbeat_status", "heartbeat-status.py")
 teamwork_path = load_sibling("startup_factory_teamwork_path", "teamwork-path.py")
+board_status = load_sibling("startup_factory_board_status", "board-status.py")
+
+# Verdicts that mean no agent process remains.  Inverted rather than
+# enumerated, so a new "stalled:*" reason counts as a present-but-unhealthy
+# agent instead of silently making a stalled board look drained.
+ABSENT_VERDICTS = {"exited", "identity-mismatch"}
 
 
 def iso(value: datetime) -> str:
@@ -512,6 +518,14 @@ def build_snapshot(
             f"process{'es' if non_agent_processes_omitted != 1 else ''}."
         )
     rows.sort(key=lambda row: (row["team"], row["category"], row["instance"]))
+    boards = build_boards(
+        rows,
+        repository=repository,
+        workspace_host=workspace_host,
+        teamwork_root=teamwork_root,
+        now=now,
+        warnings=warnings,
+    )
     return {
         "schemaVersion": SCHEMA,
         "generatedAt": iso(now),
@@ -520,8 +534,55 @@ def build_snapshot(
         "presentationOnly": True,
         "nonAgentProcessesOmitted": non_agent_processes_omitted,
         "agents": rows,
+        "boards": boards,
         "warnings": warnings,
     }
+
+
+def build_boards(
+    rows: list[dict[str, Any]],
+    *,
+    repository: Path,
+    workspace_host: Path,
+    teamwork_root: str,
+    now: datetime,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Summarize each team's board alongside its per-role rows.
+
+    A board summary is presentation only and must never be able to fail the
+    health view: a team whose board cannot be read is reported as unknown with
+    a warning, not raised.
+    """
+    try:
+        board_config = json.loads(
+            (repository / "config" / "statuses.config.json").read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return []
+    summaries: list[dict[str, Any]] = []
+    for team in sorted({row["team"] for row in rows}):
+        live = sum(
+            1
+            for row in rows
+            if row["team"] == team and row["verdict"] not in ABSENT_VERDICTS
+        )
+        try:
+            workspace = Path(
+                teamwork_path.workspace(str(workspace_host), teamwork_root, team)
+            )
+            summary = board_status.collect(
+                workspace=workspace,
+                board=board_config,
+                live_agents=live,
+                now=now,
+            )
+        except (OSError, RuntimeError, SystemExit) as exc:
+            warnings.append(f"Cannot summarize the {team} board: {exc}")
+            continue
+        summary["team"] = team
+        summaries.append(summary)
+    return summaries
 
 
 def unmanaged_snapshot(
@@ -594,6 +655,8 @@ def render_table(snapshot: dict[str, Any]) -> str:
     lines.extend(line(row) for row in values)
     if not values:
         lines.append("(no managed agents for this project)")
+    for board in snapshot.get("boards", []):
+        lines.append(f"{board['team']}: {board_status.board_line(board)}")
     lines.append("* Percentages are self-reported, fresh, and presentation-only.")
     lines.extend(f"Warning: {warning}" for warning in snapshot["warnings"])
     return "\n".join(lines)

--- a/bin/agent-health.py
+++ b/bin/agent-health.py
@@ -43,9 +43,12 @@ teamwork_path = load_sibling("startup_factory_teamwork_path", "teamwork-path.py"
 board_status = load_sibling("startup_factory_board_status", "board-status.py")
 
 # Verdicts that mean no agent process remains.  Inverted rather than
-# enumerated, so a new "stalled:*" reason counts as a present-but-unhealthy
-# agent instead of silently making a stalled board look drained.
+# enumerated, so a new reason counts as a present agent instead of silently
+# making a stalled board look drained.
 ABSENT_VERDICTS = {"exited", "identity-mismatch"}
+# A present agent that is not progressing.  Counting these as live would let a
+# board of entirely stuck agents report WORKING, which is a false all-clear.
+STALLED_PREFIX = "stalled"
 
 
 def iso(value: datetime) -> str:
@@ -558,15 +561,22 @@ def build_boards(
         board_config = json.loads(
             (repository / "config" / "statuses.config.json").read_text(encoding="utf-8")
         )
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        # Every other failure in this feature surfaces as a warning; this one
+        # must too, or the board line disappears with no explanation at all.
+        warnings.append(f"Cannot read the status configuration for board summaries: {exc}")
         return []
     summaries: list[dict[str, Any]] = []
     for team in sorted({row["team"] for row in rows}):
-        live = sum(
-            1
+        present = [
+            row["verdict"]
             for row in rows
             if row["team"] == team and row["verdict"] not in ABSENT_VERDICTS
+        ]
+        stalled = sum(
+            1 for verdict in present if verdict.split(":", 1)[0] == STALLED_PREFIX
         )
+        live = len(present) - stalled
         try:
             workspace = Path(
                 teamwork_path.workspace(str(workspace_host), teamwork_root, team)
@@ -575,6 +585,7 @@ def build_boards(
                 workspace=workspace,
                 board=board_config,
                 live_agents=live,
+                stalled_agents=stalled,
                 now=now,
             )
         except (OSError, RuntimeError, SystemExit) as exc:

--- a/bin/board-status.py
+++ b/bin/board-status.py
@@ -137,28 +137,38 @@ def summarize(
     last_pass: datetime | None,
     live_agents: int,
     now: datetime,
+    stalled_agents: int = 0,
     idle_minutes: int = DEFAULT_IDLE_MINUTES,
 ) -> dict[str, Any]:
-    """Classify a board as working, idle, or stalled.
+    """Classify a board as working, idle, stalled, or drained.
 
-    STALLED is the state the operator cannot see today: work is waiting, no
-    agent is alive to take it, and no dispatch pass has run recently.  IDLE is
-    the same shape without the elapsed-time evidence, so it is reported without
-    claiming a pass was missed.
+    STALLED is the state the operator cannot see today: work is waiting and
+    nothing healthy is moving it.  IDLE is the same shape while a dispatch pass
+    is still recent, so it is reported without claiming a pass was missed.
+
+    The two false all-clears this must never produce are WORKING when the only
+    agents left are individually stalled, and DRAINED while an in-flight [task]
+    sits orphaned by a worker that already exited.  `live_agents` therefore
+    counts only agents that are present AND progressing, and outstanding work
+    includes the working [tasks] a dead worker leaves behind.
     """
     if idle_minutes < 1:
         raise BoardStatusError("idle minutes must be at least 1")
-    outstanding = counts.get("queued", 0) + counts.get("review", 0)
+    outstanding = (
+        counts.get("queued", 0) + counts.get("review", 0) + counts.get("working", 0)
+    )
     since_pass = None
     if last_pass is not None:
         since_pass = max(0, int((now - last_pass).total_seconds()))
     stale_pass = since_pass is None or since_pass >= idle_minutes * 60
 
-    if live_agents > 0:
-        verdict = "WORKING"
-    elif outstanding == 0 and pending == 0:
+    if outstanding == 0 and pending == 0:
+        # Nothing queued, in review, in flight, or waiting to publish. This is
+        # the quiet end of a run and must stay quiet however old the last pass.
         verdict = "DRAINED"
-    elif stale_pass:
+    elif live_agents > 0:
+        verdict = "WORKING"
+    elif stalled_agents > 0 or stale_pass:
         verdict = "STALLED"
     else:
         verdict = "IDLE"
@@ -172,6 +182,7 @@ def summarize(
         "outstanding": outstanding,
         "undrainedArtifacts": pending,
         "liveAgents": live_agents,
+        "stalledAgents": stalled_agents,
         "lastPassAt": last_pass.isoformat(timespec="seconds").replace("+00:00", "Z")
         if last_pass is not None
         else None,
@@ -228,6 +239,7 @@ def collect(
     board: dict[str, Any],
     live_agents: int,
     now: datetime,
+    stalled_agents: int = 0,
     idle_minutes: int = DEFAULT_IDLE_MINUTES,
 ) -> dict[str, Any]:
     names = status_names(board)
@@ -244,6 +256,7 @@ def collect(
         pending=count_pending(workspace),
         last_pass=last_pass_at(workspace),
         live_agents=live_agents,
+        stalled_agents=stalled_agents,
         now=now,
         idle_minutes=idle_minutes,
     )
@@ -256,6 +269,7 @@ def parser() -> argparse.ArgumentParser:
     parsed.add_argument("--workspace", required=True)
     parsed.add_argument("--status-config", required=True)
     parsed.add_argument("--live-agents", type=int, default=0)
+    parsed.add_argument("--stalled-agents", type=int, default=0)
     parsed.add_argument("--idle-minutes", type=int, default=DEFAULT_IDLE_MINUTES)
     parsed.add_argument("--json", action="store_true")
     return parsed
@@ -273,6 +287,7 @@ def main() -> int:
             workspace=Path(args.workspace),
             board=board,
             live_agents=args.live_agents,
+            stalled_agents=args.stalled_agents,
             now=datetime.now(timezone.utc),
             idle_minutes=args.idle_minutes,
         )

--- a/bin/board-status.py
+++ b/bin/board-status.py
@@ -162,12 +162,15 @@ def summarize(
         since_pass = max(0, int((now - last_pass).total_seconds()))
     stale_pass = since_pass is None or since_pass >= idle_minutes * 60
 
-    if outstanding == 0 and pending == 0:
+    if live_agents > 0:
+        # A present, progressing agent outranks everything below. Safe to check
+        # first only because live excludes stalled agents; counting those as
+        # live is what used to let an entirely stuck board report WORKING.
+        verdict = "WORKING"
+    elif outstanding == 0 and pending == 0:
         # Nothing queued, in review, in flight, or waiting to publish. This is
         # the quiet end of a run and must stay quiet however old the last pass.
         verdict = "DRAINED"
-    elif live_agents > 0:
-        verdict = "WORKING"
     elif stalled_agents > 0 or stale_pass:
         verdict = "STALLED"
     else:
@@ -224,6 +227,16 @@ def board_line(summary: dict[str, Any]) -> str:
                 "" if summary["undrainedArtifacts"] == 1 else "s",
             )
         )
+    # Whether anything is alive is the operator's first question, and the
+    # verdict alone cannot answer it: WORKING and DRAINED both omit agents that
+    # matter -- a live agent with only blocked work left, or stalled agents the
+    # verdict already accounts for but does not quantify.
+    if summary["liveAgents"]:
+        parts.append("%d live agent%s" % (summary["liveAgents"],
+                                          "" if summary["liveAgents"] == 1 else "s"))
+    if summary.get("stalledAgents"):
+        parts.append("%d stalled agent%s" % (summary["stalledAgents"],
+                                             "" if summary["stalledAgents"] == 1 else "s"))
     if summary["secondsSinceLastPass"] is None:
         parts.append("no dispatch pass recorded")
     else:

--- a/bin/board-status.py
+++ b/bin/board-status.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Summarize whether a team board is progressing, idle, or stalled.
+
+Every role reaching `exited` is the normal end of a dispatch pass, so per-role
+health cannot distinguish "finished cleanly" from "stalled with work
+outstanding".  This module answers the board-level question instead: is there
+work waiting, is anything alive to do it, and when did a dispatch pass last run.
+
+Presentation only.  Nothing here controls lifecycle, scheduling, review,
+integration, or release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "board-status-v1"
+DEFAULT_IDLE_MINUTES = 15
+MAX_SNAPSHOT_BYTES = 64 * 1024 * 1024
+
+
+class BoardStatusError(RuntimeError):
+    pass
+
+
+def _read_regular(path: Path, label: str, maximum: int) -> bytes:
+    """Read a file that must be a plain, owner-readable, non-symlink file."""
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return b""
+    except OSError as exc:
+        raise BoardStatusError("cannot inspect %s: %s" % (label, exc)) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise BoardStatusError("%s must be a non-symlink regular file" % label)
+    if info.st_size > maximum:
+        raise BoardStatusError("%s is larger than its allowed size" % label)
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        raise BoardStatusError("cannot read %s: %s" % (label, exc)) from exc
+    try:
+        return os.read(descriptor, maximum + 1)
+    finally:
+        os.close(descriptor)
+
+
+def status_names(board: dict[str, Any]) -> dict[str, str]:
+    """Map task status kinds to their configured names."""
+    try:
+        statuses = board["tasks"]["statuses"]
+    except (KeyError, TypeError) as exc:
+        raise BoardStatusError("status configuration has no task statuses") from exc
+    by_kind = {
+        status.get("kind"): status.get("name")
+        for status in statuses
+        if isinstance(status, dict) and status.get("kind") and status.get("name")
+    }
+    return {
+        "queued": by_kind.get("queued", "Planned"),
+        "working": by_kind.get("working", "Active"),
+        "review": by_kind.get("review", "Review"),
+        "blocked": by_kind.get("blocked", "Blocked"),
+    }
+
+
+def count_tasks(snapshot: Any, names: dict[str, str]) -> dict[str, int]:
+    """Count tasks per status kind in an exported feature snapshot."""
+    tasks = snapshot.get("tasks") if isinstance(snapshot, dict) else None
+    if not isinstance(tasks, list):
+        return {kind: 0 for kind in names}
+    counts = {kind: 0 for kind in names}
+    inverted = {value: key for key, value in names.items()}
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        kind = inverted.get(task.get("status"))
+        if kind is not None:
+            counts[kind] += 1
+    return counts
+
+
+def count_pending(workspace: Path) -> int:
+    """Count artifacts enqueued to the outbox and not yet drained."""
+    pending = workspace / "outbox" / "pending"
+    try:
+        info = pending.lstat()
+    except FileNotFoundError:
+        return 0
+    except OSError as exc:
+        raise BoardStatusError("cannot inspect the outbox: %s" % exc) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise BoardStatusError("the outbox pending directory is not a directory")
+    total = 0
+    try:
+        for child in pending.iterdir():
+            child_info = child.lstat()
+            if stat.S_ISREG(child_info.st_mode) and not child.name.startswith("."):
+                total += 1
+    except OSError as exc:
+        raise BoardStatusError("cannot enumerate the outbox: %s" % exc) from exc
+    return total
+
+
+def last_pass_at(workspace: Path) -> datetime | None:
+    """Read the timestamp the last completed dispatch pass recorded."""
+    raw = _read_regular(workspace / "dispatch.last-pass", "dispatch pass marker", 256)
+    if not raw:
+        return None
+    try:
+        text = raw.decode("ascii", errors="strict").strip()
+    except UnicodeError:
+        raise BoardStatusError("dispatch pass marker is not ASCII") from None
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise BoardStatusError("dispatch pass marker is not an ISO-8601 instant") from None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def summarize(
+    *,
+    counts: dict[str, int],
+    pending: int,
+    last_pass: datetime | None,
+    live_agents: int,
+    now: datetime,
+    idle_minutes: int = DEFAULT_IDLE_MINUTES,
+) -> dict[str, Any]:
+    """Classify a board as working, idle, or stalled.
+
+    STALLED is the state the operator cannot see today: work is waiting, no
+    agent is alive to take it, and no dispatch pass has run recently.  IDLE is
+    the same shape without the elapsed-time evidence, so it is reported without
+    claiming a pass was missed.
+    """
+    if idle_minutes < 1:
+        raise BoardStatusError("idle minutes must be at least 1")
+    outstanding = counts.get("queued", 0) + counts.get("review", 0)
+    since_pass = None
+    if last_pass is not None:
+        since_pass = max(0, int((now - last_pass).total_seconds()))
+    stale_pass = since_pass is None or since_pass >= idle_minutes * 60
+
+    if live_agents > 0:
+        verdict = "WORKING"
+    elif outstanding == 0 and pending == 0:
+        verdict = "DRAINED"
+    elif stale_pass:
+        verdict = "STALLED"
+    else:
+        verdict = "IDLE"
+    return {
+        "schemaVersion": SCHEMA,
+        "verdict": verdict,
+        "queued": counts.get("queued", 0),
+        "working": counts.get("working", 0),
+        "review": counts.get("review", 0),
+        "blocked": counts.get("blocked", 0),
+        "outstanding": outstanding,
+        "undrainedArtifacts": pending,
+        "liveAgents": live_agents,
+        "lastPassAt": last_pass.isoformat(timespec="seconds").replace("+00:00", "Z")
+        if last_pass is not None
+        else None,
+        "secondsSinceLastPass": since_pass,
+        "idleMinutes": idle_minutes,
+        "presentationOnly": True,
+    }
+
+
+def human_duration(seconds: int) -> str:
+    if seconds < 60:
+        return "%ds" % seconds
+    minutes = seconds // 60
+    if minutes < 60:
+        return "%dm" % minutes
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return "%dh%02dm" % (hours, minutes)
+    days, hours = divmod(hours, 24)
+    return "%dd%02dh" % (days, hours)
+
+
+def board_line(summary: dict[str, Any]) -> str:
+    """One operator-facing line describing the whole board."""
+    parts: list[str] = []
+    if summary["queued"]:
+        parts.append("%d queued task%s" % (summary["queued"], "" if summary["queued"] == 1 else "s"))
+    if summary["review"]:
+        parts.append("%d in review" % summary["review"])
+    if summary["working"]:
+        parts.append("%d active" % summary["working"])
+    if summary["blocked"]:
+        parts.append("%d blocked" % summary["blocked"])
+    if summary["undrainedArtifacts"]:
+        parts.append(
+            "%d undrained artifact%s"
+            % (
+                summary["undrainedArtifacts"],
+                "" if summary["undrainedArtifacts"] == 1 else "s",
+            )
+        )
+    if summary["secondsSinceLastPass"] is None:
+        parts.append("no dispatch pass recorded")
+    else:
+        parts.append("last pass %s ago" % human_duration(summary["secondsSinceLastPass"]))
+    if not parts:
+        return summary["verdict"]
+    return "%s — %s" % (summary["verdict"], ", ".join(parts))
+
+
+def collect(
+    *,
+    workspace: Path,
+    board: dict[str, Any],
+    live_agents: int,
+    now: datetime,
+    idle_minutes: int = DEFAULT_IDLE_MINUTES,
+) -> dict[str, Any]:
+    names = status_names(board)
+    raw = _read_regular(workspace / "tasks.json", "feature snapshot", MAX_SNAPSHOT_BYTES)
+    if raw:
+        try:
+            snapshot = json.loads(raw)
+        except ValueError:
+            raise BoardStatusError("feature snapshot is not valid JSON") from None
+    else:
+        snapshot = {}
+    return summarize(
+        counts=count_tasks(snapshot, names),
+        pending=count_pending(workspace),
+        last_pass=last_pass_at(workspace),
+        live_agents=live_agents,
+        now=now,
+        idle_minutes=idle_minutes,
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    parsed = argparse.ArgumentParser(
+        description="Report whether a team board is progressing, idle, or stalled."
+    )
+    parsed.add_argument("--workspace", required=True)
+    parsed.add_argument("--status-config", required=True)
+    parsed.add_argument("--live-agents", type=int, default=0)
+    parsed.add_argument("--idle-minutes", type=int, default=DEFAULT_IDLE_MINUTES)
+    parsed.add_argument("--json", action="store_true")
+    return parsed
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        board = json.loads(Path(args.status_config).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print("board-status: cannot read status configuration: %s" % exc, file=sys.stderr)
+        return 2
+    try:
+        summary = collect(
+            workspace=Path(args.workspace),
+            board=board,
+            live_agents=args.live_agents,
+            now=datetime.now(timezone.utc),
+            idle_minutes=args.idle_minutes,
+        )
+    except BoardStatusError as exc:
+        print("board-status: %s" % exc, file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print(board_line(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/dispatch.sh
+++ b/bin/dispatch.sh
@@ -345,8 +345,53 @@ dispatch_once() { # dispatch_once <team> <featureId> <dry:yes|no> [target-task]
 
   # Holds must observe the complete authoritative feature, including work that
   # is reserved from autonomous claiming with an ignored label.
-  env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
-    "$SKILL_DIR/bin/tracker-ops.sh" export "$fid" "$tasks_file" >/dev/null
+  #
+  # The export dominates the cost of a pass: on a [feature] with hundreds of
+  # [tasks] it is hundreds of requests, so a watch loop at the default cadence
+  # can exhaust an hourly tracker budget without any work having changed. Ask
+  # the adapter for a cheap change token first and reuse the previous snapshot
+  # when nothing moved.
+  #
+  # Reuse is bounded on purpose. A token is a high-water mark, and a
+  # sufficiently unusual tracker edit can fail to move one, so a full export
+  # runs at least every EXPORT_MAX_REUSE_SECONDS regardless. A missed change
+  # therefore delays an export; it can never cancel one.
+  # Declared then assigned: `local x="$(cmd)"` would return local's own status
+  # and hide a rejected path from set -e.
+  local token_file export_stamp max_reuse
+  token_file="$(team_path "$dir" dispatch.change-token)"
+  export_stamp="$(team_path "$dir" dispatch.export-at)"
+  max_reuse="$(read_key EXPORT_MAX_REUSE_SECONDS)"; max_reuse="${max_reuse:-900}"
+  # A misconfigured value must not decide how long a stale export is trusted,
+  # and must not abort the pass in a numeric test either.
+  case "$max_reuse" in *[!0-9]*|"") max_reuse=900 ;; esac
+  local reuse=no
+  if [ -s "$tasks_file" ] && [ -s "$token_file" ]; then
+    local observed_token cached_token last_export now_seconds
+    observed_token="$(env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+      "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null || true)"
+    cached_token="$(cat "$token_file" 2>/dev/null || true)"
+    if [ -n "$observed_token" ] && [ "$observed_token" = "$cached_token" ]; then
+      now_seconds="$(date -u +%s)"
+      last_export="$(cat "$export_stamp" 2>/dev/null || echo 0)"
+      case "$last_export" in *[!0-9]*|"") last_export=0 ;; esac
+      if [ "$((now_seconds - last_export))" -lt "$max_reuse" ]; then
+        reuse=yes
+      fi
+    fi
+  fi
+  if [ "$reuse" = yes ]; then
+    echo "dispatch: tracker unchanged; reusing the cached feature export"
+  else
+    env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+      "$SKILL_DIR/bin/tracker-ops.sh" export "$fid" "$tasks_file" >/dev/null
+    # Record the token only after a successful export, so a failed export can
+    # never leave a token claiming the cached snapshot is current.
+    env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+      "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null \
+      > "$token_file" || : > "$token_file"
+    date -u +%s > "$export_stamp" 2>/dev/null || true
+  fi
   if [ "$dry" != "yes" ]; then
     local hold_result hold_actions hold_action hold_task hold_graph changed=no
     hold_result="$(python3 "$SKILL_DIR/bin/task-hold.py" sync \
@@ -629,8 +674,9 @@ EOF
   # pass, so this marker is the only evidence that separates a board nobody is
   # driving from one that simply finished its work.
   if [ "$dry" = "no" ]; then
-    printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      > "$(team_path "$dir" dispatch.last-pass)" 2>/dev/null || true
+    local pass_marker
+    pass_marker="$(team_path "$dir" dispatch.last-pass)"
+    printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$pass_marker"
   fi
 }
 

--- a/bin/dispatch.sh
+++ b/bin/dispatch.sh
@@ -348,7 +348,7 @@ refresh_export_if_changed() { # <workspace> <featureId> <tasks-file>
   env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
     "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null \
     > "$token_file" || : > "$token_file"
-  date -u +%s > "$export_stamp"
+  date -u +%s > "$export_stamp" 2>/dev/null || true
 }
 
 dispatch_once() { # dispatch_once <team> <featureId> <dry:yes|no> [target-task]
@@ -467,7 +467,7 @@ EOF
     # allowed to answer, so it must be observed before they drain it.
     local broker_work=no
     if [ -n "$(find "$(team_path "$dir" outbox/pending)" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)" ] \
-       || [ -n "$(find "$(team_path "$dir" integrations)" -mindepth 1 -maxdepth 1 ! -name '.*' -print -quit 2>/dev/null || true)" ]; then
+       || [ -n "$(find "$(team_path "$dir" integrations)" -mindepth 1 -maxdepth 1 -type f -name '*.json' -print -quit 2>/dev/null || true)" ]; then
       broker_work=yes
     fi
     "$SKILL_DIR/bin/finalize-integrations.sh" "$team" "$fid"

--- a/bin/dispatch.sh
+++ b/bin/dispatch.sh
@@ -314,7 +314,7 @@ refresh_export_if_changed() { # <workspace> <featureId> <tasks-file>
   # sufficiently unusual tracker edit can fail to move one, so a full export
   # runs at least every EXPORT_MAX_REUSE_SECONDS regardless. A missed change
   # therefore delays an export; it can never cancel one.
-  local dir="$1" fid="$2" tasks_file="$3"
+  local dir="$1" fid="$2" tasks_file="$3" force="${4:-no}"
   # Declared then assigned: `local x="$(cmd)"` returns local's own status and
   # would hide a rejected path from set -e.
   local token_file export_stamp max_reuse
@@ -326,7 +326,7 @@ refresh_export_if_changed() { # <workspace> <featureId> <tasks-file>
   # time-based backstop meaningful when a token misses a change.
   case "$max_reuse" in *[!0-9]*|"") max_reuse=900 ;; esac
   [ "$max_reuse" -le 3600 ] || max_reuse=3600
-  if [ -s "$tasks_file" ] && [ -s "$token_file" ]; then
+  if [ "$force" = no ] && [ -s "$tasks_file" ] && [ -s "$token_file" ]; then
     local observed_token cached_token last_export now_seconds
     observed_token="$(env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
       "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null || true)"
@@ -463,15 +463,24 @@ EOF
 
     # Only after task-scoped stops and durable holds are established may the
     # credentialed brokers publish artifacts or finalize integration evidence.
+    # Whether the brokers have queued work decides how the re-read below is
+    # allowed to answer, so it must be observed before they drain it.
+    local broker_work=no
+    if [ -n "$(find "$(team_path "$dir" outbox/pending)" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)" ] \
+       || [ -n "$(find "$(team_path "$dir" integrations)" -mindepth 1 -maxdepth 1 ! -name '.*' -print -quit 2>/dev/null || true)" ]; then
+      broker_work=yes
+    fi
     "$SKILL_DIR/bin/finalize-integrations.sh" "$team" "$fid"
     "$SKILL_DIR/bin/process-outbox.sh" "$team" "$fid"
-    # Re-read after the brokers, under the same rule as the export at the top
-    # of the pass. Anything they published is a tracker write, so it moves the
-    # token; if they published nothing and nobody else wrote either, the
-    # snapshot is still current and a second full export is pure cost. This
-    # export is unconditional otherwise, and it alone would keep every idle
-    # watch cycle at full price.
-    refresh_export_if_changed "$dir" "$fid" "$tasks_file"
+    # Re-read after the brokers to close the observation race their writes
+    # create. When they had nothing queued they wrote nothing, so the token
+    # rules as it does at the top of the pass and an idle cycle stays cheap --
+    # leaving this read ungated is what would keep every idle cycle at full
+    # price. When they did have work, export unconditionally: their writes are
+    # ours, and a hosted tracker does not promise that a read microseconds
+    # later already reflects them. Trusting the token there could plan on a
+    # snapshot missing the verdict we just published.
+    refresh_export_if_changed "$dir" "$fid" "$tasks_file" "$broker_work"
 
     # Close the observation race created by broker/finalizer work. If a human
     # moved a task to Blocked or reserved it with an ignored label during this

--- a/bin/dispatch.sh
+++ b/bin/dispatch.sh
@@ -301,6 +301,56 @@ print("dispatch-" + hashlib.sha256("\0".join(
 PY
 }
 
+refresh_export_if_changed() { # <workspace> <featureId> <tasks-file>
+  # Export the [feature] unless the adapter can prove nothing moved since the
+  # last successful export.
+  #
+  # The export dominates the cost of a pass: on a [feature] with hundreds of
+  # [tasks] it is hundreds of requests, and a pass performs more than one, so a
+  # watch loop at the default cadence can exhaust an hourly tracker budget with
+  # no work having changed.
+  #
+  # Reuse is bounded on purpose. A token is a high-water mark, and a
+  # sufficiently unusual tracker edit can fail to move one, so a full export
+  # runs at least every EXPORT_MAX_REUSE_SECONDS regardless. A missed change
+  # therefore delays an export; it can never cancel one.
+  local dir="$1" fid="$2" tasks_file="$3"
+  # Declared then assigned: `local x="$(cmd)"` returns local's own status and
+  # would hide a rejected path from set -e.
+  local token_file export_stamp max_reuse
+  token_file="$(team_path "$dir" dispatch.change-token)"
+  export_stamp="$(team_path "$dir" dispatch.export-at)"
+  max_reuse="$(read_key EXPORT_MAX_REUSE_SECONDS)"; max_reuse="${max_reuse:-900}"
+  # A misconfigured value must not decide how long a stale export is trusted,
+  # and must not abort the pass in a numeric test either. The ceiling keeps the
+  # time-based backstop meaningful when a token misses a change.
+  case "$max_reuse" in *[!0-9]*|"") max_reuse=900 ;; esac
+  [ "$max_reuse" -le 3600 ] || max_reuse=3600
+  if [ -s "$tasks_file" ] && [ -s "$token_file" ]; then
+    local observed_token cached_token last_export now_seconds
+    observed_token="$(env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+      "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null || true)"
+    cached_token="$(cat "$token_file" 2>/dev/null || true)"
+    if [ -n "$observed_token" ] && [ "$observed_token" = "$cached_token" ]; then
+      now_seconds="$(date -u +%s)"
+      last_export="$(cat "$export_stamp" 2>/dev/null || echo 0)"
+      case "$last_export" in *[!0-9]*|"") last_export=0 ;; esac
+      if [ "$((now_seconds - last_export))" -lt "$max_reuse" ]; then
+        echo "dispatch: tracker unchanged; reusing the cached feature export"
+        return 0
+      fi
+    fi
+  fi
+  env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+    "$SKILL_DIR/bin/tracker-ops.sh" export "$fid" "$tasks_file" >/dev/null
+  # Record the token only after a successful export, so a failed export can
+  # never leave a token claiming the cached snapshot is current.
+  env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
+    "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null \
+    > "$token_file" || : > "$token_file"
+  date -u +%s > "$export_stamp"
+}
+
 dispatch_once() { # dispatch_once <team> <featureId> <dry:yes|no> [target-task]
   local team="$1" fid="$2" dry="$3" target_task="${4:-}"
   local dir lock tasks_file; dir="$(teamroot "$team")"
@@ -345,53 +395,7 @@ dispatch_once() { # dispatch_once <team> <featureId> <dry:yes|no> [target-task]
 
   # Holds must observe the complete authoritative feature, including work that
   # is reserved from autonomous claiming with an ignored label.
-  #
-  # The export dominates the cost of a pass: on a [feature] with hundreds of
-  # [tasks] it is hundreds of requests, so a watch loop at the default cadence
-  # can exhaust an hourly tracker budget without any work having changed. Ask
-  # the adapter for a cheap change token first and reuse the previous snapshot
-  # when nothing moved.
-  #
-  # Reuse is bounded on purpose. A token is a high-water mark, and a
-  # sufficiently unusual tracker edit can fail to move one, so a full export
-  # runs at least every EXPORT_MAX_REUSE_SECONDS regardless. A missed change
-  # therefore delays an export; it can never cancel one.
-  # Declared then assigned: `local x="$(cmd)"` would return local's own status
-  # and hide a rejected path from set -e.
-  local token_file export_stamp max_reuse
-  token_file="$(team_path "$dir" dispatch.change-token)"
-  export_stamp="$(team_path "$dir" dispatch.export-at)"
-  max_reuse="$(read_key EXPORT_MAX_REUSE_SECONDS)"; max_reuse="${max_reuse:-900}"
-  # A misconfigured value must not decide how long a stale export is trusted,
-  # and must not abort the pass in a numeric test either.
-  case "$max_reuse" in *[!0-9]*|"") max_reuse=900 ;; esac
-  local reuse=no
-  if [ -s "$tasks_file" ] && [ -s "$token_file" ]; then
-    local observed_token cached_token last_export now_seconds
-    observed_token="$(env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
-      "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null || true)"
-    cached_token="$(cat "$token_file" 2>/dev/null || true)"
-    if [ -n "$observed_token" ] && [ "$observed_token" = "$cached_token" ]; then
-      now_seconds="$(date -u +%s)"
-      last_export="$(cat "$export_stamp" 2>/dev/null || echo 0)"
-      case "$last_export" in *[!0-9]*|"") last_export=0 ;; esac
-      if [ "$((now_seconds - last_export))" -lt "$max_reuse" ]; then
-        reuse=yes
-      fi
-    fi
-  fi
-  if [ "$reuse" = yes ]; then
-    echo "dispatch: tracker unchanged; reusing the cached feature export"
-  else
-    env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
-      "$SKILL_DIR/bin/tracker-ops.sh" export "$fid" "$tasks_file" >/dev/null
-    # Record the token only after a successful export, so a failed export can
-    # never leave a token claiming the cached snapshot is current.
-    env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
-      "$SKILL_DIR/bin/tracker-ops.sh" change-token "$fid" 2>/dev/null \
-      > "$token_file" || : > "$token_file"
-    date -u +%s > "$export_stamp" 2>/dev/null || true
-  fi
+  refresh_export_if_changed "$dir" "$fid" "$tasks_file"
   if [ "$dry" != "yes" ]; then
     local hold_result hold_actions hold_action hold_task hold_graph changed=no
     hold_result="$(python3 "$SKILL_DIR/bin/task-hold.py" sync \
@@ -461,8 +465,13 @@ EOF
     # credentialed brokers publish artifacts or finalize integration evidence.
     "$SKILL_DIR/bin/finalize-integrations.sh" "$team" "$fid"
     "$SKILL_DIR/bin/process-outbox.sh" "$team" "$fid"
-    env -u STARTUP_FACTORY_IGNORED_TASK_LABELS_JSON \
-      "$SKILL_DIR/bin/tracker-ops.sh" export "$fid" "$tasks_file" >/dev/null
+    # Re-read after the brokers, under the same rule as the export at the top
+    # of the pass. Anything they published is a tracker write, so it moves the
+    # token; if they published nothing and nobody else wrote either, the
+    # snapshot is still current and a second full export is pure cost. This
+    # export is unconditional otherwise, and it alone would keep every idle
+    # watch cycle at full price.
+    refresh_export_if_changed "$dir" "$fid" "$tasks_file"
 
     # Close the observation race created by broker/finalizer work. If a human
     # moved a task to Blocked or reserved it with an ignored label during this

--- a/bin/dispatch.sh
+++ b/bin/dispatch.sh
@@ -625,6 +625,13 @@ print((matches[0]["state"]+"\t"+matches[0]["createdAt"]) if matches else "absent
   done <<EOF
 $plan
 EOF
+  # Record that a pass completed. Every role exiting is the normal end of a
+  # pass, so this marker is the only evidence that separates a board nobody is
+  # driving from one that simply finished its work.
+  if [ "$dry" = "no" ]; then
+    printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      > "$(team_path "$dir" dispatch.last-pass)" 2>/dev/null || true
+  fi
 }
 
 [ $# -ge 3 ] || die "usage: dispatch.sh <team> <featureId> --once|--watch [--dry-run] [--task <taskId>]"

--- a/bin/outbox_capability.py
+++ b/bin/outbox_capability.py
@@ -111,12 +111,13 @@ def _protected_dir(path: Path) -> Path:
     return path
 
 
-def state_directories(repository: str | Path) -> tuple[Path, Path]:
+def state_directories(repository: str | Path) -> tuple[Path, Path, Path]:
     common = git_common_dir(repository)
     broker = _protected_dir(common / "startup-factory-broker")
     records = _protected_dir(broker / "outbox-capabilities")
     active = _protected_dir(broker / "outbox-active")
-    return records, active
+    revoked = _protected_dir(broker / "outbox-revoked")
+    return records, active, revoked
 
 
 def _write_exclusive(path: Path, content: bytes, mode: int = 0o600) -> None:
@@ -143,6 +144,47 @@ def _replace_owner_only(path: Path, content: bytes) -> None:
             temporary.unlink()
         except FileNotFoundError:
             pass
+
+
+def _revocation_tombstone(revoked: Path, capability_id: str) -> Path:
+    """Path of the durable marker proving one capability was explicitly revoked.
+
+    Revocation and supersession both clear a capability's active pointer, so the
+    pointer alone cannot distinguish them once any later mint recreates it.  The
+    tombstone records the revoked identity itself, which no subsequent mint can
+    reproduce: capability ids are unique per mint.
+    """
+    return revoked / (capability_id + ".revoked")
+
+
+def _record_revocation(revoked: Path, capability_id: str) -> None:
+    if not CAPABILITY_ID.fullmatch(capability_id):
+        raise CapabilityError("cannot revoke an invalid capability identity")
+    _replace_owner_only(
+        _revocation_tombstone(revoked, capability_id),
+        (capability_id + "\n").encode("ascii"),
+    )
+
+
+def _is_revoked(revoked: Path, capability_id: str) -> bool:
+    """Report whether an explicit revocation tombstone exists.
+
+    Any unreadable, non-regular, group/world-accessible, or mismatched
+    tombstone is treated as a revocation: a capability whose revocation
+    evidence cannot be trusted must not publish.
+    """
+    path = _revocation_tombstone(revoked, capability_id)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise CapabilityError("cannot inspect capability revocation: %s" % exc) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise CapabilityError("capability revocation must be a non-symlink regular file")
+    if info.st_uid != os.geteuid() or info.st_mode & 0o077:
+        raise CapabilityError("capability revocation must be owner-only")
+    return True
 
 
 def _active_key(record: Dict[str, Any]) -> str:
@@ -201,7 +243,7 @@ def mint(
     if ttl_seconds < 60 or ttl_seconds > 7 * 24 * 60 * 60:
         raise CapabilityError("capability TTL must be between 60 seconds and 7 days")
 
-    records, active = state_directories(repo)
+    records, active, _revoked = state_directories(repo)
     issued = int(time.time())
     capability_id = "cap-" + secrets.token_hex(16)
     secret = secrets.token_hex(32)
@@ -330,7 +372,7 @@ def _verify_entry(
 
     repo = _repo(repository)
     workspace_real = Path(os.path.realpath(workspace))
-    records, active = state_directories(repo)
+    records, active, revoked = state_directories(repo)
     raw = _read_protected(records / (capability_id + ".json"), "capability record")
     try:
         record = json.loads(raw)
@@ -346,11 +388,21 @@ def _verify_entry(
     if record.get("id") != capability_id:
         raise CapabilityError("capability record identity mismatch")
     if require_active:
-        active_id = _read_protected(
+        # An explicit revocation always wins.  Supersession does not: a relaunch
+        # replaces the active pointer of an equally-named instance, and the work
+        # the previous boot already enqueued is still authentic, still signed by
+        # a record that is still unexpired, and must still reach the board.
+        if _is_revoked(revoked, capability_id):
+            raise CapabilityError("producer capability was revoked")
+        # The pointer must still exist and be readable.  A cleared pointer with
+        # no tombstone is either a pre-tombstone revocation or a tampered state
+        # directory; neither proves this capability survived, so fail closed.
+        # Which id the pointer names no longer matters -- that only records
+        # which boot minted last, and the unexpired lease below is the bound
+        # that keeps a superseded producer from publishing indefinitely.
+        _read_protected(
             active / (_active_key(record) + ".id"), "active capability", 256
         )
-        if active_id.decode("ascii", errors="strict").strip() != capability_id:
-            raise CapabilityError("producer capability was superseded by a newer launch")
         now = int(time.time())
         if isinstance(record.get("expiresAt"), bool) or int(record.get("expiresAt", 0)) <= now:
             raise CapabilityError("producer capability expired")
@@ -443,7 +495,7 @@ def revoke_task(repository: str, workspace: str, team: str, task: str) -> int:
     _safe_text(team, "team", 63)
     _safe_text(task, "taskId")
 
-    records, active = state_directories(repo)
+    records, active, revoked_dir = state_directories(repo)
     revoked = 0
     for pointer in sorted(active.iterdir(), key=lambda item: item.name):
         try:
@@ -483,6 +535,7 @@ def revoke_task(repository: str, workspace: str, team: str, task: str) -> int:
             and record.get("executionKind") == "task"
             and record.get("taskId") == task
         ):
+            _record_revocation(revoked_dir, capability_id)
             pointer.unlink()
             revoked += 1
     return revoked
@@ -501,7 +554,7 @@ def revoke_role(repository: str, workspace: str, team: str, role: str) -> int:
     if not ROLE.fullmatch(role):
         raise CapabilityError("invalid capability role")
 
-    records, active = state_directories(repo)
+    records, active, revoked_dir = state_directories(repo)
     revoked = 0
     for pointer in sorted(active.iterdir(), key=lambda item: item.name):
         try:
@@ -541,6 +594,7 @@ def revoke_role(repository: str, workspace: str, team: str, role: str) -> int:
             and record.get("executionKind") == "gate"
             and record.get("role") == role
         ):
+            _record_revocation(revoked_dir, capability_id)
             pointer.unlink()
             revoked += 1
     return revoked

--- a/bin/outbox_capability.py
+++ b/bin/outbox_capability.py
@@ -166,6 +166,44 @@ def _record_revocation(revoked: Path, capability_id: str) -> None:
     )
 
 
+def _revoke_matching_records(records: Path, revoked: Path, matches) -> None:
+    """Tombstone every capability ever minted for the identity being revoked.
+
+    An active pointer names only the newest capability, so revoking through it
+    would miss earlier ones that a relaunch had already superseded -- exactly
+    the capabilities most likely to be holding an undrained artifact. Records
+    are immutable and never deleted, so they are the complete set. A capability
+    minted after this call gets a fresh id that no tombstone names, which is
+    what lets a revoke-then-relaunch restart keep working.
+    """
+    try:
+        entries = sorted(records.iterdir(), key=lambda item: item.name)
+    except OSError as exc:
+        raise CapabilityError("cannot enumerate capability records: %s" % exc) from exc
+    for path in entries:
+        if not path.name.endswith(".json"):
+            continue
+        try:
+            info = path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise CapabilityError("cannot inspect capability record: %s" % exc) from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise CapabilityError("capability record is not a regular file")
+        try:
+            record = json.loads(_read_protected(path, "capability record"))
+        except (UnicodeError, ValueError) as exc:
+            raise CapabilityError("invalid capability record") from exc
+        if not isinstance(record, dict):
+            raise CapabilityError("invalid capability record")
+        capability_id = record.get("id")
+        if not isinstance(capability_id, str) or path.name != capability_id + ".json":
+            raise CapabilityError("capability record identity mismatch")
+        if matches(record):
+            _record_revocation(revoked, capability_id)
+
+
 def _is_revoked(revoked: Path, capability_id: str) -> bool:
     """Report whether an explicit revocation tombstone exists.
 
@@ -496,6 +534,17 @@ def revoke_task(repository: str, workspace: str, team: str, task: str) -> int:
     _safe_text(task, "taskId")
 
     records, active, revoked_dir = state_directories(repo)
+    _revoke_matching_records(
+        records,
+        revoked_dir,
+        lambda record: (
+            record.get("canonicalRepo") == str(repo)
+            and record.get("canonicalWorkspace") == str(workspace_real)
+            and record.get("team") == team
+            and record.get("executionKind") == "task"
+            and record.get("taskId") == task
+        ),
+    )
     revoked = 0
     for pointer in sorted(active.iterdir(), key=lambda item: item.name):
         try:
@@ -555,6 +604,17 @@ def revoke_role(repository: str, workspace: str, team: str, role: str) -> int:
         raise CapabilityError("invalid capability role")
 
     records, active, revoked_dir = state_directories(repo)
+    _revoke_matching_records(
+        records,
+        revoked_dir,
+        lambda record: (
+            record.get("canonicalRepo") == str(repo)
+            and record.get("canonicalWorkspace") == str(workspace_real)
+            and record.get("team") == team
+            and record.get("executionKind") == "gate"
+            and record.get("role") == role
+        ),
+    )
     revoked = 0
     for pointer in sorted(active.iterdir(), key=lambda item: item.name):
         try:

--- a/bin/outbox_capability.py
+++ b/bin/outbox_capability.py
@@ -183,23 +183,26 @@ def _revoke_matching_records(records: Path, revoked: Path, matches) -> None:
     for path in entries:
         if not path.name.endswith(".json"):
             continue
+        # An individual unreadable record must not abort the revocation.  This
+        # directory is append-only for the life of the repository, so one
+        # truncated record -- what a crash during mint() leaves behind -- would
+        # otherwise permanently break every revoke, and with it the
+        # revoke-then-relaunch restart path for every role and team sharing the
+        # repository.  Skipping is safe rather than lenient: verification reads
+        # the same record through the same helper, so a record that cannot be
+        # read here cannot authenticate anything there either.
         try:
             info = path.lstat()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            raise CapabilityError("cannot inspect capability record: %s" % exc) from exc
-        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
-            raise CapabilityError("capability record is not a regular file")
-        try:
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+                continue
             record = json.loads(_read_protected(path, "capability record"))
-        except (UnicodeError, ValueError) as exc:
-            raise CapabilityError("invalid capability record") from exc
+        except (CapabilityError, OSError, UnicodeError, ValueError):
+            continue
         if not isinstance(record, dict):
-            raise CapabilityError("invalid capability record")
+            continue
         capability_id = record.get("id")
         if not isinstance(capability_id, str) or path.name != capability_id + ".json":
-            raise CapabilityError("capability record identity mismatch")
+            continue
         if matches(record):
             _record_revocation(revoked, capability_id)
 

--- a/bin/pm-agent.py
+++ b/bin/pm-agent.py
@@ -57,7 +57,26 @@ HEALTH_SNAPSHOT_KEYS = {
     "presentationOnly",
     "nonAgentProcessesOmitted",
     "agents",
+    "boards",
     "warnings",
+}
+HEALTH_BOARD_SCHEMA = "board-status-v1"
+HEALTH_BOARD_VERDICTS = {"WORKING", "IDLE", "STALLED", "DRAINED"}
+HEALTH_BOARD_KEYS = {
+    "schemaVersion",
+    "team",
+    "verdict",
+    "queued",
+    "working",
+    "review",
+    "blocked",
+    "outstanding",
+    "undrainedArtifacts",
+    "liveAgents",
+    "lastPassAt",
+    "secondsSinceLastPass",
+    "idleMinutes",
+    "presentationOnly",
 }
 HEALTH_ROW_KEYS = {
     "team",
@@ -660,6 +679,34 @@ def validate_health_snapshot(
         parse_health_time(row["updatedAt"], "agent updatedAt")
         if row.get("nextActionBy") is not None:
             parse_health_time(row["nextActionBy"], "agent nextActionBy")
+    boards = value.get("boards")
+    if not isinstance(boards, list):
+        raise MonitorError("health snapshot boards must be a list")
+    for board in boards:
+        if not isinstance(board, dict) or set(board) != HEALTH_BOARD_KEYS:
+            raise MonitorError("health snapshot contains an unsupported board row")
+        if board.get("schemaVersion") != HEALTH_BOARD_SCHEMA:
+            raise MonitorError("health snapshot board uses an unsupported schema")
+        if not isinstance(board.get("team"), str) or not board["team"]:
+            raise MonitorError("health snapshot board team must be a non-empty string")
+        if board.get("verdict") not in HEALTH_BOARD_VERDICTS:
+            raise MonitorError("health snapshot board verdict is unsupported")
+        if board.get("presentationOnly") is not True:
+            raise MonitorError("health snapshot board must remain presentation-only")
+        for field in (
+            "queued", "working", "review", "blocked", "outstanding",
+            "undrainedArtifacts", "liveAgents", "idleMinutes",
+        ):
+            if type(board.get(field)) is not int or board[field] < 0:
+                raise MonitorError(f"health snapshot board {field} must be a non-negative integer")
+        since = board.get("secondsSinceLastPass")
+        if since is not None and (type(since) is not int or since < 0):
+            raise MonitorError("health snapshot board pass age must be non-negative or null")
+        last_pass = board.get("lastPassAt")
+        if last_pass is not None:
+            parse_health_time(last_pass, "board lastPassAt")
+        if (last_pass is None) != (since is None):
+            raise MonitorError("health snapshot board pass age does not match its timestamp")
     generated_at = parse_health_time(value.get("generatedAt"), "generatedAt")
     earliest = started_at.astimezone(timezone.utc) - timedelta(seconds=1)
     latest = finished_at.astimezone(timezone.utc) + timedelta(seconds=1)

--- a/bin/pm-agent.py
+++ b/bin/pm-agent.py
@@ -73,6 +73,7 @@ HEALTH_BOARD_KEYS = {
     "outstanding",
     "undrainedArtifacts",
     "liveAgents",
+    "stalledAgents",
     "lastPassAt",
     "secondsSinceLastPass",
     "idleMinutes",
@@ -695,7 +696,7 @@ def validate_health_snapshot(
             raise MonitorError("health snapshot board must remain presentation-only")
         for field in (
             "queued", "working", "review", "blocked", "outstanding",
-            "undrainedArtifacts", "liveAgents", "idleMinutes",
+            "undrainedArtifacts", "liveAgents", "stalledAgents", "idleMinutes",
         ):
             if type(board.get(field)) is not int or board[field] < 0:
                 raise MonitorError(f"health snapshot board {field} must be a non-negative integer")

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -19,6 +19,7 @@
 #                                                                            # idempotent [DENIED ACTION] audit comment
 #   tracker-ops.sh integrate      <taskId> <hash> [bodyfile]                # terminal move + completion comment citing <hash>
 #   tracker-ops.sh probe          <featureId>                               # minimal read proving access + feature scope
+#   tracker-ops.sh change-token   <featureId>                               # read-side: cheap token that moves when the [feature] changes
 #   tracker-ops.sh export         <featureId> <outfile>                     # read-side: dump the [feature]'s [tasks] as JSON
 #   tracker-ops.sh scan           <outfile> --status <Status>...            # board-wide normalized discovery
 #   tracker-ops.sh feature-state  <featureId> <Status>                      # set [feature] status (generic name)
@@ -526,6 +527,58 @@ class Linear:
         observed = (data.get('project') or {}).get('id')
         if observed != project_id:
             die("no Linear project '%s' — andon" % feature_id)
+
+    def change_token(self, feature_id):
+        # Two requests, independent of [task] count, versus the hundreds a full
+        # export costs. The token is a high-water mark over everything the
+        # export reads: the project itself, the most recently updated issue
+        # (archived included, so trashing one still moves the mark), and the
+        # most recently updated comment.
+        #
+        # A high-water mark cannot prove a hard delete, which removes a row
+        # without moving any surviving row's timestamp. That is why the caller
+        # must also refresh on a bounded interval: a token this misses delays
+        # an export, it does not cancel it. Anything unreadable returns None,
+        # which forces the exhaustive export rather than a false "nothing
+        # moved".
+        project_id = self.project_id(feature_id)
+        issues = self.gql('''query($id: String!) {
+          project(id: $id) {
+            updatedAt
+            issues(first: 1, orderBy: updatedAt, includeArchived: true) {
+              nodes { updatedAt }
+              pageInfo { hasNextPage }
+            }
+          }
+        }''', {'id': project_id})
+        project = (issues.get('project') or {}) if isinstance(issues, dict) else {}
+        connection = project.get('issues') or {}
+        nodes = connection.get('nodes')
+        if not isinstance(nodes, list):
+            return None
+        issue_mark = (nodes[0] or {}).get('updatedAt') if nodes else ''
+        comments = self.gql('''query($id: ID!) {
+          comments(
+            filter: { project: { id: { eq: $id } } }
+            orderBy: updatedAt
+            first: 1
+          ) {
+            nodes { updatedAt }
+          }
+        }''', {'id': project_id})
+        comment_nodes = ((comments.get('comments') or {}).get('nodes')
+                         if isinstance(comments, dict) else None)
+        if not isinstance(comment_nodes, list):
+            return None
+        comment_mark = (comment_nodes[0] or {}).get('updatedAt') if comment_nodes else ''
+        if not isinstance(issue_mark, (str, type(None))) or not isinstance(
+                comment_mark, (str, type(None))):
+            return None
+        return 'linear:' + hashlib.sha256(json.dumps({
+            'project': project.get('updatedAt') or '',
+            'issue': issue_mark or '',
+            'comment': comment_mark or '',
+        }, sort_keys=True).encode('utf-8')).hexdigest()
 
     @staticmethod
     def mutation_payload(data, key, action):
@@ -1851,6 +1904,12 @@ class Markdown:
         if not re.search(r'^# .*?\[[^\]]+\][ \t]*$', text, re.M):
             die("Markdown feature has no bracketed status: %s" % feature_id)
 
+    def change_token(self, feature_id):
+        # The whole board is one file, so the token is exact: any edit the
+        # export could observe changes the digest.
+        return 'sha256:' + hashlib.sha256(
+            self.load(feature_id).encode('utf-8')).hexdigest()
+
     def save(self, feature_id, text):
         directory_fd = temp_fd = None
         temp_name = None
@@ -2261,6 +2320,25 @@ def op_probe(args):
             die("adapter returned a malformed feature probe — andon")
     print("probe OK: %s" % feature_id)
 
+def op_change_token(args):
+    if len(args) != 1:
+        die("usage: change-token <featureId>")
+    feature_id = args[0]
+    resolver = getattr(backend, 'change_token', None)
+    if not callable(resolver):
+        # Adapters that cannot prove "nothing moved" simply do not offer a
+        # token, and every caller falls back to the exhaustive export.
+        print("")
+        return
+    token = resolver(feature_id)
+    if token is None:
+        print("")
+        return
+    if not isinstance(token, str) or not token or len(token) > 512 or any(
+            ord(character) < 32 for character in token):
+        die("adapter returned a malformed change token — andon")
+    print(token)
+
 def op_state(args):
     if len(args) != 2:
         die("usage: state <taskId> <Status>")
@@ -2659,13 +2737,13 @@ def op_scan(args):
         os.replace(temp, outfile)
         print("scanned %d [tasks] (%d orphaned) to %s" % (len(normalized), len(orphans), outfile))
 
-OPS = {'probe': op_probe, 'state': op_state, 'comment': op_comment, 'comment-once': op_comment_once, 'update-comment': op_update_comment,
+OPS = {'probe': op_probe, 'change-token': op_change_token, 'state': op_state, 'comment': op_comment, 'comment-once': op_comment_once, 'update-comment': op_update_comment,
        'upsert-progress': op_upsert_progress, 'upsert-digest': op_upsert_digest,
        'upsert-deployment': op_upsert_deployment, 'feature-state': op_feature_state,
        'feature-reopen': op_feature_reopen, 'task-reopen': op_task_reopen,
        'claim': op_claim, 'record-denial': op_record_denial, 'integrate': op_integrate,
        'export': op_export, 'scan': op_scan}
 if not ARGS or ARGS[0] not in OPS:
-    die("usage: tracker-ops.sh {probe|state|feature-state|feature-reopen|task-reopen|comment|comment-once|update-comment|upsert-progress|upsert-digest|upsert-deployment|claim|record-denial|integrate|export|scan} ...")
+    die("usage: tracker-ops.sh {probe|change-token|state|feature-state|feature-reopen|task-reopen|comment|comment-once|update-comment|upsert-progress|upsert-digest|upsert-deployment|claim|record-denial|integrate|export|scan} ...")
 OPS[ARGS[0]](ARGS[1:])
 PYEOF

--- a/bin/tracker-ops.sh
+++ b/bin/tracker-ops.sh
@@ -528,6 +528,31 @@ class Linear:
         if observed != project_id:
             die("no Linear project '%s' — andon" % feature_id)
 
+    @staticmethod
+    def high_water_mark(nodes):
+        """Newest updatedAt in a connection ordered newest-first, or None.
+
+        `orderBy: updatedAt` is asked for and then *checked* rather than
+        trusted: two nodes are fetched, and if the first is not at least as
+        recent as the second the connection is not newest-first and the mark
+        would silently freeze. Returning None there costs a full export, which
+        is the safe direction. An empty connection has no mark but is still a
+        valid answer, so it reports the empty string rather than None.
+        """
+        if not isinstance(nodes, list):
+            return None
+        marks = []
+        for node in nodes[:2]:
+            value = (node or {}).get('updatedAt') if isinstance(node, dict) else None
+            if value is not None and not isinstance(value, str):
+                return None
+            marks.append(value or '')
+        if not marks:
+            return ''
+        if len(marks) > 1 and marks[0] < marks[1]:
+            return None
+        return marks[0]
+
     def change_token(self, feature_id):
         # Two requests, independent of [task] count, versus the hundreds a full
         # export costs. The token is a high-water mark over everything the
@@ -538,14 +563,14 @@ class Linear:
         # A high-water mark cannot prove a hard delete, which removes a row
         # without moving any surviving row's timestamp. That is why the caller
         # must also refresh on a bounded interval: a token this misses delays
-        # an export, it does not cancel it. Anything unreadable returns None,
-        # which forces the exhaustive export rather than a false "nothing
-        # moved".
+        # an export, it does not cancel it. Anything unreadable, or any
+        # connection that does not come back newest-first, returns None, which
+        # forces the exhaustive export rather than a false "nothing moved".
         project_id = self.project_id(feature_id)
         issues = self.gql('''query($id: String!) {
           project(id: $id) {
             updatedAt
-            issues(first: 1, orderBy: updatedAt, includeArchived: true) {
+            issues(first: 2, orderBy: updatedAt, includeArchived: true) {
               nodes { updatedAt }
               pageInfo { hasNextPage }
             }
@@ -553,26 +578,22 @@ class Linear:
         }''', {'id': project_id})
         project = (issues.get('project') or {}) if isinstance(issues, dict) else {}
         connection = project.get('issues') or {}
-        nodes = connection.get('nodes')
-        if not isinstance(nodes, list):
+        issue_mark = self.high_water_mark(connection.get('nodes'))
+        if issue_mark is None:
             return None
-        issue_mark = (nodes[0] or {}).get('updatedAt') if nodes else ''
         comments = self.gql('''query($id: ID!) {
           comments(
             filter: { project: { id: { eq: $id } } }
             orderBy: updatedAt
-            first: 1
+            first: 2
           ) {
             nodes { updatedAt }
           }
         }''', {'id': project_id})
-        comment_nodes = ((comments.get('comments') or {}).get('nodes')
-                         if isinstance(comments, dict) else None)
-        if not isinstance(comment_nodes, list):
-            return None
-        comment_mark = (comment_nodes[0] or {}).get('updatedAt') if comment_nodes else ''
-        if not isinstance(issue_mark, (str, type(None))) or not isinstance(
-                comment_mark, (str, type(None))):
+        comment_mark = self.high_water_mark(
+            (comments.get('comments') or {}).get('nodes')
+            if isinstance(comments, dict) else None)
+        if comment_mark is None:
             return None
         return 'linear:' + hashlib.sha256(json.dumps({
             'project': project.get('updatedAt') or '',

--- a/bin/update-installed-skill.sh
+++ b/bin/update-installed-skill.sh
@@ -683,6 +683,7 @@ for required_file in \
   adapters/Markdown.md \
   bin/dispatch.sh \
   bin/agent-health.py \
+  bin/board-status.py \
   bin/heartbeat-status.py \
   bin/launch-team.sh \
   bin/process-lifecycle.py \

--- a/config/team.config.md
+++ b/config/team.config.md
@@ -80,6 +80,11 @@ AGENT_SANDBOX_HOME=null          # Optional absolute mode-0700 directory outside
 DOCTOR_TIMEOUT_SECONDS=60        # Per distinct configured command. team/gate-team runs one
                                  # non-mutating prompt/auth round trip before launching any role.
 POLL_INTERVAL_SECONDS=120        # Fallback only; local runtime events wake dispatch within ~1s
+EXPORT_MAX_REUSE_SECONDS=900     # Longest a dispatch pass may reuse the cached [feature] export when
+                                 # the adapter reports the tracker unchanged. A full export always
+                                 # runs once this elapses, so a change token that misses an edit
+                                 # delays an export rather than cancelling one. Adapters without a
+                                 # change token export every pass regardless.
 STUCK_AFTER_MINUTES=15           # Lead treats silence longer than this as "stuck"
 ESCALATE_AFTER_ATTEMPTS=2        # Failed unblock attempts before the Lead escalates to the human
 TURBO_MODE=off                   # off|safe. Safe is a fail-closed readiness profile; it never

--- a/packaging/bundle-spec.json
+++ b/packaging/bundle-spec.json
@@ -43,6 +43,7 @@
     "bin/delivery_profile.py",
     "bin/evidence_provider.py",
     "bin/agent-health.py",
+    "bin/board-status.py",
     "bin/heartbeat-status.py",
     "bin/process-lifecycle.py",
     "bin/teamwork-path.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.18"
+version = "0.1.20"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/reference/dispatch.md
+++ b/reference/dispatch.md
@@ -31,10 +31,16 @@ exhaust an hourly hosted-tracker budget without any work having changed — whic
 is how an affordable-looking mechanism becomes unusable and operators fall back
 to invisible manual dispatch.
 
-A pass therefore asks the adapter for a **change token** first
+A pass therefore asks the adapter for a **change token**
 (`tracker-ops.sh change-token <featureId>`) and reuses the cached export when
-the token has not moved. An idle pass costs a couple of requests instead of
-hundreds.
+the token has not moved.
+
+A pass reads the board **twice** — once before planning and once after the
+brokers run, to close the observation race their writes create. Both reads go
+through the same rule, which matters: gating only the first would leave every
+idle cycle paying full price for the second, and halve the cost rather than
+remove it. Anything a broker publishes is itself a tracker write, so it moves
+the token and the second read exports for real.
 
 The contract on that token is the important part:
 

--- a/reference/dispatch.md
+++ b/reference/dispatch.md
@@ -23,6 +23,51 @@ before any status write, outbox processing, integration, or launch.
 owns that process**, explicitly. Hiding this ownership is how a pipeline
 silently stalls for hours.
 
+## What an idle pass costs
+
+The [feature] export dominates a pass. On a [feature] with hundreds of [tasks]
+it is hundreds of tracker requests, so a watch loop at the default cadence can
+exhaust an hourly hosted-tracker budget without any work having changed — which
+is how an affordable-looking mechanism becomes unusable and operators fall back
+to invisible manual dispatch.
+
+A pass therefore asks the adapter for a **change token** first
+(`tracker-ops.sh change-token <featureId>`) and reuses the cached export when
+the token has not moved. An idle pass costs a couple of requests instead of
+hundreds.
+
+The contract on that token is the important part:
+
+- It must move whenever anything the export reads moves. An adapter that cannot
+  promise this must not implement `change_token` at all; absence degrades to a
+  full export every pass, never to a false "nothing moved".
+- Reuse is bounded by `EXPORT_MAX_REUSE_SECONDS` (default 900). A full export
+  runs once that elapses regardless of the token, so a token that misses an edit
+  delays an export rather than cancelling one.
+- The token is recorded only after a successful export, so a failed export
+  cannot leave a token claiming the cached snapshot is current.
+
+Shipped support: Markdown (exact, a digest of the single board file) and Linear
+(a high-water mark over the project, its most recently updated issue including
+archived ones, and its most recently updated comment). Jira and GitHub Issues
+export every pass.
+
+## Seeing a stalled board
+
+Every role reaching `exited` is the normal end of a pass, so per-role health
+cannot distinguish a board that finished cleanly from one nobody is driving.
+`launch-team.sh health` adds one board-level line per team:
+
+```
+factory-one: STALLED — 2 queued tasks, 4 undrained artifacts, last pass 31m ago
+```
+
+`STALLED` means outstanding work, no live agent, and no dispatch pass in the
+last 15 minutes. `IDLE` is the same without the elapsed-time evidence,
+`WORKING` has live agents, and `DRAINED` is the quiet, healthy end of a run.
+Each completed non-dry pass records its time in `dispatch.last-pass`, which is
+the evidence the verdict rests on. All of it is presentation only.
+
 ## The event table
 
 One pass reads the [feature]'s task export, the team mailboxes, and the

--- a/reference/dispatch.md
+++ b/reference/dispatch.md
@@ -39,8 +39,14 @@ A pass reads the board **twice** — once before planning and once after the
 brokers run, to close the observation race their writes create. Both reads go
 through the same rule, which matters: gating only the first would leave every
 idle cycle paying full price for the second, and halve the cost rather than
-remove it. Anything a broker publishes is itself a tracker write, so it moves
-the token and the second read exports for real.
+remove it.
+
+The second read has one extra rule. When either broker had queued work, it
+exports unconditionally rather than consulting the token, because those writes
+are the pass's own and a hosted tracker does not promise that a read
+microseconds later already reflects them. Trusting the token there could plan
+on a snapshot missing the verdict just published. When the brokers had nothing
+queued they wrote nothing, and the token rules as it does at the top.
 
 The contract on that token is the important part:
 

--- a/tests/board-status-test.py
+++ b/tests/board-status-test.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 import tempfile
 import unittest
@@ -130,6 +131,16 @@ class SummarizeTest(unittest.TestCase):
         summary = self.summarize(counts=counts(working=1), live_agents=1)
         self.assertEqual(summary["verdict"], "WORKING")
 
+    def test_a_live_agent_outranks_an_all_blocked_board(self) -> None:
+        """DRAINED must not hide a running agent.
+
+        Ordering DRAINED first would report the quiet end of a run while an
+        agent is demonstrably alive, which is the same false-all-clear shape
+        the stalled-agent and orphaned-task cases above pin.
+        """
+        summary = self.summarize(counts=counts(blocked=5), live_agents=1)
+        self.assertEqual(summary["verdict"], "WORKING")
+
     def test_the_idle_threshold_is_configurable(self) -> None:
         """A pass age between the custom and default thresholds must flip."""
         arguments = {"counts": counts(queued=1), "last_pass": NOW - timedelta(minutes=8)}
@@ -160,6 +171,58 @@ class SummarizeTest(unittest.TestCase):
         )
 
 
+class VerdictContractTest(unittest.TestCase):
+    """agent-health classifies verdicts by a naming convention across files.
+
+    Nothing in the language enforces that every non-progressing verdict
+    heartbeat-status.py adds keeps the "stalled:" prefix, so this pins the
+    convention itself: a future verdict that breaks it fails here instead of
+    silently making a stuck board look alive.
+    """
+
+    PROGRESSING = {"starting", "active"}
+    SOURCES = ("heartbeat-status.py", "agent-health.py", "pm-agent.py")
+
+    def emitted_verdicts(self) -> set[str]:
+        """Every verdict literal the health pipeline can produce.
+
+        Scanned line-wise rather than by assignment, because verdicts are also
+        produced from ternaries and dict literals that an assignment-shaped
+        pattern silently misses.
+        """
+        found: set[str] = set()
+        for name in self.SOURCES:
+            text = (ROOT / "bin" / name).read_text(encoding="utf-8")
+            found |= set(re.findall(r'"(stalled:[a-z-]+)"', text))
+            for line in text.splitlines():
+                # Only the right-hand side of a verdict assignment, so that a
+                # neighbouring dict key on the same line is not mistaken for a
+                # verdict value.
+                match = re.search(r'"?verdict"?\s*[=:]\s*(.*)$', line)
+                if match:
+                    found |= set(re.findall(r'"([a-z][a-z:-]{2,})"', match.group(1)))
+        return found - {"verdict"}
+
+    def test_every_emitted_verdict_is_classifiable(self) -> None:
+        agent_health = load("startup_factory_agent_health_contract", "agent-health.py")
+        emitted = self.emitted_verdicts()
+        self.assertGreaterEqual(
+            len({v for v in emitted if v.startswith("stalled:")}), 9,
+            "expected the known stalled verdicts to be discovered; the scan "
+            "found %r" % sorted(emitted),
+        )
+        for verdict in sorted(emitted):
+            with self.subTest(verdict=verdict):
+                absent = verdict in agent_health.ABSENT_VERDICTS
+                stalled = verdict.split(":", 1)[0] == agent_health.STALLED_PREFIX
+                progressing = verdict in self.PROGRESSING
+                self.assertTrue(
+                    absent or stalled or progressing,
+                    "%s is neither absent, stalled:*, nor a known progressing "
+                    "verdict; board status would count it as live" % verdict,
+                )
+
+
 class BoardLineTest(unittest.TestCase):
     def test_the_operator_line_names_work_artifacts_and_pass_age(self) -> None:
         summary = board_status.summarize(
@@ -184,6 +247,18 @@ class BoardLineTest(unittest.TestCase):
         )
         self.assertIn("1 queued task,", board_status.board_line(summary))
         self.assertIn("1 undrained artifact,", board_status.board_line(summary))
+
+    def test_the_line_names_live_and_stalled_agents(self) -> None:
+        """The verdict alone cannot tell an operator what is alive."""
+        working = board_status.summarize(
+            counts=counts(blocked=5), pending=0, last_pass=NOW, live_agents=1, now=NOW
+        )
+        self.assertIn("1 live agent", board_status.board_line(working))
+        stalled = board_status.summarize(
+            counts=counts(queued=1), pending=0, last_pass=NOW,
+            live_agents=0, stalled_agents=2, now=NOW,
+        )
+        self.assertIn("2 stalled agents", board_status.board_line(stalled))
 
     def test_a_board_with_no_recorded_pass_says_so(self) -> None:
         summary = board_status.summarize(

--- a/tests/board-status-test.py
+++ b/tests/board-status-test.py
@@ -109,6 +109,27 @@ class SummarizeTest(unittest.TestCase):
     def test_the_summary_stays_presentation_only(self) -> None:
         self.assertIs(self.summarize()["presentationOnly"], True)
 
+    def test_only_stalled_agents_is_not_working(self) -> None:
+        """A false all-clear: agents present, none of them progressing."""
+        summary = self.summarize(
+            counts=counts(queued=3),
+            live_agents=0,
+            stalled_agents=1,
+            last_pass=NOW,
+        )
+        self.assertEqual(summary["verdict"], "STALLED")
+
+    def test_an_orphaned_in_flight_task_is_not_drained(self) -> None:
+        """A false all-clear: a working [task] whose worker already exited."""
+        summary = self.summarize(
+            counts=counts(working=1), last_pass=NOW - timedelta(days=3)
+        )
+        self.assertEqual(summary["verdict"], "STALLED")
+
+    def test_an_in_flight_task_with_a_healthy_agent_is_working(self) -> None:
+        summary = self.summarize(counts=counts(working=1), live_agents=1)
+        self.assertEqual(summary["verdict"], "WORKING")
+
     def test_the_idle_threshold_is_configurable(self) -> None:
         """A pass age between the custom and default thresholds must flip."""
         arguments = {"counts": counts(queued=1), "last_pass": NOW - timedelta(minutes=8)}

--- a/tests/board-status-test.py
+++ b/tests/board-status-test.py
@@ -109,6 +109,35 @@ class SummarizeTest(unittest.TestCase):
     def test_the_summary_stays_presentation_only(self) -> None:
         self.assertIs(self.summarize()["presentationOnly"], True)
 
+    def test_the_idle_threshold_is_configurable(self) -> None:
+        """A pass age between the custom and default thresholds must flip."""
+        arguments = {"counts": counts(queued=1), "last_pass": NOW - timedelta(minutes=8)}
+        self.assertEqual(self.summarize(**arguments)["verdict"], "IDLE")
+        self.assertEqual(
+            self.summarize(idle_minutes=5, **arguments)["verdict"], "STALLED"
+        )
+
+    def test_the_configured_threshold_is_reported_back(self) -> None:
+        self.assertEqual(self.summarize(idle_minutes=5)["idleMinutes"], 5)
+
+    def test_a_zero_idle_threshold_is_refused(self) -> None:
+        with self.assertRaises(board_status.BoardStatusError):
+            self.summarize(idle_minutes=0)
+
+    def test_the_threshold_is_inclusive_at_its_exact_boundary(self) -> None:
+        """Pins >= rather than >, so the boundary cannot drift unnoticed."""
+        arguments = {"counts": counts(queued=1)}
+        self.assertEqual(
+            self.summarize(last_pass=NOW - timedelta(minutes=15), **arguments)["verdict"],
+            "STALLED",
+        )
+        self.assertEqual(
+            self.summarize(
+                last_pass=NOW - timedelta(seconds=15 * 60 - 1), **arguments
+            )["verdict"],
+            "IDLE",
+        )
+
 
 class BoardLineTest(unittest.TestCase):
     def test_the_operator_line_names_work_artifacts_and_pass_age(self) -> None:

--- a/tests/board-status-test.py
+++ b/tests/board-status-test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Black-box tests for board-level idle and stall reporting.
+
+Every role reaching `exited` is the normal end of a dispatch pass, so per-role
+health cannot separate a board that finished from one nobody is driving.  These
+tests pin that distinction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "bin" / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+board_status = load("startup_factory_board_status", "board-status.py")
+
+NOW = datetime(2026, 9, 2, 12, 0, 0, tzinfo=timezone.utc)
+BOARD = json.loads((ROOT / "config" / "statuses.config.json").read_text(encoding="utf-8"))
+
+
+def counts(queued: int = 0, working: int = 0, review: int = 0, blocked: int = 0) -> dict:
+    return {"queued": queued, "working": working, "review": review, "blocked": blocked}
+
+
+class SummarizeTest(unittest.TestCase):
+    def summarize(self, **changes):
+        arguments = {
+            "counts": counts(),
+            "pending": 0,
+            "last_pass": NOW,
+            "live_agents": 0,
+            "now": NOW,
+        }
+        arguments.update(changes)
+        return board_status.summarize(**arguments)
+
+    def test_live_agents_mean_the_board_is_working(self) -> None:
+        summary = self.summarize(counts=counts(queued=2), live_agents=1)
+        self.assertEqual(summary["verdict"], "WORKING")
+
+    def test_no_work_and_no_agents_is_drained_not_stalled(self) -> None:
+        """The normal, healthy end of a run must not raise an alarm."""
+        summary = self.summarize(last_pass=NOW - timedelta(hours=3))
+        self.assertEqual(summary["verdict"], "DRAINED")
+
+    def test_outstanding_work_with_no_agents_and_a_stale_pass_is_stalled(self) -> None:
+        summary = self.summarize(
+            counts=counts(queued=2),
+            pending=4,
+            last_pass=NOW - timedelta(minutes=31),
+        )
+        self.assertEqual(summary["verdict"], "STALLED")
+        self.assertEqual(summary["outstanding"], 2)
+        self.assertEqual(summary["undrainedArtifacts"], 4)
+        self.assertEqual(summary["secondsSinceLastPass"], 31 * 60)
+
+    def test_outstanding_work_with_a_recent_pass_is_idle_not_stalled(self) -> None:
+        summary = self.summarize(
+            counts=counts(queued=2), last_pass=NOW - timedelta(minutes=2)
+        )
+        self.assertEqual(summary["verdict"], "IDLE")
+
+    def test_undrained_artifacts_alone_can_stall_a_board(self) -> None:
+        """Verdicts waiting to publish are outstanding work even with no tasks."""
+        summary = self.summarize(pending=3, last_pass=NOW - timedelta(minutes=45))
+        self.assertEqual(summary["verdict"], "STALLED")
+
+    def test_a_board_that_never_dispatched_is_stalled_when_work_waits(self) -> None:
+        summary = self.summarize(counts=counts(review=1), last_pass=None)
+        self.assertEqual(summary["verdict"], "STALLED")
+        self.assertIsNone(summary["lastPassAt"])
+        self.assertIsNone(summary["secondsSinceLastPass"])
+
+    def test_review_work_counts_as_outstanding(self) -> None:
+        summary = self.summarize(
+            counts=counts(review=2), last_pass=NOW - timedelta(minutes=40)
+        )
+        self.assertEqual(summary["outstanding"], 2)
+        self.assertEqual(summary["verdict"], "STALLED")
+
+    def test_blocked_work_alone_does_not_stall_a_board(self) -> None:
+        """Blocked tasks are waiting on a human, not on dispatch."""
+        summary = self.summarize(
+            counts=counts(blocked=5), last_pass=NOW - timedelta(hours=2)
+        )
+        self.assertEqual(summary["verdict"], "DRAINED")
+
+    def test_a_clock_skewed_pass_never_reports_negative_age(self) -> None:
+        summary = self.summarize(
+            counts=counts(queued=1), last_pass=NOW + timedelta(minutes=5)
+        )
+        self.assertEqual(summary["secondsSinceLastPass"], 0)
+
+    def test_the_summary_stays_presentation_only(self) -> None:
+        self.assertIs(self.summarize()["presentationOnly"], True)
+
+
+class BoardLineTest(unittest.TestCase):
+    def test_the_operator_line_names_work_artifacts_and_pass_age(self) -> None:
+        summary = board_status.summarize(
+            counts=counts(queued=2),
+            pending=4,
+            last_pass=NOW - timedelta(minutes=31),
+            live_agents=0,
+            now=NOW,
+        )
+        self.assertEqual(
+            board_status.board_line(summary),
+            "STALLED — 2 queued tasks, 4 undrained artifacts, last pass 31m ago",
+        )
+
+    def test_singulars_read_correctly(self) -> None:
+        summary = board_status.summarize(
+            counts=counts(queued=1),
+            pending=1,
+            last_pass=NOW - timedelta(minutes=31),
+            live_agents=0,
+            now=NOW,
+        )
+        self.assertIn("1 queued task,", board_status.board_line(summary))
+        self.assertIn("1 undrained artifact,", board_status.board_line(summary))
+
+    def test_a_board_with_no_recorded_pass_says_so(self) -> None:
+        summary = board_status.summarize(
+            counts=counts(queued=1), pending=0, last_pass=None, live_agents=0, now=NOW
+        )
+        self.assertIn("no dispatch pass recorded", board_status.board_line(summary))
+
+
+class CollectTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temporary.name).resolve()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_tasks(self, statuses: list[str]) -> None:
+        (self.workspace / "tasks.json").write_text(
+            json.dumps(
+                {
+                    "tasks": [
+                        {"taskId": "TASK-%d" % index, "status": status}
+                        for index, status in enumerate(statuses, start=1)
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def collect(self, **changes):
+        arguments = {
+            "workspace": self.workspace,
+            "board": BOARD,
+            "live_agents": 0,
+            "now": NOW,
+        }
+        arguments.update(changes)
+        return board_status.collect(**arguments)
+
+    def test_an_empty_workspace_is_drained_not_an_error(self) -> None:
+        self.assertEqual(self.collect()["verdict"], "DRAINED")
+
+    def test_counts_come_from_the_configured_status_names(self) -> None:
+        self.write_tasks(["Planned", "Planned", "Review", "Active", "Blocked"])
+        summary = self.collect()
+        self.assertEqual(summary["queued"], 2)
+        self.assertEqual(summary["review"], 1)
+        self.assertEqual(summary["working"], 1)
+        self.assertEqual(summary["blocked"], 1)
+
+    def test_pending_artifacts_are_counted_from_the_outbox(self) -> None:
+        pending = self.workspace / "outbox" / "pending"
+        pending.mkdir(parents=True)
+        for index in range(3):
+            (pending / ("entry-%d.json" % index)).write_text("{}", encoding="utf-8")
+        (pending / ".hidden").write_text("{}", encoding="utf-8")
+        self.assertEqual(self.collect()["undrainedArtifacts"], 3)
+
+    def test_the_dispatch_marker_is_read_when_present(self) -> None:
+        (self.workspace / "dispatch.last-pass").write_text(
+            "2026-09-02T11:29:00Z\n", encoding="utf-8"
+        )
+        self.write_tasks(["Planned"])
+        summary = self.collect()
+        self.assertEqual(summary["secondsSinceLastPass"], 31 * 60)
+        self.assertEqual(summary["verdict"], "STALLED")
+
+    def test_a_malformed_dispatch_marker_is_refused_not_guessed(self) -> None:
+        (self.workspace / "dispatch.last-pass").write_text("yesterday\n", encoding="utf-8")
+        with self.assertRaises(board_status.BoardStatusError):
+            self.collect()
+
+    def test_a_malformed_snapshot_is_refused_not_guessed(self) -> None:
+        (self.workspace / "tasks.json").write_text("{not json", encoding="utf-8")
+        with self.assertRaises(board_status.BoardStatusError):
+            self.collect()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/dispatch-test.sh
+++ b/tests/dispatch-test.sh
@@ -328,6 +328,20 @@ if [ "$(cat .teamwork/feat-team/dispatch.export-at)" != "0" ]; then
 else
   echo "FAIL: reuse was not bounded by EXPORT_MAX_REUSE_SECONDS"; FAILURES=$((FAILURES+1))
 fi
+# Queued broker work forces the post-broker export. The brokers' writes are our
+# own, and a hosted tracker does not promise a read microseconds later reflects
+# them, so the token must not be allowed to vouch for that snapshot.
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1
+mkdir -p .teamwork/feat-team/outbox/pending
+echo '{}' > .teamwork/feat-team/outbox/pending/probe-entry.json
+echo 0 > .teamwork/feat-team/dispatch.export-at
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1 || true
+if [ "$(cat .teamwork/feat-team/dispatch.export-at)" != "0" ]; then
+  echo "ok: queued broker work forces a fresh post-broker export"
+else
+  echo "FAIL: pending broker work still reused a cached export"; FAILURES=$((FAILURES+1))
+fi
+rm -f .teamwork/feat-team/outbox/pending/probe-entry.json
 
 # -- agent-writable PID text is not a liveness authority -----------------------
 mkdir -p .teamwork/feat-team/pids

--- a/tests/dispatch-test.sh
+++ b/tests/dispatch-test.sh
@@ -292,6 +292,38 @@ check "PA queue in mailbox"          grep -rq "$FID#4" .teamwork/feat-team/mailb
 check "sceptical queue in mailbox"   grep -rq "$FID#4" .teamwork/feat-team/mailbox/sceptical-architect/
 check "security reviewer launched"   test -f .teamwork/feat-team/pids/senior-security-engineer.pid
 
+# -- idle passes reuse the cached export instead of re-reading the tracker -----
+# The export dominates a pass; re-reading an unchanged [feature] every cadence
+# is what exhausts a hosted tracker's request budget.
+check "first pass recorded a change token" test -s .teamwork/feat-team/dispatch.change-token
+check "first pass recorded a pass marker"  test -s .teamwork/feat-team/dispatch.last-pass
+# A pass that acts on the board also writes to it, so its own token is stale by
+# the time it is recorded. Settle first, then assert the next pass reuses.
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1
+reuse_out="$(TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once 2>&1)"
+if echo "$reuse_out" | grep -q "tracker unchanged; reusing the cached feature export"; then
+  echo "ok: unchanged tracker reuses the cached export"
+else
+  echo "FAIL: unchanged tracker still paid for a full export"; FAILURES=$((FAILURES+1))
+fi
+# A real edit must defeat the cache: a missed change would strand the work.
+printf '\n## 9 Fresh work [Planned]\n' >> "$FID"
+change_out="$(TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once 2>&1)"
+if echo "$change_out" | grep -q "tracker unchanged; reusing the cached feature export"; then
+  echo "FAIL: an edited [feature] was skipped as unchanged"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: an edited [feature] forces a fresh export"
+fi
+check "edited task reached the snapshot" grep -q "Fresh work" .teamwork/feat-team/tasks.json
+# An elapsed reuse window forces a full export even when the token has not moved.
+echo 0 > .teamwork/feat-team/dispatch.export-at
+stale_out="$(TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once 2>&1)"
+if echo "$stale_out" | grep -q "tracker unchanged; reusing the cached feature export"; then
+  echo "FAIL: reuse was not bounded by EXPORT_MAX_REUSE_SECONDS"; FAILURES=$((FAILURES+1))
+else
+  echo "ok: reuse is bounded even when the token has not moved"
+fi
+
 # -- agent-writable PID text is not a liveness authority -----------------------
 mkdir -p .teamwork/feat-team/pids
 echo $$ > .teamwork/feat-team/pids/senior-security-engineer.pid

--- a/tests/dispatch-test.sh
+++ b/tests/dispatch-test.sh
@@ -307,21 +307,26 @@ else
   echo "FAIL: unchanged tracker still paid for a full export"; FAILURES=$((FAILURES+1))
 fi
 # A real edit must defeat the cache: a missed change would strand the work.
+# A pass now refreshes twice (before planning and after the brokers), and the
+# second read legitimately reuses when the first just exported, so the evidence
+# of a full export is the stamp, not the log line.
+echo 0 > .teamwork/feat-team/dispatch.export-at
 printf '\n## 9 Fresh work [Planned]\n' >> "$FID"
-change_out="$(TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once 2>&1)"
-if echo "$change_out" | grep -q "tracker unchanged; reusing the cached feature export"; then
-  echo "FAIL: an edited [feature] was skipped as unchanged"; FAILURES=$((FAILURES+1))
-else
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1
+if [ "$(cat .teamwork/feat-team/dispatch.export-at)" != "0" ]; then
   echo "ok: an edited [feature] forces a fresh export"
+else
+  echo "FAIL: an edited [feature] was skipped as unchanged"; FAILURES=$((FAILURES+1))
 fi
 check "edited task reached the snapshot" grep -q "Fresh work" .teamwork/feat-team/tasks.json
 # An elapsed reuse window forces a full export even when the token has not moved.
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1
 echo 0 > .teamwork/feat-team/dispatch.export-at
-stale_out="$(TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once 2>&1)"
-if echo "$stale_out" | grep -q "tracker unchanged; reusing the cached feature export"; then
-  echo "FAIL: reuse was not bounded by EXPORT_MAX_REUSE_SECONDS"; FAILURES=$((FAILURES+1))
-else
+TEAM_RUNNER=background "$DISPATCH" feat-team "$FID" --once >/dev/null 2>&1
+if [ "$(cat .teamwork/feat-team/dispatch.export-at)" != "0" ]; then
   echo "ok: reuse is bounded even when the token has not moved"
+else
+  echo "FAIL: reuse was not bounded by EXPORT_MAX_REUSE_SECONDS"; FAILURES=$((FAILURES+1))
 fi
 
 # -- agent-writable PID text is not a liveness authority -----------------------

--- a/tests/outbox-capability-supersede-test.py
+++ b/tests/outbox-capability-supersede-test.py
@@ -231,6 +231,54 @@ class OutboxCapabilitySupersedeTest(unittest.TestCase):
             self.verify(payload, signature)
         self.assertIn("cannot read active capability", str(caught.exception))
 
+    def tombstones(self) -> Path:
+        return self.base / ".git" / "startup-factory-broker" / "outbox-revoked"
+
+    def test_a_group_readable_tombstone_is_treated_as_revoked(self) -> None:
+        """Revocation evidence that cannot be trusted must not let work publish."""
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        self.mint_gate()
+
+        marker = self.tombstones() / (capability["id"] + ".revoked")
+        marker.chmod(0o644)
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("owner-only", str(caught.exception))
+
+    def test_a_symlinked_tombstone_is_treated_as_revoked(self) -> None:
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        self.mint_gate()
+
+        marker = self.tombstones() / (capability["id"] + ".revoked")
+        marker.unlink()
+        marker.symlink_to(self.base / "elsewhere")
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("symlink", str(caught.exception))
+
+    def test_a_directory_in_place_of_a_tombstone_is_treated_as_revoked(self) -> None:
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        self.mint_gate()
+
+        marker = self.tombstones() / (capability["id"] + ".revoked")
+        marker.unlink()
+        marker.mkdir()
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("regular file", str(caught.exception))
+
     def test_a_forged_signature_is_still_rejected_after_supersession(self) -> None:
         capability = self.mint_gate()
         payload = entry()

--- a/tests/outbox-capability-supersede-test.py
+++ b/tests/outbox-capability-supersede-test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Black-box tests separating capability supersession from revocation.
+
+A relaunch mints a new capability into the active pointer of an equally-named
+role instance.  The work the previous boot already enqueued is still authentic
+and must still publish; only an explicit revocation may stop it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "bin"))
+from outbox_capability import (  # noqa: E402
+    CapabilityError,
+    mint,
+    revoke_role,
+    revoke_task,
+    sign_entry,
+    verify_entry,
+)
+
+FEATURE = "FEATURE-1"
+TEAM = "factory-one"
+ROLE = "principal-architect"
+BODY = b"architecture verdict body\n"
+BODY_DIGEST = "sha256:" + hashlib.sha256(BODY).hexdigest()
+
+
+def entry(actor: str = ROLE, *, marker: str = "architecture-approval") -> dict:
+    return {
+        "schemaVersion": 1,
+        "id": "entry-1",
+        "team": TEAM,
+        "featureId": FEATURE,
+        "taskId": "-",
+        "attempt": 0,
+        "actor": actor,
+        "marker": marker,
+        "targetStatus": None,
+        "createdAt": "2026-09-02T10:00:00Z",
+    }
+
+
+class OutboxCapabilitySupersedeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name).resolve()
+        self.workspace = self.base / "workspace"
+        self.workspace.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", str(self.base)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def mint_gate(self, role: str = ROLE, ttl_seconds: int = 24 * 60 * 60) -> dict:
+        """Mint a gate capability the way launch-team.sh does.
+
+        The instance is `gate:<role>`, which is stable across launches, so a
+        relaunch of the same role mints into the same active pointer.
+        """
+        return mint(
+            str(self.base),
+            str(self.workspace),
+            TEAM,
+            FEATURE,
+            role,
+            "gate",
+            "-",
+            0,
+            "gate:%s" % role,
+            ttl_seconds,
+        )
+
+    def signed(self, capability: dict, payload: dict | None = None) -> dict:
+        return sign_entry(
+            payload or entry(),
+            BODY,
+            capability["id"],
+            capability["secret"],
+            capability["instance"],
+            capability["expiresAt"],
+        )
+
+    def verify(self, payload: dict, signature: dict) -> dict:
+        enriched = dict(payload)
+        enriched["producerCapability"] = signature
+        return verify_entry(str(self.base), str(self.workspace), enriched, BODY_DIGEST)
+
+    def test_capability_verifies_while_it_is_the_active_launch(self) -> None:
+        capability = self.mint_gate()
+        payload = entry()
+        verified = self.verify(payload, self.signed(capability, payload))
+        self.assertEqual(verified["role"], ROLE)
+        self.assertEqual(verified["executionKind"], "gate")
+
+    def test_relaunch_does_not_destroy_what_the_previous_boot_enqueued(self) -> None:
+        """The regression this suite exists for.
+
+        A gate verdict is produced, then the role is relaunched four seconds
+        later before the outbox drain runs.  The verdict is authentic and
+        unexpired, so it must still publish.
+        """
+        first = self.mint_gate()
+        payload = entry()
+        signature = self.signed(first, payload)
+
+        self.mint_gate()  # relaunch: same instance, replaces the active pointer
+
+        verified = self.verify(payload, signature)
+        self.assertEqual(verified["role"], ROLE)
+
+    def test_three_gate_verdicts_survive_one_relaunch(self) -> None:
+        """Three review-board roles share one relaunch's blast radius."""
+        roles = ("principal-architect", "sceptical-architect", "senior-security-engineer")
+        enqueued = []
+        for role in roles:
+            capability = self.mint_gate(role)
+            payload = entry(actor=role)
+            enqueued.append((payload, self.signed(capability, payload)))
+
+        for role in roles:
+            self.mint_gate(role)
+
+        for role, (payload, signature) in zip(roles, enqueued):
+            with self.subTest(role=role):
+                self.assertEqual(self.verify(payload, signature)["role"], role)
+
+    def test_revocation_still_rejects(self) -> None:
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+
+        self.assertEqual(revoke_role(str(self.base), str(self.workspace), TEAM, ROLE), 1)
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("revoked", str(caught.exception))
+
+    def test_revocation_outlives_a_later_mint_for_the_same_role(self) -> None:
+        """The hole a naive supersession fix would open.
+
+        Revoking clears the active pointer; a later mint recreates it.  Without
+        a durable tombstone the revoked capability would then be
+        indistinguishable from a merely superseded one and would publish.
+        """
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        self.mint_gate()  # pointer exists again, naming a different capability
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("revoked", str(caught.exception))
+
+    def test_task_revocation_outlives_a_later_mint(self) -> None:
+        def mint_task() -> dict:
+            return mint(
+                str(self.base),
+                str(self.workspace),
+                TEAM,
+                FEATURE,
+                ROLE,
+                "task",
+                "TASK-1",
+                1,
+                "task:TASK-1:1",
+            )
+
+        capability = mint_task()
+        payload = entry()
+        payload["taskId"] = "TASK-1"
+        payload["attempt"] = 1
+        signature = self.signed(capability, payload)
+
+        self.assertEqual(
+            revoke_task(str(self.base), str(self.workspace), TEAM, "TASK-1"), 1
+        )
+        mint_task()
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("revoked", str(caught.exception))
+
+    def test_expiry_still_bounds_a_superseded_capability(self) -> None:
+        """Supersession is no longer the bound, so the lease must still be."""
+        capability = self.mint_gate(ttl_seconds=60)
+        payload = entry()
+        signature = self.signed(capability, payload)
+        self.mint_gate()
+
+        import outbox_capability
+
+        original = outbox_capability.time.time
+        outbox_capability.time.time = lambda: original() + 120
+        try:
+            with self.assertRaises(CapabilityError) as caught:
+                self.verify(payload, signature)
+        finally:
+            outbox_capability.time.time = original
+        self.assertIn("expired", str(caught.exception))
+
+    def test_cleared_pointer_without_a_tombstone_fails_closed(self) -> None:
+        """Legacy state predating tombstones must not become publishable."""
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+
+        broker = self.base / ".git" / "startup-factory-broker"
+        pointers = sorted((broker / "outbox-active").glob("*.id"))
+        self.assertEqual(len(pointers), 1)
+        pointers[0].unlink()
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("cannot read active capability", str(caught.exception))
+
+    def test_a_forged_signature_is_still_rejected_after_supersession(self) -> None:
+        capability = self.mint_gate()
+        payload = entry()
+        signature = self.signed(capability, payload)
+        self.mint_gate()
+
+        forged = dict(signature)
+        forged["signature"] = "hmac-sha256:" + "0" * 64
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, forged)
+        self.assertIn("signature mismatch", str(caught.exception))
+
+    def test_a_superseded_capability_cannot_publish_for_another_role(self) -> None:
+        capability = self.mint_gate()
+        self.mint_gate()
+
+        payload = entry(actor="team-lead")
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, self.signed(capability, payload))
+        self.assertIn("does not match the verified capability role", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/outbox-capability-supersede-test.py
+++ b/tests/outbox-capability-supersede-test.py
@@ -231,6 +231,34 @@ class OutboxCapabilitySupersedeTest(unittest.TestCase):
             self.verify(payload, signature)
         self.assertIn("cannot read active capability", str(caught.exception))
 
+    def test_revocation_covers_a_capability_superseded_before_it(self) -> None:
+        """Revoking fences off the identity, not just the newest capability.
+
+        A revoke can only see whichever capability the active pointer names, so
+        an earlier boot's capability -- already superseded, still holding an
+        undrained artifact -- would never be tombstoned by id. launch-team.sh
+        restarts a role by revoking and relaunching, so "superseded, then
+        revoked, then relaunched" is an ordinary sequence, not an edge case.
+        """
+        first = self.mint_gate()
+        payload = entry()
+        signature = self.signed(first, payload)
+
+        self.mint_gate()  # a relaunch supersedes the boot that enqueued
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        self.mint_gate()  # a further relaunch recreates the active pointer
+
+        with self.assertRaises(CapabilityError) as caught:
+            self.verify(payload, signature)
+        self.assertIn("revoked", str(caught.exception))
+
+    def test_a_capability_minted_after_a_revocation_still_publishes(self) -> None:
+        """Fencing an identity must not disable it forever."""
+        revoke_role(str(self.base), str(self.workspace), TEAM, ROLE)
+        capability = self.mint_gate()
+        payload = entry()
+        self.assertEqual(self.verify(payload, self.signed(capability, payload))["role"], ROLE)
+
     def tombstones(self) -> Path:
         return self.base / ".git" / "startup-factory-broker" / "outbox-revoked"
 

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -151,7 +151,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.18")
+        self.assertEqual(project["version"], "0.1.20")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -348,7 +348,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.18")
+        self.assertEqual(metadata["Version"], "0.1.20")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])

--- a/tests/pm-agent-health-test.py
+++ b/tests/pm-agent-health-test.py
@@ -48,6 +48,7 @@ def snapshot(**changes):
         "presentationOnly": True,
         "nonAgentProcessesOmitted": 0,
         "agents": [],
+        "boards": [],
         "warnings": [],
     }
     value.update(changes)
@@ -681,6 +682,7 @@ class HealthPublisherTest(unittest.TestCase):
                 "release-worker.py",
                 "process-lifecycle.py",
                 "agent-health.py",
+                "board-status.py",
                 "heartbeat-status.py",
                 "teamwork-path.py",
             ):

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -53,6 +53,8 @@ FULL_PYTHON_TESTS=(
   tracker-adapter-pagination-test.py
   heartbeat-status-test.py
   task-hold-test.py
+  outbox-capability-supersede-test.py
+  board-status-test.py
   custom-tracker-release-snapshot-test.py
 )
 FULL_SHELL_TESTS=(
@@ -87,6 +89,8 @@ SMOKE_PYTHON_TESTS=(
   tracker-adapter-pagination-test.py
   heartbeat-status-test.py
   task-hold-test.py
+  outbox-capability-supersede-test.py
+  board-status-test.py
 )
 SMOKE_SHELL_TESTS=(
   update-installed-skill-test.sh

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -55,6 +55,7 @@ FULL_PYTHON_TESTS=(
   task-hold-test.py
   outbox-capability-supersede-test.py
   board-status-test.py
+  tracker-change-token-test.py
   custom-tracker-release-snapshot-test.py
 )
 FULL_SHELL_TESTS=(
@@ -91,6 +92,7 @@ SMOKE_PYTHON_TESTS=(
   task-hold-test.py
   outbox-capability-supersede-test.py
   board-status-test.py
+  tracker-change-token-test.py
 )
 SMOKE_SHELL_TESTS=(
   update-installed-skill-test.sh

--- a/tests/tracker-change-token-test.py
+++ b/tests/tracker-change-token-test.py
@@ -19,7 +19,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_STATUS_FIXTURE = ROOT / "config" / "statuses.config.json"
+DEFAULT_STATUS_FIXTURE = ROOT / "tests" / "fixtures" / "statuses.default-profile.json"
+PROJECT_UUID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
 
 
 def load_definitions(adapter, extra_config=""):
@@ -52,7 +53,6 @@ class LinearChangeTokenTest(unittest.TestCase):
         os.environ["LINEAR_API_KEY"] = "offline-test-key"
         self.ns = load_definitions("Linear", "LINEAR_DEFAULT_TEAM=ENG\n")
         self.linear = self.ns["Linear"]()
-        self.linear.project_id = lambda feature_id: "project-1"
         self.requests = 0
 
     def respond(self, *, project="2026-09-02T10:00:00Z",
@@ -78,60 +78,80 @@ class LinearChangeTokenTest(unittest.TestCase):
                                 "issues": {"nodes": nodes,
                                            "pageInfo": {"hasNextPage": False}}}}
         self.linear.gql = gql
+        return gql
 
     def test_an_idle_project_costs_two_requests(self) -> None:
-        """The whole point: bounded cost that does not scale with task count."""
+        """The whole point: bounded cost that does not scale with task count.
+
+        A UUID feature id resolves without a lookup, so this counts the probe
+        itself. A name-configured [feature] adds exactly one resolution request,
+        which the next test pins; neither grows with [task] count.
+        """
         self.respond()
-        self.linear.change_token("FEATURE-1")
+        self.linear.change_token(PROJECT_UUID)
         self.assertEqual(self.requests, 2)
+
+    def test_a_name_configured_project_adds_one_resolution_request(self) -> None:
+        outer = self.respond()
+
+        def gql(query, variables=None):
+            if "projects(first: 2" in query:
+                self.requests += 1
+                return {"projects": {"nodes": [{"id": PROJECT_UUID,
+                                                "name": "Feature One"}]}}
+            return outer(query, variables)
+
+        self.linear.gql = gql
+        self.assertTrue(self.linear.change_token("Feature One"))
+        self.assertEqual(self.requests, 3)
 
     def test_the_token_is_stable_while_nothing_moves(self) -> None:
         self.respond()
-        first = self.linear.change_token("FEATURE-1")
-        second = self.linear.change_token("FEATURE-1")
+        first = self.linear.change_token(PROJECT_UUID)
+        second = self.linear.change_token(PROJECT_UUID)
         self.assertEqual(first, second)
         self.assertTrue(first.startswith("linear:"))
 
     def test_an_edited_issue_moves_the_token(self) -> None:
         self.respond()
-        before = self.linear.change_token("FEATURE-1")
+        before = self.linear.change_token(PROJECT_UUID)
         self.respond(issue="2026-09-02T11:45:00Z")
-        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+        self.assertNotEqual(before, self.linear.change_token(PROJECT_UUID))
 
     def test_a_new_comment_moves_the_token(self) -> None:
         """A review verdict arrives as a comment; missing it would strand it."""
         self.respond()
-        before = self.linear.change_token("FEATURE-1")
+        before = self.linear.change_token(PROJECT_UUID)
         self.respond(comment="2026-09-02T12:15:00Z")
-        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+        self.assertNotEqual(before, self.linear.change_token(PROJECT_UUID))
 
     def test_a_project_edit_moves_the_token(self) -> None:
         self.respond()
-        before = self.linear.change_token("FEATURE-1")
+        before = self.linear.change_token(PROJECT_UUID)
         self.respond(project="2026-09-02T12:00:00Z")
-        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+        self.assertNotEqual(before, self.linear.change_token(PROJECT_UUID))
 
     def test_an_empty_project_still_yields_a_token(self) -> None:
         self.respond(issue="", comment="")
-        self.assertTrue(self.linear.change_token("FEATURE-1"))
+        self.assertTrue(self.linear.change_token(PROJECT_UUID))
 
     def test_a_first_issue_moves_the_token_from_empty(self) -> None:
         self.respond(issue="", comment="")
-        before = self.linear.change_token("FEATURE-1")
+        before = self.linear.change_token(PROJECT_UUID)
         self.respond(comment="")
-        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+        self.assertNotEqual(before, self.linear.change_token(PROJECT_UUID))
 
     def test_a_malformed_issue_response_forces_a_full_export(self) -> None:
         self.respond(issue_nodes="not-a-list")
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
     def test_a_malformed_comment_response_forces_a_full_export(self) -> None:
         self.respond(comment_nodes="not-a-list")
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
     def test_a_missing_project_forces_a_full_export(self) -> None:
         self.linear.gql = lambda query, variables=None: {}
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
     def test_an_oldest_first_connection_forces_a_full_export(self) -> None:
         """The ordering is checked, not trusted.
@@ -141,21 +161,21 @@ class LinearChangeTokenTest(unittest.TestCase):
         """
         self.respond(issue_nodes=[{"updatedAt": "2026-09-01T00:00:00Z"},
                                   {"updatedAt": "2026-09-02T11:00:00Z"}])
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
     def test_an_oldest_first_comment_connection_forces_a_full_export(self) -> None:
         self.respond(comment_nodes=[{"updatedAt": "2026-09-01T00:00:00Z"},
                                     {"updatedAt": "2026-09-02T11:30:00Z"}])
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
     def test_a_single_issue_project_needs_no_ordering_proof(self) -> None:
         """One node cannot be mis-ordered, so it is still a usable mark."""
         self.respond(issue_nodes=[{"updatedAt": "2026-09-02T11:00:00Z"}])
-        self.assertTrue(self.linear.change_token("FEATURE-1"))
+        self.assertTrue(self.linear.change_token(PROJECT_UUID))
 
     def test_a_non_string_timestamp_forces_a_full_export(self) -> None:
         self.respond(issue_nodes=[{"updatedAt": 1757000000}])
-        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+        self.assertIsNone(self.linear.change_token(PROJECT_UUID))
 
 
 class MarkdownChangeTokenTest(unittest.TestCase):

--- a/tests/tracker-change-token-test.py
+++ b/tests/tracker-change-token-test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Black-box tests for the cheap change token that gates the feature export.
+
+The export dominates the cost of a dispatch pass.  The token exists so an idle
+pass costs a couple of requests instead of hundreds, which is what makes the
+documented watch loop affordable.  Its one hard requirement is that it must
+never report "nothing moved" when something did.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STATUS_FIXTURE = ROOT / "config" / "statuses.config.json"
+
+
+def load_definitions(adapter, extra_config=""):
+    source = (ROOT / "bin" / "tracker-ops.sh").read_text()
+    embedded = source.split("<<'PYEOF'\n", 1)[1].rsplit("\nPYEOF", 1)[0]
+    definitions = embedded.split("\nBACKENDS =", 1)[0]
+    temp = tempfile.TemporaryDirectory()
+    skill = Path(temp.name)
+    (skill / "config").mkdir()
+    (skill / "bin").mkdir()
+    shutil.copy(DEFAULT_STATUS_FIXTURE, skill / "config" / "statuses.config.json")
+    shutil.copy(ROOT / "bin" / "ticket_content_security.py",
+                skill / "bin" / "ticket_content_security.py")
+    (skill / "config" / "project-management.config.md").write_text(
+        "PRODUCT_MANAGEMENT_TOOL=%s\nSTATUS_CONFIG=config/statuses.config.json\n%s"
+        % (adapter, extra_config))
+    old_argv = sys.argv
+    sys.argv = ["tracker-ops-test", str(skill)]
+    namespace = {"__name__": "tracker_ops_definitions"}
+    try:
+        exec(compile(definitions, "tracker-ops embedded", "exec"), namespace)
+    finally:
+        sys.argv = old_argv
+    namespace["_tempdir"] = temp
+    return namespace
+
+
+class LinearChangeTokenTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["LINEAR_API_KEY"] = "offline-test-key"
+        self.ns = load_definitions("Linear", "LINEAR_DEFAULT_TEAM=ENG\n")
+        self.linear = self.ns["Linear"]()
+        self.linear.project_id = lambda feature_id: "project-1"
+        self.requests = 0
+
+    def respond(self, *, project="2026-09-02T10:00:00Z",
+                issue="2026-09-02T11:00:00Z", comment="2026-09-02T11:30:00Z",
+                issue_nodes=None, comment_nodes=None):
+        def gql(query, variables=None):
+            self.requests += 1
+            if "comments(" in query:
+                nodes = (comment_nodes if comment_nodes is not None
+                         else ([{"updatedAt": comment}] if comment else []))
+                return {"comments": {"nodes": nodes}}
+            nodes = (issue_nodes if issue_nodes is not None
+                     else ([{"updatedAt": issue}] if issue else []))
+            return {"project": {"updatedAt": project,
+                                "issues": {"nodes": nodes,
+                                           "pageInfo": {"hasNextPage": False}}}}
+        self.linear.gql = gql
+
+    def test_an_idle_project_costs_two_requests(self) -> None:
+        """The whole point: bounded cost that does not scale with task count."""
+        self.respond()
+        self.linear.change_token("FEATURE-1")
+        self.assertEqual(self.requests, 2)
+
+    def test_the_token_is_stable_while_nothing_moves(self) -> None:
+        self.respond()
+        first = self.linear.change_token("FEATURE-1")
+        second = self.linear.change_token("FEATURE-1")
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("linear:"))
+
+    def test_an_edited_issue_moves_the_token(self) -> None:
+        self.respond()
+        before = self.linear.change_token("FEATURE-1")
+        self.respond(issue="2026-09-02T11:45:00Z")
+        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+
+    def test_a_new_comment_moves_the_token(self) -> None:
+        """A review verdict arrives as a comment; missing it would strand it."""
+        self.respond()
+        before = self.linear.change_token("FEATURE-1")
+        self.respond(comment="2026-09-02T12:15:00Z")
+        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+
+    def test_a_project_edit_moves_the_token(self) -> None:
+        self.respond()
+        before = self.linear.change_token("FEATURE-1")
+        self.respond(project="2026-09-02T12:00:00Z")
+        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+
+    def test_an_empty_project_still_yields_a_token(self) -> None:
+        self.respond(issue="", comment="")
+        self.assertTrue(self.linear.change_token("FEATURE-1"))
+
+    def test_a_first_issue_moves_the_token_from_empty(self) -> None:
+        self.respond(issue="", comment="")
+        before = self.linear.change_token("FEATURE-1")
+        self.respond(comment="")
+        self.assertNotEqual(before, self.linear.change_token("FEATURE-1"))
+
+    def test_a_malformed_issue_response_forces_a_full_export(self) -> None:
+        self.respond(issue_nodes="not-a-list")
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+    def test_a_malformed_comment_response_forces_a_full_export(self) -> None:
+        self.respond(comment_nodes="not-a-list")
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+    def test_a_missing_project_forces_a_full_export(self) -> None:
+        self.linear.gql = lambda query, variables=None: {}
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+
+class MarkdownChangeTokenTest(unittest.TestCase):
+    def setUp(self):
+        self.ns = load_definitions("Markdown")
+        self.markdown = self.ns["Markdown"]()
+        self.text = "# Feature [Planned]\n\n- TASK-1 [Planned]\n"
+        self.markdown.load = lambda feature_id: self.text
+
+    def test_the_token_is_exact_for_a_single_file_board(self) -> None:
+        first = self.markdown.change_token("FEATURE-1")
+        self.assertTrue(first.startswith("sha256:"))
+        self.assertEqual(first, self.markdown.change_token("FEATURE-1"))
+
+    def test_any_edit_moves_the_token(self) -> None:
+        before = self.markdown.change_token("FEATURE-1")
+        self.text = "# Feature [Active]\n\n- TASK-1 [Active]\n"
+        self.assertNotEqual(before, self.markdown.change_token("FEATURE-1"))
+
+    def test_a_removed_task_moves_the_token(self) -> None:
+        """A high-water mark could miss a delete; a digest cannot."""
+        before = self.markdown.change_token("FEATURE-1")
+        self.text = "# Feature [Planned]\n"
+        self.assertNotEqual(before, self.markdown.change_token("FEATURE-1"))
+
+
+class AdapterContractTest(unittest.TestCase):
+    def test_adapters_without_a_token_are_still_supported(self) -> None:
+        """Absence must degrade to the exhaustive export, never to a false skip."""
+        namespace = load_definitions("Jira", "JIRA_PROJECT_KEY=ENG\n")
+        for adapter in ("Jira", "GitHubIssues"):
+            with self.subTest(adapter=adapter):
+                backend = namespace.get(adapter)
+                self.assertIsNotNone(backend)
+                self.assertFalse(
+                    callable(getattr(backend, "change_token", None)),
+                    "%s advertises a change token; it needs its own coverage"
+                    % adapter,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/tracker-change-token-test.py
+++ b/tests/tracker-change-token-test.py
@@ -58,14 +58,22 @@ class LinearChangeTokenTest(unittest.TestCase):
     def respond(self, *, project="2026-09-02T10:00:00Z",
                 issue="2026-09-02T11:00:00Z", comment="2026-09-02T11:30:00Z",
                 issue_nodes=None, comment_nodes=None):
+        """Answer both probe queries the way a newest-first connection would.
+
+        The adapter asks for two nodes so it can check the ordering it asked
+        for, so the stub returns a strictly older second node.
+        """
+        def newest_first(mark, older):
+            return [{"updatedAt": mark}, {"updatedAt": older}] if mark else []
+
         def gql(query, variables=None):
             self.requests += 1
             if "comments(" in query:
                 nodes = (comment_nodes if comment_nodes is not None
-                         else ([{"updatedAt": comment}] if comment else []))
+                         else newest_first(comment, "2026-09-01T00:00:00Z"))
                 return {"comments": {"nodes": nodes}}
             nodes = (issue_nodes if issue_nodes is not None
-                     else ([{"updatedAt": issue}] if issue else []))
+                     else newest_first(issue, "2026-09-01T00:00:00Z"))
             return {"project": {"updatedAt": project,
                                 "issues": {"nodes": nodes,
                                            "pageInfo": {"hasNextPage": False}}}}
@@ -123,6 +131,30 @@ class LinearChangeTokenTest(unittest.TestCase):
 
     def test_a_missing_project_forces_a_full_export(self) -> None:
         self.linear.gql = lambda query, variables=None: {}
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+    def test_an_oldest_first_connection_forces_a_full_export(self) -> None:
+        """The ordering is checked, not trusted.
+
+        If the connection came back oldest-first the mark would freeze and the
+        cache would go stale silently, so the token refuses to answer.
+        """
+        self.respond(issue_nodes=[{"updatedAt": "2026-09-01T00:00:00Z"},
+                                  {"updatedAt": "2026-09-02T11:00:00Z"}])
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+    def test_an_oldest_first_comment_connection_forces_a_full_export(self) -> None:
+        self.respond(comment_nodes=[{"updatedAt": "2026-09-01T00:00:00Z"},
+                                    {"updatedAt": "2026-09-02T11:30:00Z"}])
+        self.assertIsNone(self.linear.change_token("FEATURE-1"))
+
+    def test_a_single_issue_project_needs_no_ordering_proof(self) -> None:
+        """One node cannot be mis-ordered, so it is still a usable mark."""
+        self.respond(issue_nodes=[{"updatedAt": "2026-09-02T11:00:00Z"}])
+        self.assertTrue(self.linear.change_token("FEATURE-1"))
+
+    def test_a_non_string_timestamp_forces_a_full_export(self) -> None:
+        self.respond(issue_nodes=[{"updatedAt": 1757000000}])
         self.assertIsNone(self.linear.change_token("FEATURE-1"))
 
 

--- a/tests/update-installed-skill-test.sh
+++ b/tests/update-installed-skill-test.sh
@@ -49,6 +49,7 @@ done
 for required_file in \
   adapters/_TEMPLATE.md \
   bin/agent-health.py \
+  bin/board-status.py \
   bin/dispatch.sh \
   bin/heartbeat-status.py \
   bin/launch-team.sh \


### PR DESCRIPTION
An operator field report from a two-day continuous delivery run measured a **35% first-attempt artifact failure rate** — 52 of 148 artifacts never published. 16 were independent gate decisions; 17 were the `andon`/`escalation` artifacts *about* the problem. The board went quiet and the alarm went quiet with it.

The causal chain, and what this PR changes at each link:

| Link | Change |
|---|---|
| `--watch` costs ~350 requests/pass → exhausts a 2,500/hr budget → operators go manual | Change-probe before the export |
| Manual dispatch is invisible — a thinking board and a dead board look identical | Board-level stall reporting |
| Manual restarts destroy whatever the previous boot enqueued | Supersession no longer blocks publication |

## 1. An idle pass costs a probe, not a full export

`dispatch_once` reads the board **twice** — before planning, and after the brokers to close their observation race. Both now go through one gated helper; gating only the first would halve the cost rather than remove it.

The token is a cache in front of the authoritative board read, which is exactly the "silently skips real work" failure this repo exists to prevent, so it is bounded on every side:

- A full export runs at least every `EXPORT_MAX_REUSE_SECONDS` (default 900, capped at 3600) regardless of the token. A missed change **delays** an export; it can never cancel one.
- The token is recorded only after a *successful* export, so a failed export cannot leave a token vouching for a stale snapshot.
- The post-broker read exports **unconditionally** when either broker had queued work. Those writes are the pass's own, and a hosted tracker does not promise a read microseconds later reflects them.
- Adapters that cannot promise the token moves whenever the export would simply omit `change_token`. Jira and GitHub Issues export every pass, unchanged.

Markdown's token is exact (a digest of its single board file). Linear's is a high-water mark over the project, its newest issue (archived included), and its newest comment — 2 requests, independent of task count. It fetches two nodes and **verifies** the `orderBy` direction rather than trusting it; nothing else in the repo relies on that ordering, and if it were oldest-first the mark would freeze silently.

## 2. A stalled board says so

Every role reaching `exited` is the *normal* end of a pass, so per-role health cannot tell a board that finished from one nobody is driving. `launch-team.sh health` now adds one line per team:

```
factory-one: STALLED — 2 queued tasks, 4 undrained artifacts, last pass 31m ago, 1 stalled agent
```

`DRAINED` keeps the healthy end of a run quiet. Blocked tasks don't stall a board — they wait on a human, not on dispatch. All presentation-only; it cannot fail the health view or control anything.

## 3. A relaunch no longer destroys enqueued verdicts

Gate capabilities are minted with a **stable** instance (`gate:<role>`), and the active-pointer key includes it, so relaunching a role overwrote the pointer and orphaned everything the previous boot had enqueued into `outbox/failed`. That is why one relaunch took the architecture, sceptical and security verdicts together — three gate roles, one shared failure mode.

Supersession no longer blocks publication; the unexpired lease is the real bound and already existed. **The naive version of this fix opens a security hole**: revocation and supersession both clear the same pointer, so once any later mint recreates it, a genuinely revoked capability becomes indistinguishable from a merely superseded one. Revocation now writes durable tombstones over the immutable record set, covering capabilities an earlier relaunch had already superseded. A cleared pointer with no tombstone still fails closed.

## Review

Two independent reviewers were run against the finished diff, and **both found real defects that are fixed here** — including three blockers in my own first attempt, and four more introduced by those fixes:

- Revocation wasn't durable across a supersession (reproduced, then fixed).
- The probe saved nothing on the path that runs — the second export was ungated.
- `WORKING` was reported when every agent was individually stalled; `DRAINED` while an in-flight task sat orphaned.
- Enumerating records made one truncated record (an ordinary crash mid-`mint()`) permanently brick every revoke, and with it restart-role recovery.
- The broker-work check matched `integrations/history/`, a permanent archive — reverting the saving forever for any team that had superseded an integration.

## Verification

Full suite **ALL TESTS PASS**; packaging 46 tests OK. 91 new/changed tests across four files, registered in both FULL and SMOKE lists.

⚠️ Two suites (`agent-health`, `pm-agent-health`) fail locally under macOS system Python **3.9** because of a pre-existing `Path.stat(follow_symlinks=)` call on `main` (line 165). I confirmed `origin/main` fails identically in a clean worktree. CI asserts `/usr/bin/python3 >= 3.10` first, so this cannot occur there.

## Known limits, deliberately not fixed

- Revoke is now O(all capabilities ever minted); records are never pruned. Acceptable for a rare operation, worth a follow-up.
- Two Linear semantics questions can't be settled offline: whether archiving bumps `updatedAt`, and whether an issue moved out of a project vanishes without moving any watched timestamp. Both are bounded by the forced refresh.
- The stalled-verdict classification relies on a naming convention across files. A new contract test pins all 13 verdicts, so a future one that breaks it fails loudly.

## Notes

Version **0.1.20** — 0.1.19 is claimed by the README PR (#49). If this merges first, that one needs a bump. No README changelog entry here: this branch carries the old README that #49 replaces wholesale, so an entry would guarantee a conflict. It should be added after #49 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
