### PR TITLE
Stop an update from silently undoing work

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,31 @@ Read the full contracts before enabling unattended or production operation:
 - [`reference/deployment.md`](reference/deployment.md)
 - [`reference/orchestration.md`](reference/orchestration.md)
 
+## What's new in 0.1.23
+
+Updating an installation could quietly undo work, in three different ways.
+
+A local edit to a shipped file was replaced without a word. The updater already
+records the hash of every file it installs, but only consulted it when deciding
+whether a *retired* file was safe to delete — never for files the incoming
+version overwrites. It now names them: `WARNING: 2 upstream file(s) were
+modified locally since they were installed`, in both the dry run and the applied
+update, so a local fix is either re-applied deliberately or upstreamed.
+
+`update` also had no notion of version order and would write an older bundle over
+a newer installation. A published index is not always ahead of what is installed
+— a release can be mid-flight, or half-published when post-publish verification
+fails — so `@latest` legitimately resolves to the previous version, and
+installing it reverted whatever the newer one fixed. Downgrades are now refused
+unless `--allow-downgrade` says otherwise.
+
+Finally, `bin/update-installed-skill.sh` already refuses release-managed
+installations because it cannot carry their bundle provenance, but the mirror
+image was open: the release CLI would convert a source-managed installation
+without comment, which is how the previous two problems combined into a silent
+revert. `update` now refuses it and names the updater that preserves source
+provenance.
+
 ## What's new in 0.1.22
 
 Two defects could stop a board permanently, and the contract behind one of them

--- a/bin/update-installed-skill.sh
+++ b/bin/update-installed-skill.sh
@@ -301,6 +301,8 @@ collect_preserved_paths() {
   local local_file relative_file source_file
   preserved_paths="$tmp/preserved-paths"
   : > "$preserved_paths"
+  locally_modified_paths="$tmp/locally-modified-paths"
+  : > "$locally_modified_paths"
   validate_owned_manifest
 
   if [ ! -d "$install_dir" ]; then
@@ -350,6 +352,16 @@ collect_preserved_paths() {
     source_file="$checkout/$relative_file"
     if [ -e "$source_file" ] || [ -L "$source_file" ]; then
       if ! $has_ownership_manifest || is_old_owned "$relative_file"; then
+        # An upstream-owned file is replaced by the incoming version. If the
+        # project edited it since it was installed, that edit is about to be
+        # discarded — silently, which is how a local fix gets reverted by a
+        # routine sync and nobody notices until the behaviour it fixed returns.
+        # The install already records the hash it wrote, so say so.
+        if $has_ownership_hashes && [ -f "$local_file" ] && \
+           ! current_file_matches_old_hash "$relative_file" && \
+           ! { [ -f "$source_file" ] && cmp -s "$local_file" "$source_file"; }; then
+          printf '%s\n' "$relative_file" >> "$locally_modified_paths"
+        fi
         continue
       fi
       if [ -f "$source_file" ] && cmp -s "$local_file" "$source_file"; then
@@ -738,6 +750,17 @@ done < "$tracked_paths"
 install_parent="$(dirname "$install_dir")"
 install_name="$(basename "$install_dir")"
 
+report_locally_modified() {
+  local count
+  [ -n "${locally_modified_paths:-}" ] && [ -s "$locally_modified_paths" ] || return 0
+  count="$(wc -l < "$locally_modified_paths" | tr -d ' ')"
+  echo
+  echo "WARNING: $count upstream file(s) were modified locally since they were installed."
+  echo "The incoming version replaces them, so those local edits are discarded:"
+  sed 's/^/  - /' "$locally_modified_paths"
+  echo "Re-apply anything still needed, or upstream it so the next sync keeps it."
+}
+
 if $dry_run; then
   collect_preserved_paths
   stage_dir="$tmp/stage"
@@ -749,6 +772,7 @@ if $dry_run; then
   echo "Resolved source commit: $resolved_commit"
   echo "Planned filesystem changes: $change_count"
   echo "Dry run complete; no destination files were written."
+  report_locally_modified
 else
   mkdir -p "$install_parent"
   lock_dir="$install_parent/.$install_name.startup-factory.lock"
@@ -801,6 +825,7 @@ else
   if ! $overwrite_config; then
     echo "Preserved existing project configuration and project-owned files."
   fi
+  report_locally_modified
 fi
 
 target_repo="$(git -C "$install_dir" rev-parse --show-toplevel 2>/dev/null || true)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "startup-factory"
-version = "0.1.22"
+version = "0.1.23"
 description = "Agentic orchestration for governed end-to-end product delivery"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/startup_factory_cli/cli.py
+++ b/src/startup_factory_cli/cli.py
@@ -66,6 +66,11 @@ def build_parser() -> argparse.ArgumentParser:
     _mutation_arguments(install)
     update = subparsers.add_parser("update", help="safely update an existing installation")
     _mutation_arguments(update)
+    update.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help="write the selected bundle even when it is older than the installed version",
+    )
     verify = subparsers.add_parser("verify", help="verify installed runtime files and provenance")
     _target_arguments(verify)
     initialize_parser = subparsers.add_parser(
@@ -227,6 +232,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     command=args.command,
                     overwrite_config=bool(args.overwrite_config),
                     dry_run=bool(args.dry_run),
+                    allow_downgrade=bool(getattr(args, "allow_downgrade", False)),
                 )
         _print_result(result, as_json=json_output)
         return 0

--- a/src/startup_factory_cli/installer.py
+++ b/src/startup_factory_cli/installer.py
@@ -36,6 +36,7 @@ BUNDLE_PREFIX = "startup-factory/"
 BUNDLE_MANIFEST = ".startup-factory-bundle.json"
 OWNERSHIP_MANIFEST = ".startup-factory-owned-files"
 INSTALL_PROVENANCE = ".startup-factory-install.json"
+SOURCE_INSTALL_PROVENANCE = ".startup-factory-source-install.json"
 SKILL_NAME = "startup-factory"
 SCHEMA_VERSION = 1
 POLICY_VERSION = 1
@@ -915,6 +916,64 @@ def _swap_stage(stage: Path, target: Path) -> None:
             raise InstallerError(f"update succeeded but old backup could not be removed: {backup}: {exc}") from exc
 
 
+def _stable_semver(value: object) -> tuple[int, int, int] | None:
+    """Parse a release version, or None when it is not stable numeric SemVer."""
+    if not isinstance(value, str):
+        return None
+    parts = value.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)  # type: ignore[return-value]
+
+
+def _assert_source_managed_install_untouched(target: Path) -> None:
+    """Refuse to convert a source-managed installation into a release one.
+
+    `bin/update-installed-skill.sh` already refuses the mirror image of this —
+    it will not update a release-CLI install because it cannot carry the
+    canonical bundle provenance. Leaving this direction open means a routine
+    `update` silently replaces a source install with whatever version the
+    index resolves, which can be older than what the project already has.
+    """
+    if (target / INSTALL_PROVENANCE).is_file():
+        return
+    if not (target / SOURCE_INSTALL_PROVENANCE).is_file():
+        return
+    raise InstallerError(
+        "this installation is source-managed (it carries "
+        f"{SOURCE_INSTALL_PROVENANCE} and no release provenance); update it with "
+        "bin/update-installed-skill.sh, which preserves its source provenance"
+    )
+
+
+def _assert_not_downgrade(bundle: ValidatedBundle, target: Path, allow_downgrade: bool) -> None:
+    """Refuse to write an older bundle over a newer installation.
+
+    A published index is not always ahead of the installation: a release can be
+    mid-flight, or half-published if the post-publish verification fails, so
+    `@latest` legitimately resolves to the previous version. Writing it would
+    revert whatever the newer version fixed, without a word.
+    """
+    if allow_downgrade:
+        return
+    provenance_path = target / INSTALL_PROVENANCE
+    if not provenance_path.is_file() or provenance_path.is_symlink():
+        return
+    try:
+        installed = _load_json_file(provenance_path, "install provenance").get("version")
+    except InstallerError:
+        return
+    current = _stable_semver(installed)
+    incoming = _stable_semver(bundle.manifest.version)
+    if current is None or incoming is None or incoming >= current:
+        return
+    raise InstallerError(
+        f"refusing to downgrade the installation: {installed} is already installed and "
+        f"the selected bundle is {bundle.manifest.version}. Re-run with a newer version, "
+        "or pass --allow-downgrade to overwrite it deliberately"
+    )
+
+
 def install_or_update(
     bundle: ValidatedBundle,
     target: Path,
@@ -922,10 +981,14 @@ def install_or_update(
     command: str,
     overwrite_config: bool,
     dry_run: bool,
+    allow_downgrade: bool = False,
 ) -> OperationResult:
     if command not in {"install", "update"}:
         raise ValueError(f"unsupported command: {command}")
     target = _canonical_target(target)
+    if command == "update":
+        _assert_source_managed_install_untouched(target)
+        _assert_not_downgrade(bundle, target, allow_downgrade)
     plan = make_plan(
         bundle,
         target,
@@ -940,6 +1003,12 @@ def install_or_update(
             locked_target = _canonical_target(target)
             if locked_target != target:
                 raise InstallerError("install destination changed while acquiring the installer lock")
+            if command == "update":
+                # Re-assert under the lock for the same reason the plan is rebuilt
+                # here: the provenance these guards read could have changed between
+                # the first check and the moment this operation gained authority.
+                _assert_source_managed_install_untouched(target)
+                _assert_not_downgrade(bundle, target, allow_downgrade)
             plan = make_plan(
                 bundle,
                 target,

--- a/tests/packaging/test_cli_installer.py
+++ b/tests/packaging/test_cli_installer.py
@@ -465,6 +465,55 @@ class CliInstallerTest(unittest.TestCase):
         with self.assertRaisesRegex(installer.InstallerError, "trusted sidecar"):
             installer.validate_bundle(self.bundle_v1, expected_sha256="0" * 64)
 
+    def test_update_refuses_to_write_an_older_bundle_over_a_newer_install(self) -> None:
+        # A published index is not always ahead of the installation: a release
+        # can be mid-flight or half-published, so "latest" legitimately resolves
+        # to the previous version. Writing it would revert whatever the newer
+        # version fixed, silently.
+        newer = write_bundle(self.root / "v2.tar.gz", version="2.0.0")
+        target = self.install(bundle=newer)
+        before = (target / "bin/runtime.sh").read_bytes()
+
+        code, output, error = self.update(target, self.bundle_v1)
+
+        self.assertNotEqual(code, 0, output)
+        self.assertIn("refusing to downgrade", output + error)
+        self.assertIn("2.0.0", output + error)
+        self.assertEqual((target / "bin/runtime.sh").read_bytes(), before)
+
+    def test_update_downgrade_needs_an_explicit_flag(self) -> None:
+        newer = write_bundle(self.root / "v2-flagged.tar.gz", version="2.0.0")
+        target = self.install(bundle=newer)
+
+        code, output, error = self.update(target, self.bundle_v1, "--allow-downgrade")
+
+        self.assertEqual(code, 0, output + error)
+
+    def test_update_allows_the_same_or_a_newer_version(self) -> None:
+        target = self.install()
+        for label, version in (("same", "1.0.0"), ("newer", "1.0.1")):
+            with self.subTest(label=label):
+                bundle = write_bundle(self.root / f"{label}.tar.gz", version=version)
+                code, output, error = self.update(target, bundle)
+                self.assertEqual(code, 0, output + error)
+
+    def test_update_refuses_a_source_managed_installation(self) -> None:
+        # bin/update-installed-skill.sh already refuses the mirror image of this.
+        # Leaving this direction open lets a routine update silently convert a
+        # source install and replace it with whatever version the index serves.
+        target = self.install()
+        (target / installer.INSTALL_PROVENANCE).unlink()
+        (target / installer.SOURCE_INSTALL_PROVENANCE).write_text(
+            json.dumps({"schemaVersion": 1, "name": "startup-factory", "sourceCommit": "a" * 40}),
+            encoding="utf-8",
+        )
+
+        code, output, error = self.update(target, self.bundle_v1)
+
+        self.assertNotEqual(code, 0, output)
+        self.assertIn("source-managed", output + error)
+        self.assertIn("update-installed-skill.sh", output + error)
+
     def test_failed_swap_rolls_back_original_installation(self) -> None:
         target = self.install()
         payload_v2 = base_payload("2")

--- a/tests/packaging/test_packaging_metadata.py
+++ b/tests/packaging/test_packaging_metadata.py
@@ -151,7 +151,7 @@ class ProjectMetadataTests(unittest.TestCase):
     def test_public_package_metadata(self) -> None:
         project = self.config["project"]
         self.assertEqual(project["name"], "startup-factory")
-        self.assertEqual(project["version"], "0.1.22")
+        self.assertEqual(project["version"], "0.1.23")
         self.assertEqual(project["requires-python"], ">=3.10")
         self.assertEqual(project["license"], "MIT")
         self.assertEqual(project["license-files"], ["LICENSE"])
@@ -348,7 +348,7 @@ class BuiltDistributionIdentityTests(unittest.TestCase):
             license_bytes = archive.read(license_names[0])
 
         self.assertEqual(metadata["Name"], "startup-factory")
-        self.assertEqual(metadata["Version"], "0.1.22")
+        self.assertEqual(metadata["Version"], "0.1.23")
         self.assertEqual(metadata["Requires-Python"], ">=3.10")
         self.assertEqual(metadata["License-Expression"], "MIT")
         self.assertEqual(metadata.get_all("License-File", []), ["LICENSE"])

--- a/tests/update-installed-skill-test.sh
+++ b/tests/update-installed-skill-test.sh
@@ -629,6 +629,37 @@ else
   FAILURES=$((FAILURES + 1))
 fi
 
+# A local edit to a shipped file is about to be discarded by the incoming
+# version. The updater records the hash it installed, so it can say so instead
+# of reverting the edit silently.
+DRIFT_INSTALL="$TMP/drift-install"
+mkdir -p "$DRIFT_INSTALL"
+env STARTUP_FACTORY_REMOTE_URL="$UPSTREAM" STARTUP_FACTORY_REF=main \
+  bash "$ROOT/bin/update-installed-skill.sh" --install-dir "$DRIFT_INSTALL" \
+    > "$TMP/drift-install.out"
+
+env STARTUP_FACTORY_REMOTE_URL="$UPSTREAM" STARTUP_FACTORY_REF=main \
+  bash "$ROOT/bin/update-installed-skill.sh" --install-dir "$DRIFT_INSTALL" --dry-run \
+    > "$TMP/drift-clean.out"
+if grep -q 'modified locally' "$TMP/drift-clean.out"; then
+  echo "FAIL: an unmodified installation was reported as locally modified"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "ok: an unmodified installation reports no local drift"
+fi
+
+printf '\n# local edit that upstream does not have\n' >> "$DRIFT_INSTALL/bin/tracker-ops.sh"
+env STARTUP_FACTORY_REMOTE_URL="$UPSTREAM" STARTUP_FACTORY_REF=main \
+  bash "$ROOT/bin/update-installed-skill.sh" --install-dir "$DRIFT_INSTALL" --dry-run \
+    > "$TMP/drift-dirty.out"
+if grep -q 'modified locally' "$TMP/drift-dirty.out" && \
+   grep -q 'bin/tracker-ops.sh' "$TMP/drift-dirty.out"; then
+  echo "ok: a locally modified shipped file is named before it is replaced"
+else
+  echo "FAIL: a locally modified shipped file was not reported"
+  FAILURES=$((FAILURES + 1))
+fi
+
 echo "---"
 if [ "$FAILURES" -ne 0 ]; then
   echo "$FAILURES updater test(s) failed"


### PR DESCRIPTION
Three independent defects in the update path. Each one alone loses work quietly; together they turn a routine sync into a silent revert. All three reproduce on `main` (`3036c3d`).

## 1. A local edit to a shipped file is replaced with no output at all

`bin/update-installed-skill.sh` already records the hash of every file it installs (`.startup-factory-owned-hashes`) and already has `current_file_matches_old_hash()`. But it only consults it on the **deletion** path — for files that no longer exist upstream, to tell "leftover we installed" from "the project wrote this".

For files the incoming version overwrites, the branch at `collect_preserved_paths` was:

```sh
if ! $has_ownership_manifest || is_old_owned "$relative_file"; then
  continue      # replaced unconditionally — no drift check, no message
fi
```

So a local fix to a shipped file vanished on the next sync, with nothing printed. Nobody notices until the behaviour it fixed comes back.

The data and the helper were already there; this just asks the question on the path that matters:

```
WARNING: 2 upstream file(s) were modified locally since they were installed.
The incoming version replaces them, so those local edits are discarded:
  - bin/tracker-ops.sh
  - bin/process-outbox.sh
Re-apply anything still needed, or upstream it so the next sync keeps it.
```

Printed in both the dry run and the applied update. **Verified against a real installation carrying two hand-applied patches — it named exactly those two files and nothing else.**

## 2. `update` had no notion of version order

There is no version comparison anywhere in `src/startup_factory_cli/`. `update` would write an older bundle over a newer installation without a word.

This is not hypothetical: a published index is not always ahead of what is installed. A release can be mid-flight, or **half-published** when post-publish verification fails *after* the artifact is already public — in which case `@latest` legitimately resolves to the previous version. Installing it reverts whatever the newer version fixed.

Downgrades are now refused, with the escape hatch made explicit:

```
refusing to downgrade the installation: 0.1.23 is already installed and the
selected bundle is 0.1.22. Re-run with a newer version, or pass
--allow-downgrade to overwrite it deliberately
```

Versions that are not stable numeric SemVer are left alone rather than guessed at, so prereleases and odd strings can't be blocked by a bad comparison.

## 3. The "wrong updater" refusal was one-way

`bin/update-installed-skill.sh` explicitly refuses release-managed installs because it cannot carry their canonical bundle provenance. The mirror image was open: `_validate_existing_target` only requires `SKILL.md` and `bin/update-installed-skill.sh`, both of which a source install has — so the release CLI would convert a source-managed installation without comment.

That is the path that combines #1 and #2: it replaces a source install with whatever the index serves, which may be older, dropping any local edit on the way. `update` now refuses it and names the updater that preserves source provenance.

## Concurrency

Both CLI guards run before planning **and again under the installer lock**, for the same reason `install_or_update` already rebuilds the plan there: the provenance they read can change between the first check and the moment the operation gains authority.

## Verification

- `tests/packaging/test_cli_installer.py` — four cases: downgrade refused and the installation left byte-identical; `--allow-downgrade` works; same/newer versions still allowed; source-managed install refused naming `update-installed-skill.sh`.
- `tests/update-installed-skill-test.sh` — two cases: a clean install reports **no** drift (guards against a false positive), and a modified shipped file is named before replacement.
- **Negative control run:** disabling the two guards fails exactly the two refusal tests and leaves the others passing, so they bind to real behaviour rather than passing vacuously.
- `tests/run-all.sh --full`: **ALL TESTS PASS** (36 tests, `RUNALL_EXIT=0`). `unittest discover -s tests/packaging`: **OK**, `PACKAGING_EXIT=0`.
- Version 0.1.22 → 0.1.23 across all four pinned spots; two bundle builds verified **byte-for-byte identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)